### PR TITLE
fix: get every CI job green (norm debt, ft_malloc link, oracle skew)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,11 @@ jobs:
   # The debug build (SAFE=1) is used so AddressSanitizer / LeakSanitizer are
   # meaningful. Two layers: the ~2481-case unit suite (diffed against
   # `bash --posix`), and the self-contained script corpus + leak check.
+  #
+  # The golden oracle is a PINNED bash (5.3.9), built once and cached: the
+  # suite diffs hellish against whatever `bash` is first in PATH, and the
+  # runner's distro bash drifts (24.04 ships 5.2) — 5.2 vs 5.3 disagree on
+  # ~30 cases, which shows up here as phantom hellish failures.
   tests:
     name: Tests · suite + scripts + leaks
     runs-on: ubuntu-latest
@@ -120,6 +125,29 @@ jobs:
           submodules: recursive
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install -y build-essential libreadline-dev
+      - name: Restore pinned bash 5.3.9
+        id: bashcache
+        uses: actions/cache@v4
+        with:
+          path: ~/bash-5.3.9
+          key: bash-5.3.9-${{ runner.os }}-${{ runner.arch }}
+      - name: Build pinned bash 5.3.9
+        if: steps.bashcache.outputs.cache-hit != 'true'
+        run: |
+          curl -sLO https://ftp.gnu.org/gnu/bash/bash-5.3.tar.gz
+          tar xzf bash-5.3.tar.gz
+          cd bash-5.3
+          for i in $(seq 1 9); do
+            p=$(printf 'bash53-%03d' "$i")
+            curl -sL "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/$p" | patch -p0
+          done
+          ./configure --prefix="$HOME/bash-5.3.9" > configure.log 2>&1
+          make -j"$(nproc)" > make.log 2>&1
+          make install > install.log 2>&1
+      - name: Use pinned bash as the golden oracle
+        run: |
+          echo "$HOME/bash-5.3.9/bin" >> "$GITHUB_PATH"
+          "$HOME/bash-5.3.9/bin/bash" --version | head -1
       - name: Build debug (SAFE=1, ASan)
         run: |
           if ! make re > build.log 2>&1; then
@@ -132,5 +160,12 @@ jobs:
           cd tests
           ./tester 2>&1 | sed 's/\x1b\[[0-9;]*[A-Za-z]//g' | tee ../suite.log | grep -E 'PASSED|FAIL' | tail -3
           grep -q 'ALL [0-9]* TESTS PASSED' ../suite.log || { echo "::error::Unit suite has failures"; exit 1; }
+      - name: Upload suite log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: suite-log
+          path: suite.log
+          if-no-files-found: ignore
       - name: Script corpus vs bash --posix + leak check
         run: tests/run_scripts.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ make hist-test      # pty-driven check of cmdhist multiline history joining
 make readline-test  # pty gate over every libreadline entry point (completion,
                     #   history recall, vi/emacs) — run before touching readline linkage
 make anim-test      # pty-driven check that the prompt animation never clobbers pasted input
+make git-prompt-test # pty gate: the prompt's git dirty check never blocks a render — cd
+                    #   into a slow-scanning repo must prompt instantly, star arrives async
 make charts         # regenerate bench/charts/*.svg from whatever harness output is on disk
                     #   (never re-measures — charting and measuring stay separate)
 make rss            # peak-RSS dimension alone (needs a prior `make perf` build)

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,20 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 
 # Build libft (in its directory) into a per-SAFE tree so the libc and ft_malloc
 # archives coexist and never reuse each other's objects.
+# SAFE=0 needs the ft_malloc sources, but libft declares that nested
+# submodule `update = none`, so `git submodule update --init --recursive`
+# skips it — a fresh clone (and CI) would silently build the libc fallback
+# and then die at link on the force-bound malloc_live_bytes. Materialize it
+# here, with --checkout to override the none policy, before the libft build.
 $(LIBFT_A):
+	@if [ "$(SAFE_TAG)" = "ft" ] \
+		&& [ ! -f vendor/libft/srcs/memory/ft_malloc/Makefile ]; then \
+		printf "  fetching ft_malloc (declared update=none in libft)\n" >&2; \
+		git -C vendor/libft submodule update --init --checkout \
+			srcs/memory/ft_malloc >&2 \
+		|| { printf "SAFE=0 needs ft_malloc; run: git -C vendor/libft \
+submodule update --init --checkout srcs/memory/ft_malloc\n" >&2; exit 1; }; \
+	fi
 	@printf "\n  \033[1;36m▸\033[0m \033[1;37mBuilding libft (-O3, %s)\033[0m\n\n" \
 		"$(if $(filter ft,$(SAFE_TAG)),ft_malloc,libc)" >&2
 	@$(MAKE) -C vendor/libft -j1 SAFE=$(SAFE) BUILD_DIR=build-$(SAFE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,14 @@ readline-test: all
 anim-test: all
 	@python3 $(TEST_DIR)/anim_paste_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
+# Prompt git segment must never block on `git status` (real pty): cd into
+# a repo where the scan takes seconds shows the next prompt immediately
+# (the check finishes in the background and the star arrives a render
+# late), TTL refreshes stay non-blocking, and normal-speed repos keep
+# their exact synchronous star. See tests/git_prompt_stall_test.py.
+git-prompt-test: all
+	@python3 $(TEST_DIR)/git_prompt_stall_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
+
 # Command-line option parsing (-e, -o name, +c, flags after -c, --/-,
 # invalid-option status, $-, mode-dependent nounset) vs bash --posix. These
 # exercise how the shell parses its own argv, which the golden -c harness
@@ -377,5 +385,5 @@ geoman: all
 .PHONY: test bench re all clean fclean norm my_shell help safe_banner \
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
 	docker-arch docker-clean cd-zsh-test cd-posix-test agnostic-bench \
-	hist-test readline-test anim-test conformance perf rss charts cli-opts-test \
-	login-test geoman
+	hist-test readline-test anim-test git-prompt-test conformance perf rss \
+	charts cli-opts-test login-test geoman

--- a/incs/env.h
+++ b/incs/env.h
@@ -116,6 +116,7 @@ char		**get_envp_all(t_shell *state, char *exe_path);
 char		*env_to_str(t_env *e);
 t_env		*env_nget(t_vec_env *env, char *key, int len);
 void		set_shlvl(t_shell *state);
+void		set_shell_var(t_shell *state);
 
 /* O(1) env name index (env_index.c) -- lazy hash table over the vector.
    Pass len<0 to use strlen(key).  Returns vector position, -1 if absent. */

--- a/incs/env.h
+++ b/incs/env.h
@@ -74,7 +74,7 @@ void		rec_append(t_string *out, long idx, const char *v, int vl);
 typedef struct s_var_attr
 {
 	char	*name;
-	char	kind;   /* 'i' integer, 'n' nameref */
+	char	kind; /* 'i' integer, 'n' nameref */
 	char	*target; /* nameref target name (NULL for -i) */
 }	t_var_attr;
 
@@ -84,9 +84,22 @@ void		attr_set(t_shell *state, const char *name, char kind,
 				const char *target);
 void		attr_clear(t_shell *state);
 
+/* Streaming iterator over an assoc-encoded value: prime with
+   assoc_it_init, then each assoc_next fills k/kl (key slice) and
+   v/vl (value slice), false at end. One struct instead of the five
+   pointer out-params the 42 norm forbids. */
+typedef struct s_assoc_it
+{
+	const char	*cur;
+	const char	*k;
+	const char	*v;
+	int			kl;
+	int			vl;
+}	t_assoc_it;
+
 bool		assoc_is(const char *val);
-bool		assoc_next(const char **cur, const char **k, int *kl,
-				const char **v, int *vl);
+void		assoc_it_init(t_assoc_it *it, const char *val);
+bool		assoc_next(t_assoc_it *it);
 int			assoc_count(const char *val);
 char		*assoc_get(const char *val, const char *key, int klen);
 char		*assoc_with_set(const char *old, const char *key, int klen,

--- a/incs/expander.h
+++ b/incs/expander.h
@@ -76,7 +76,7 @@ int			expand_dollar_sub(t_shell *state, const char *s, int slen,
    (${v:-w}), length (${#v}) and trim (${v#p}) forms, NULL otherwise. Used by
    both the word expander and the heredoc expander. */
 char		*expand_param_format(t_shell *state, const char *s, int slen,
-			bool dq);
+				bool dq);
 
 /* Process substitution */
 char		*expand_proc_sub(t_shell *state, t_ast_node *node);

--- a/incs/lexer.h
+++ b/incs/lexer.h
@@ -106,7 +106,7 @@ void		reclassify_keywords(t_deque_tok *tokens);
 size_t		visible_lexeme_len(t_token *t);
 size_t		num_digits(size_t v);
 void		compute_columns(t_deque_tok *tokens,
-				size_t *w_name, size_t *w_len, size_t *w_lexeme);
+						size_t *w_name, size_t *w_len, size_t *w_lexeme);
 void		print_table_header(size_t w_name, size_t w_len, size_t w_lexeme);
 void		print_table_footer(size_t w_name, size_t w_len, size_t w_lexeme);
 
@@ -115,7 +115,7 @@ const char	**get_tt_names(void);
 t_hash		*get_color_map(void);
 void		advance_bs(char **str);
 int			create_token_consume(char *start, int fd_len,
-				t_tt tt, t_token *out);
+						t_tt tt, t_token *out);
 int			check_fd_redirect(char *str, t_token *out);
 
 #endif

--- a/incs/parena.h
+++ b/incs/parena.h
@@ -29,14 +29,15 @@
 # include <stdbool.h>
 
 # define PARENA_MAX_CHUNKS 64
-# define PARENA_FIRST_CHUNK (256 * 1024)
-# define PARENA_MAX_CHUNK (8 * 1024 * 1024)
+# define PARENA_FIRST_CHUNK 262144
+# define PARENA_MAX_CHUNK 8388608
 
-/* Bump-allocation granularity. alloc and try_extend MUST round with the
-   same formula or the tip test in try_extend misfires. 8 bytes: every
-   parse object is pointer-aligned, and small blocks waste half as much
-   padding as the old 16. */
-# define PARENA_ROUND(n) (((n) + 7) & ~(size_t)7)
+/* Bump-allocation granularity is 8 bytes: every parse object is
+   pointer-aligned, and small blocks waste half as much padding as the
+   old 16. alloc and try_extend MUST round through this one function or
+   the tip test in try_extend misfires (it replaced a macro the 42 norm
+   forbids; LTO inlines it right back on optimized builds). */
+size_t		parena_round(size_t n);
 
 typedef struct s_parena
 {

--- a/incs/public/token.h
+++ b/incs/public/token.h
@@ -21,6 +21,7 @@
 
 # include "libft.h"
 # include <stdint.h>
+# include "token_old.h"
 
 /* Exhaustive list of terminal token types the lexer can produce.
    TT_WORD is the catch-all for unquoted words; TT_SQWORD/TT_DQWORD for
@@ -73,19 +74,6 @@ typedef enum e_tt
 	TT_HERESTRING,
 	TT_COPROC
 }	t_tt;
-
-/* Compact back-reference to the original full word before the lexer split
-   it into sub-tokens.  Used by the expander to reconstruct the original
-   text for ${v} word forms that span multiple sub-tokens.
-   Field order packs the struct to 16 bytes (pointer, int, two flag bytes)
-   instead of the 24 the old bool-first layout padded out to. */
-typedef struct s_token_old
-{
-	char	*start; /* pointer to start of original word in input */
-	int		len; /* byte length of the original word */
-	bool	present; /* true if this back-reference is valid */
-	bool	allocated; /* true if start is heap (must be freed) */
-}	t_token_old;
 
 /* Memoized arithmetic lex, attached to a pure-$((...)) word token so a loop
    re-evaluates without re-lexing/re-parsing. Defined in arith.h; owned by the
@@ -182,21 +170,6 @@ static inline t_token	create_tok4(char *start, int len,
 			.allocated = allocated,
 			.full_word = NULL
 		});
-}
-
-static inline t_token_old	create_token_old(char *start, int len, bool present)
-{
-	return ((t_token_old)
-		{
-			.start = start,
-			.len = len,
-			.present = present
-		});
-}
-
-static inline t_token_old	init_token_old(void)
-{
-	return ((t_token_old){.present = false, .start = NULL, .len = 0});
 }
 
 #endif

--- a/incs/public/token_old.h
+++ b/incs/public/token_old.h
@@ -1,0 +1,52 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   token_old.h                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/07/28 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/07/28 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+/* The legacy t_token_old back-reference type and its constructors, split
+   out of token.h for the 42-norm five-function file limit. token.h
+   includes this among its top includes, so every existing include site
+   keeps seeing the full token API unchanged. Do not include directly —
+   go through token.h. */
+
+#ifndef TOKEN_OLD_H
+# define TOKEN_OLD_H
+
+# include "libft.h"
+
+/* Compact back-reference to the original full word before the lexer split
+   it into sub-tokens.  Used by the expander to reconstruct the original
+   text for ${v} word forms that span multiple sub-tokens.
+   Field order packs the struct to 16 bytes (pointer, int, two flag bytes)
+   instead of the 24 the old bool-first layout padded out to. */
+typedef struct s_token_old
+{
+	char	*start; /* pointer to start of original word in input */
+	int		len; /* byte length of the original word */
+	bool	present; /* true if this back-reference is valid */
+	bool	allocated; /* true if start is heap (must be freed) */
+}	t_token_old;
+
+static inline t_token_old	create_token_old(char *start, int len, bool present)
+{
+	return ((t_token_old)
+		{
+			.start = start,
+			.len = len,
+			.present = present
+		});
+}
+
+static inline t_token_old	init_token_old(void)
+{
+	return ((t_token_old){.present = false, .start = NULL, .len = 0});
+}
+
+#endif

--- a/incs/shell.h
+++ b/incs/shell.h
@@ -225,7 +225,7 @@ typedef struct s_shell
 	int					errexit_off; /* >0: -e is suspended (in conditions) */
 	/* --- traps and readonly vars --- */
 	char				*traps[SH_NTRAP]; /* trap strings, by signal num */
-	int					trap_depth; /* >0 while a trap body runs (no re-entry) */
+	int					trap_depth; /* >0 while a trap body runs */
 	t_vec				readonly_vars; /* names that cannot be reassigned */
 	/* --- heredoc runtime state --- */
 	t_vec_redir			redirects; /* active redirections for current cmd */
@@ -264,17 +264,16 @@ typedef struct s_shell
 
 /* shopt option bits (state->shopt). Only the ones with observable
    behaviour or that scripts commonly toggle are modelled. */
-# define SHOPT_NULLGLOB   (1u << 0)
-# define SHOPT_DOTGLOB    (1u << 1)
-# define SHOPT_GLOBSTAR   (1u << 2)
-# define SHOPT_NOCASEGLOB (1u << 3)
-# define SHOPT_EXTGLOB    (1u << 4)
-# define SHOPT_LASTPIPE   (1u << 5)
-# define SHOPT_HISTAPPEND (1u << 6)
-# define SHOPT_CHECKWINSIZE (1u << 7)
-# define SHOPT_AUTOCD     (1u << 8)
-# define SHOPT_CDSPELL    (1u << 9)
-
+# define SHOPT_NULLGLOB 0x001
+# define SHOPT_DOTGLOB 0x002
+# define SHOPT_GLOBSTAR 0x004
+# define SHOPT_NOCASEGLOB 0x008
+# define SHOPT_EXTGLOB 0x010
+# define SHOPT_LASTPIPE 0x020
+# define SHOPT_HISTAPPEND 0x040
+# define SHOPT_CHECKWINSIZE 0x080
+# define SHOPT_AUTOCD 0x100
+# define SHOPT_CDSPELL 0x200
 
 /* Directory matcher ctx for glob expansion */
 typedef struct s_dir_matcher

--- a/src/alias/alias_scan.c
+++ b/src/alias/alias_scan.c
@@ -51,17 +51,29 @@ void	asc_pop(t_ascan *a)
 	a->depth--;
 }
 
-/* A newline inside a spliced alias value would break the driver's
-   one-statement-list-per-cycle model (everything after the first
-   statement would be dropped), so it is rewritten exactly like the
-   cmdhist joiner rewrites history: "; " where a separator is valid, a
-   plain space where the grammar still expects a command (right after
-   do/then/{/;/&&...) — which is precisely what cmd_pos tracks. */
-void	asc_emit_sep(t_ascan *a)
+/* One scan step: classify the byte at the top-of-stack cursor and hand
+   it to the matching handler.  Order is load-bearing: NUL pops the
+   exhausted source before anything reads past it, and '#' opens a
+   comment only at the start of a word. */
+static void	asc_step(t_ascan *a)
 {
-	if (!a->cmd_pos)
-		vec_push_nstr(&a->out, ";", 1);
-	vec_push_nstr(&a->out, " ", 1);
+	t_ascan_src	*s;
+	char		c;
+
+	s = &a->src[a->depth - 1];
+	c = s->s[s->pos];
+	if (c == '\0')
+		asc_pop(a);
+	else if (c == ' ' || c == '\t')
+		asc_scan_blank(a, s, c);
+	else if (c == '\n')
+		asc_newline(a);
+	else if (c == '#' && a->wstart)
+		asc_comment(a);
+	else if (ft_strchr(";|&()<>", c))
+		asc_op(a);
+	else
+		asc_word(a);
 }
 
 /* One full scan of a logical input line: aliases in command position are
@@ -70,9 +82,8 @@ void	asc_emit_sep(t_ascan *a)
    all behave like bash.  Returns an xmalloc'd NUL-terminated string. */
 char	*alias_scan_line(t_hash *aliases, const char *input)
 {
-	t_ascan		a;
-	t_ascan_src	*s;
-	char		c;
+	t_ascan	a;
+	char	c;
 
 	if (!input)
 		return (NULL);
@@ -87,22 +98,7 @@ char	*alias_scan_line(t_hash *aliases, const char *input)
 	a.src[0] = (t_ascan_src){.s = input};
 	a.depth = 1;
 	while (a.depth > 0)
-	{
-		s = &a.src[a.depth - 1];
-		c = s->s[s->pos];
-		if (c == '\0')
-			asc_pop(&a);
-		else if (c == ' ' || c == '\t')
-			asc_scan_blank(&a, s, c);
-		else if (c == '\n')
-			asc_newline(&a);
-		else if (c == '#' && a.wstart)
-			asc_comment(&a);
-		else if (ft_strchr(";|&()<>", c))
-			asc_op(&a);
-		else
-			asc_word(&a);
-	}
+		asc_step(&a);
 	c = '\0';
 	vec_push(&a.out, &c);
 	while (a.hd_n > 0)

--- a/src/alias/alias_scan2.c
+++ b/src/alias/alias_scan2.c
@@ -12,24 +12,6 @@
 
 #include "sh_alias.h"
 
-/* True while the given name is an active expansion source: POSIX forbids
-   re-expanding a name whose own value is still being spliced, which is
-   what turns `alias e='echo e'; e` into `echo e` instead of a loop. */
-bool	asc_active(t_ascan *a, const char *w, size_t len)
-{
-	int	i;
-
-	i = 1;
-	while (i < a->depth)
-	{
-		if (a->src[i].name && ft_strlen(a->src[i].name) == len
-			&& !ft_strncmp(a->src[i].name, w, len))
-			return (true);
-		i++;
-	}
-	return (false);
-}
-
 /* Measure the word starting at p.  A word runs until an unquoted blank,
    newline or operator character; quoted spans, backslash pairs, $(...)
    and `...` bodies belong to the word.  *plain reports whether the word
@@ -101,11 +83,32 @@ static void	asc_word_state(t_ascan *a, const char *w, size_t len, bool plain)
 	a->wstart = false;
 }
 
+/* Words copied through untouched, never alias-expanded: a queued
+   here-doc delimiter (captured for the body matcher on the way) and a
+   pure digit run glued to < or > (an fd prefix, part of the operator,
+   not a command word).  True means the word was consumed. */
+static bool	asc_word_verbatim(t_ascan *a, t_ascan_src *s, size_t len)
+{
+	if (a->pend_hd)
+	{
+		asc_hd_delim(a, s->s + s->pos, len);
+		vec_push_nstr(&a->out, s->s + s->pos, len);
+		s->pos += len;
+		return (true);
+	}
+	if (asc_digits_redir(s->s + s->pos, len))
+	{
+		vec_push_nstr(&a->out, s->s + s->pos, len);
+		s->pos += len;
+		return (true);
+	}
+	return (false);
+}
+
 /* Handle one word at the cursor: here-doc delimiters and redirection
    targets are copied through untouched; an eligible alias word is
    replaced by pushing its value as the new source; everything else is
-   emitted and folded into the position-tracking state machine.  A pure
-   digit run glued to < or > is an fd prefix, not a word. */
+   emitted and folded into the position-tracking state machine. */
 void	asc_word(t_ascan *a)
 {
 	t_ascan_src	*s;
@@ -114,19 +117,8 @@ void	asc_word(t_ascan *a)
 
 	s = &a->src[a->depth - 1];
 	len = asc_word_span(s->s + s->pos, &plain);
-	if (a->pend_hd)
-	{
-		asc_hd_delim(a, s->s + s->pos, len);
-		vec_push_nstr(&a->out, s->s + s->pos, len);
-		s->pos += len;
+	if (asc_word_verbatim(a, s, len))
 		return ;
-	}
-	if (asc_digits_redir(s->s + s->pos, len))
-	{
-		vec_push_nstr(&a->out, s->s + s->pos, len);
-		s->pos += len;
-		return ;
-	}
 	if (!a->after_redir && (a->cmd_pos || a->chk_next) && plain
 		&& !asc_is_assign(s->s + s->pos, len)
 		&& asc_try_alias(a, s->s + s->pos, len))

--- a/src/alias/alias_scan3.c
+++ b/src/alias/alias_scan3.c
@@ -12,11 +12,26 @@
 
 #include "sh_alias.h"
 
+/* << at the cursor, first < already emitted: copy the second <, queue a
+   here-doc delimiter capture (2 = <<- tab-stripping form), and pull in a
+   clustered - or a third < (<<< here-string turns back into a plain
+   redirection target inside asc_op_extra). */
+static void	asc_op_hd(t_ascan *a, t_ascan_src *s)
+{
+	vec_push(&a->out, &s->s[s->pos]);
+	s->pos++;
+	a->pend_hd = 1;
+	if (s->s[s->pos] == '-')
+		a->pend_hd = 2;
+	if (s->s[s->pos] == '-' || s->s[s->pos] == '<')
+		asc_op_extra(a, s);
+}
+
 /* Operator characters at the cursor: copy them through and update the
    position state.  ; | & ( ) and friends put the scanner back in command
    position; < and > (plus clustered <<, >>, <&, >&, >|, <>) arm the
    redirection-target rule instead, and << additionally queues a here-doc
-   delimiter capture (2 = <<- tab-stripping form). */
+   delimiter capture via asc_op_hd. */
 void	asc_op(t_ascan *a)
 {
 	t_ascan_src	*s;
@@ -35,13 +50,7 @@ void	asc_op(t_ascan *a)
 	}
 	if (c == '<' && s->s[s->pos] == '<')
 	{
-		vec_push(&a->out, &s->s[s->pos]);
-		s->pos++;
-		a->pend_hd = 1;
-		if (s->s[s->pos] == '-')
-			a->pend_hd = 2;
-		if (s->s[s->pos] == '-' || s->s[s->pos] == '<')
-			asc_op_extra(a, s);
+		asc_op_hd(a, s);
 		return ;
 	}
 	a->after_redir = true;
@@ -64,32 +73,6 @@ void	asc_op_extra(t_ascan *a, t_ascan_src *s)
 		a->pend_hd = 0;
 		a->after_redir = true;
 	}
-}
-
-/* A newline ends the command: emit it, then, if here-doc delimiters are
-   queued, copy the body lines through verbatim (aliases never expand
-   inside a here-doc body).  Inside an alias value the newline becomes a
-   "; " (or " ") instead — see asc_emit_sep.  The next word is in
-   command position. */
-void	asc_newline(t_ascan *a)
-{
-	t_ascan_src	*s;
-	char		c;
-
-	s = &a->src[a->depth - 1];
-	c = '\n';
-	s->pos++;
-	if (a->depth > 1 && a->hd_n == 0)
-		asc_emit_sep(a);
-	else
-		vec_push(&a->out, &c);
-	while (a->hd_n > 0 && s->s[s->pos])
-		asc_hd_body(a, s);
-	a->cmd_pos = true;
-	a->chk_next = false;
-	a->after_redir = false;
-	a->pend_hd = 0;
-	a->wstart = true;
 }
 
 /* Register a here-doc delimiter captured right after <<.  One level of

--- a/src/alias/alias_scan5.c
+++ b/src/alias/alias_scan5.c
@@ -57,7 +57,7 @@ void	asc_hd_drop(t_ascan *a)
    alias expansion stays live for what follows. */
 bool	asc_kw_cmdnext(const char *w, size_t len)
 {
-	static const char	*const	kw[] = {"if", "then", "elif", "else",
+	static const char *const	kw[] = {"if", "then", "elif", "else",
 		"while", "until", "do", "{", "!", NULL};
 	int							i;
 
@@ -75,7 +75,7 @@ bool	asc_kw_cmdnext(const char *w, size_t len)
    variables, case subjects, wordlists). */
 bool	asc_kw_noncmd(const char *w, size_t len)
 {
-	static const char	*const	kw[] = {"for", "case", "in", NULL};
+	static const char *const	kw[] = {"for", "case", "in", NULL};
 	int							i;
 
 	i = 0;

--- a/src/alias/alias_scan6.c
+++ b/src/alias/alias_scan6.c
@@ -1,0 +1,70 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   alias_scan6.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/07/19 12:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/07/19 12:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "sh_alias.h"
+
+/* True while the given name is an active expansion source: POSIX forbids
+   re-expanding a name whose own value is still being spliced, which is
+   what turns `alias e='echo e'; e` into `echo e` instead of a loop. */
+bool	asc_active(t_ascan *a, const char *w, size_t len)
+{
+	int	i;
+
+	i = 1;
+	while (i < a->depth)
+	{
+		if (a->src[i].name && ft_strlen(a->src[i].name) == len
+			&& !ft_strncmp(a->src[i].name, w, len))
+			return (true);
+		i++;
+	}
+	return (false);
+}
+
+/* A newline inside a spliced alias value would break the driver's
+   one-statement-list-per-cycle model (everything after the first
+   statement would be dropped), so it is rewritten exactly like the
+   cmdhist joiner rewrites history: "; " where a separator is valid, a
+   plain space where the grammar still expects a command (right after
+   do/then/{/;/&&...) — which is precisely what cmd_pos tracks. */
+void	asc_emit_sep(t_ascan *a)
+{
+	if (!a->cmd_pos)
+		vec_push_nstr(&a->out, ";", 1);
+	vec_push_nstr(&a->out, " ", 1);
+}
+
+/* A newline ends the command: emit it, then, if here-doc delimiters are
+   queued, copy the body lines through verbatim (aliases never expand
+   inside a here-doc body).  Inside an alias value the newline becomes a
+   "; " (or " ") instead — see asc_emit_sep.  The next word is in
+   command position. */
+void	asc_newline(t_ascan *a)
+{
+	t_ascan_src	*s;
+	char		c;
+
+	s = &a->src[a->depth - 1];
+	c = '\n';
+	s->pos++;
+	if (a->depth > 1 && a->hd_n == 0)
+		asc_emit_sep(a);
+	else
+		vec_push(&a->out, &c);
+	while (a->hd_n > 0 && s->s[s->pos])
+		asc_hd_body(a, s);
+	a->cmd_pos = true;
+	a->chk_next = false;
+	a->after_redir = false;
+	a->pend_hd = 0;
+	a->wstart = true;
+}

--- a/src/builtins/builtin_declare.c
+++ b/src/builtins/builtin_declare.c
@@ -13,6 +13,8 @@
 #include "builtins_private.h"
 #include "env.h"
 
+int	declare_assoc(t_shell *state, t_vec argv, size_t i);
+
 /* declare / typeset: the subset scripts actually depend on.
    - declare -p [NAME...]  prints each variable's declaration in bash form
      (declare -a a=([0]="x") for arrays, declare -- v="val" for scalars).
@@ -86,65 +88,54 @@ static void	declare_assign(t_shell *state, const char *word, int export)
 	env_set(&state->env, env_create(key, ft_strdup(eq + 1), export != 0));
 }
 
-/* declare -A NAME...: create each NAME as an EMPTY associative array
-   (value = the assoc magic byte). The attribute lives in the value, so a
-   later h[key]=v sees the assoc magic and treats key as a literal string.
-   NAME=(...) compound init after -A is a v1 scope-out; the near-universal
-   pattern is `declare -A h; h[k]=v`. */
-static int	declare_assoc(t_shell *state, t_vec argv, size_t i)
-{
-	char	*empty;
-	char	*eq;
-	char	*key;
-
-	while (i < argv.len)
-	{
-		eq = ft_strchr(((char **)argv.ctx)[i], '=');
-		if (eq)
-			key = ft_strndup(((char **)argv.ctx)[i],
-					eq - ((char **)argv.ctx)[i]);
-		else
-			key = ft_strdup(((char **)argv.ctx)[i]);
-		empty = xmalloc(2);
-		empty[0] = ARR_ASSOC_MAGIC;
-		empty[1] = '\0';
-		env_set(&state->env, env_create(key, empty, false));
-		i++;
-	}
-	return (0);
-}
-
-int	builtin_declare(t_shell *state, t_vec argv)
+/* Scan declare's leading option words into a p/x/A bitmask (1/2/4).
+   -n and -i are terminal: everything from that word on goes to the
+   nameref/integer routine, so we stop at the word carrying one and
+   report it through *term ('n' outranks 'i' inside one cluster, as
+   before). Returns the index of the first unconsumed word. */
+static size_t	declare_scan(t_vec argv, int *flags, char *term)
 {
 	size_t	i;
-	int		export;
-	int		printmode;
-	int		assoc;
 
-	export = 0;
-	printmode = 0;
-	assoc = 0;
+	*flags = 0;
+	*term = 0;
 	i = 1;
 	while (i < argv.len && ((char **)argv.ctx)[i][0] == '-'
 		&& ((char **)argv.ctx)[i][1])
 	{
 		if (ft_strchr(((char **)argv.ctx)[i], 'p'))
-			printmode = 1;
+			*flags |= 1;
 		if (ft_strchr(((char **)argv.ctx)[i], 'x'))
-			export = 1;
+			*flags |= 2;
 		if (ft_strchr(((char **)argv.ctx)[i], 'A'))
-			assoc = 1;
+			*flags |= 4;
 		if (ft_strchr(((char **)argv.ctx)[i], 'n'))
-			return (declare_nameref(state, argv, i));
-		if (ft_strchr(((char **)argv.ctx)[i], 'i'))
-			return (declare_integer(state, argv, i));
+			*term = 'n';
+		else if (ft_strchr(((char **)argv.ctx)[i], 'i'))
+			*term = 'i';
+		if (*term)
+			return (i);
 		i++;
 	}
-	if (assoc)
+	return (i);
+}
+
+int	builtin_declare(t_shell *state, t_vec argv)
+{
+	size_t	i;
+	int		flags;
+	char	term;
+
+	i = declare_scan(argv, &flags, &term);
+	if (term == 'n')
+		return (declare_nameref(state, argv, i));
+	if (term == 'i')
+		return (declare_integer(state, argv, i));
+	if (flags & 4)
 		return (declare_assoc(state, argv, i));
-	if (printmode)
+	if (flags & 1)
 		return (declare_print(state, argv, i));
 	while (i < argv.len)
-		declare_assign(state, ((char **)argv.ctx)[i++], export);
+		declare_assign(state, ((char **)argv.ctx)[i++], (flags & 2) != 0);
 	return (0);
 }

--- a/src/builtins/builtin_declare2.c
+++ b/src/builtins/builtin_declare2.c
@@ -26,7 +26,10 @@ int	declare_nameref(t_shell *state, t_vec argv, size_t i)
 	while (i < argv.len)
 	{
 		if (((char **)argv.ctx)[i][0] == '-')
-			return (i++, (i < argv.len) ? declare_nameref(state, argv, i) : 0);
+		{
+			i++;
+			continue ;
+		}
 		eq = ft_strchr(((char **)argv.ctx)[i], '=');
 		if (eq)
 		{
@@ -80,6 +83,34 @@ int	declare_integer(t_shell *state, t_vec argv, size_t i)
 			val = int_eval(state, eq + 1);
 			env_set(&state->env, env_create(name, val, false));
 		}
+		i++;
+	}
+	return (0);
+}
+
+/* declare -A NAME...: create each NAME as an EMPTY associative array
+   (value = the assoc magic byte). The attribute lives in the value, so a
+   later h[key]=v sees the assoc magic and treats key as a literal string.
+   NAME=(...) compound init after -A is a v1 scope-out; the near-universal
+   pattern is `declare -A h; h[k]=v`. */
+int	declare_assoc(t_shell *state, t_vec argv, size_t i)
+{
+	char	*empty;
+	char	*eq;
+	char	*key;
+
+	while (i < argv.len)
+	{
+		eq = ft_strchr(((char **)argv.ctx)[i], '=');
+		if (eq)
+			key = ft_strndup(((char **)argv.ctx)[i],
+					eq - ((char **)argv.ctx)[i]);
+		else
+			key = ft_strdup(((char **)argv.ctx)[i]);
+		empty = xmalloc(2);
+		empty[0] = ARR_ASSOC_MAGIC;
+		empty[1] = '\0';
+		env_set(&state->env, env_create(key, empty, false));
 		i++;
 	}
 	return (0);

--- a/src/builtins/builtin_mapfile.c
+++ b/src/builtins/builtin_mapfile.c
@@ -40,6 +40,15 @@ static char	*slurp_stdin(void)
 	return ((char *)buf.ctx);
 }
 
+/* Duplicate n bytes of `line` into a fresh element appended to `elems`. */
+static void	push_line(t_vec *elems, const char *line, size_t n)
+{
+	char	*el;
+
+	el = ft_strndup(line, n);
+	vec_push(elems, &el);
+}
+
 /* Split `text` into lines, one array element each. With keep_nl the
    terminating '\n' stays on the element (bash without -t); otherwise it
    is dropped. A trailing partial line (no newline) still becomes an
@@ -59,17 +68,13 @@ static char	*mapfile_encode(const char *text, int keep_nl)
 	{
 		if (text[i] == '\n')
 		{
-			el = ft_strndup(text + start, i - start + keep_nl);
-			vec_push(&elems, &el);
+			push_line(&elems, text + start, i - start + keep_nl);
 			start = i + 1;
 		}
 		i++;
 	}
 	if (i > start)
-	{
-		el = ft_strndup(text + start, i - start);
-		vec_push(&elems, &el);
-	}
+		push_line(&elems, text + start, i - start);
 	el = arr_from_elems((char **)elems.ctx, (int)elems.len, NULL);
 	return (mapfile_free_elems(&elems), el);
 }

--- a/src/builtins/builtin_misc2.c
+++ b/src/builtins/builtin_misc2.c
@@ -59,7 +59,7 @@ int	umask_opts(char **av, size_t len, int *idx)
 	int	j;
 
 	flags = 0;
-	while ((size_t)*idx < len && av[*idx][0] == '-' && av[*idx][1])
+	while ((size_t)(*idx) < len && av[*idx][0] == '-' && av[*idx][1])
 	{
 		if (ft_strcmp(av[*idx], "--") == 0)
 			return ((*idx)++, flags);

--- a/src/builtins/builtin_printf2.c
+++ b/src/builtins/builtin_printf2.c
@@ -59,55 +59,6 @@ static void	run_format(t_pf *pf, const char *fmt)
 	}
 }
 
-/* Locate the format word: an optional "--" end-of-options marker is
-   consumed (as in `printf -- '-'`); a lone "-" is a format string; any
-   other leading dash-word — including bash's -v extension — is rejected as
-   an invalid option with status 2, like dash (and like bash for every
-   option it does not know). We deliberately do NOT implement -v's variable
-   assignment: printf is on the forkless $(...) whitelist precisely because
-   it cannot touch shell state, and an in-process `$(printf -v x ...)`
-   would leak the assignment into the parent where bash's subshell drops
-   it. The spec's expected output for the -v error path (status 2, nothing
-   printed) is exactly what this produces. Returns the format's index, or
-   -1 on an invalid option. */
-/* A valid printf -v target: a POSIX identifier, optionally with a
-   [subscript] suffix (array element). Rejects digit-initial names and
-   an unterminated bracket, matching bash's "not a valid identifier". */
-static bool	pf_valid_name(const char *n)
-{
-	int	i;
-
-	if (!n[0] || (!ft_isalpha((unsigned char)n[0]) && n[0] != '_'))
-		return (false);
-	i = 1;
-	while (n[i] && n[i] != '[')
-	{
-		if (!ft_isalnum((unsigned char)n[i]) && n[i] != '_')
-			return (false);
-		i++;
-	}
-	if (n[i] == '[')
-		return (n[ft_strlen(n) - 1] == ']');
-	return (true);
-}
-
-static int	pf_fmt_index(t_vec argv, char **vname)
-{
-	char	**av;
-
-	av = (char **)argv.ctx;
-	*vname = NULL;
-	if (argv.len >= 3 && ft_strcmp(av[1], "-v") == 0 && pf_valid_name(av[2]))
-		return (*vname = av[2], 3);
-	if (argv.len >= 3 && ft_strcmp(av[1], "-v") == 0)
-		return (-1);
-	if (argv.len >= 2 && !ft_strncmp(av[1], "--", 3))
-		return (2);
-	if (argv.len >= 2 && av[1][0] == '-' && av[1][1])
-		return (-1);
-	return (1);
-}
-
 /* Deliver the rendered output to stdout in one go. Returns printf's exit
    status — 1 if any conversion saw an invalid argument or directive,
    else 0. */

--- a/src/builtins/builtin_printf3.c
+++ b/src/builtins/builtin_printf3.c
@@ -91,3 +91,52 @@ void	pf_build_spec(char *dst, t_spec *sp, char conv)
 	dst[k] = conv;
 	dst[k + 1] = '\0';
 }
+
+/* A valid printf -v target: a POSIX identifier, optionally with a
+   [subscript] suffix (array element). Rejects digit-initial names and
+   an unterminated bracket, matching bash's "not a valid identifier". */
+static bool	pf_valid_name(const char *n)
+{
+	int	i;
+
+	if (!n[0] || (!ft_isalpha((unsigned char)n[0]) && n[0] != '_'))
+		return (false);
+	i = 1;
+	while (n[i] && n[i] != '[')
+	{
+		if (!ft_isalnum((unsigned char)n[i]) && n[i] != '_')
+			return (false);
+		i++;
+	}
+	if (n[i] == '[')
+		return (n[ft_strlen(n) - 1] == ']');
+	return (true);
+}
+
+/* Locate the format word: an optional "--" end-of-options marker is
+   consumed (as in `printf -- '-'`); a lone "-" is a format string; any
+   other leading dash-word — including bash's -v extension — is rejected as
+   an invalid option with status 2, like dash (and like bash for every
+   option it does not know). We deliberately do NOT implement -v's variable
+   assignment: printf is on the forkless $(...) whitelist precisely because
+   it cannot touch shell state, and an in-process `$(printf -v x ...)`
+   would leak the assignment into the parent where bash's subshell drops
+   it. The spec's expected output for the -v error path (status 2, nothing
+   printed) is exactly what this produces. Returns the format's index, or
+   -1 on an invalid option. */
+int	pf_fmt_index(t_vec argv, char **vname)
+{
+	char	**av;
+
+	av = (char **)argv.ctx;
+	*vname = NULL;
+	if (argv.len >= 3 && ft_strcmp(av[1], "-v") == 0 && pf_valid_name(av[2]))
+		return (*vname = av[2], 3);
+	if (argv.len >= 3 && ft_strcmp(av[1], "-v") == 0)
+		return (-1);
+	if (argv.len >= 2 && !ft_strncmp(av[1], "--", 3))
+		return (2);
+	if (argv.len >= 2 && av[1][0] == '-' && av[1][1])
+		return (-1);
+	return (1);
+}

--- a/src/builtins/builtin_read3.c
+++ b/src/builtins/builtin_read3.c
@@ -40,6 +40,26 @@ size_t	parse_read_opts(t_vec argv, bool *raw)
 	return (i);
 }
 
+/* Route the completed line to its destination: -a fills the named array,
+   no variable names sends the whole line to $REPLY, otherwise the line is
+   IFS-split across the named variables. rd_set_var takes ownership of the
+   line; the array/word paths copy fields out of it, so it is freed here. */
+static void	rd_dispatch(t_shell *state, t_vec argv, char *line, t_rdopt *o)
+{
+	if (o->aname)
+	{
+		rd_assign_array(state, line, o);
+		xfree(line);
+	}
+	else if (o->first >= argv.len)
+		rd_set_var(state, "REPLY", line);
+	else
+	{
+		assign_words(state, line, argv, o);
+		xfree(line);
+	}
+}
+
 /* read [-r] [var ...]: read one line from stdin and split it into variables.
    If no variable names are given, the whole line goes into $REPLY (POSIX).
    Returns 1 on EOF even if some data was read (mimics bash), so `while read
@@ -60,17 +80,6 @@ int	builtin_read(t_shell *state, t_vec argv)
 	line = read_one_line(o.raw, &eof);
 	if (!line)
 		return (xfree(o.ifs), 1);
-	if (o.aname)
-	{
-		rd_assign_array(state, line, &o);
-		xfree(line);
-	}
-	else if (o.first >= argv.len)
-		rd_set_var(state, "REPLY", line);
-	else
-	{
-		assign_words(state, line, argv, &o);
-		xfree(line);
-	}
+	rd_dispatch(state, argv, line, &o);
 	return (xfree(o.ifs), eof != 0);
 }

--- a/src/builtins/builtin_set2.c
+++ b/src/builtins/builtin_set2.c
@@ -99,26 +99,6 @@ static char	**collect_tail_positionals(t_shell *state, int from, int count)
 	return (vals);
 }
 
-/* Like pos_build but the strings are BORROWED (pointer copy, no strdup): used
-   for a function call's $1.. which live in the caller's argv for the call's
-   duration. shift/set promote to an owned copy (pos_build) before mutating, so
-   the borrowed strings are never freed by pos_free. */
-void	pos_borrow(t_pos *pos, char **args, size_t n)
-{
-	size_t	i;
-
-	pos->args = ft_calloc(n + 1, sizeof(char *));
-	i = 0;
-	while (pos->args && args && i < n)
-	{
-		pos->args[i] = args[i];
-		i++;
-	}
-	pos->count = (int)n;
-	pos->args_owned = false;
-	pos_set_cnt(pos);
-}
-
 /* shift [n]: discard the first n positional parameters (default 1). We
    collect the remaining tail as a new owned array, then replace the current
    set. Shifting by more than $# is an error (status 1) per POSIX — we do

--- a/src/builtins/builtin_shopt.c
+++ b/src/builtins/builtin_shopt.c
@@ -49,29 +49,12 @@ static void	shopt_sync(t_shell *state)
 	*glob_dotglob_cell() = (state->shopt & SHOPT_DOTGLOB) != 0;
 }
 
-/* Print every known option as "name<TAB>on|off" (the no-argument form). */
-static int	shopt_print_all(t_shell *state)
-{
-	static const char	*const	names[] = {"autocd", "cdspell",
-		"checkwinsize", "dotglob", "extglob", "globstar", "histappend",
-		"lastpipe", "nocaseglob", "nullglob", NULL};
-	int							i;
-
-	i = 0;
-	while (names[i])
-	{
-		ft_printf("%-20s\t%s\n", names[i],
-			((state->shopt & shopt_bit(names[i])) ? "on" : "off"));
-		i++;
-	}
-	return (0);
-}
-
 /* Apply/query one name under mode ('s' set, 'u' unset, 'q' query,
    0 print). Returns the per-name status for -q/print accumulation. */
 static int	shopt_one(t_shell *state, const char *name, char mode)
 {
 	unsigned int	bit;
+	const char		*st;
 
 	bit = shopt_bit(name);
 	if (bit == 0)
@@ -82,9 +65,31 @@ static int	shopt_one(t_shell *state, const char *name, char mode)
 	else if (mode == 'u')
 		state->shopt &= ~bit;
 	else if (mode == 0)
-		ft_printf("%-20s\t%s\n", name,
-			((state->shopt & bit) ? "on" : "off"));
-	return ((state->shopt & bit) ? 0 : 1);
+	{
+		st = "off";
+		if (state->shopt & bit)
+			st = "on";
+		ft_printf("%-20s\t%s\n", name, st);
+	}
+	if (state->shopt & bit)
+		return (0);
+	return (1);
+}
+
+/* Print every known option as "name<TAB>on|off" (the no-argument form).
+   Each line goes through shopt_one's print mode so the output format
+   lives in exactly one place. */
+static int	shopt_print_all(t_shell *state)
+{
+	static const char *const	names[] = {"autocd", "cdspell",
+		"checkwinsize", "dotglob", "extglob", "globstar", "histappend",
+		"lastpipe", "nocaseglob", "nullglob", NULL};
+	int							i;
+
+	i = 0;
+	while (names[i])
+		shopt_one(state, names[i++], 0);
+	return (0);
 }
 
 int	builtin_shopt(t_shell *state, t_vec argv)

--- a/src/builtins/core_builtins.c
+++ b/src/builtins/core_builtins.c
@@ -144,4 +144,3 @@ int	builtin_echo(t_shell *state, t_vec argv)
 	xfree(out.ctx);
 	return (0);
 }
-

--- a/src/builtins/core_builtins2.c
+++ b/src/builtins/core_builtins2.c
@@ -16,7 +16,10 @@
    (-f). Like export and cd, must run in the parent shell; a forked child
    unsetting a variable would have zero visible effect. The -f/-v flag is
    optional and only detected when it is a standalone single-char word —
-   `-fv` is not parsed to keep the logic simple (bash behaves the same). */
+   `-fv` is not parsed to keep the logic simple (bash behaves the same).
+   The option scan stops on a literal "--"; the boolean increment right
+   after the loop consumes that terminator (and nothing else) so it is
+   never handed to try_unset as a name. */
 int	builtin_unset(t_shell *state, t_vec argv)
 {
 	char	**av;
@@ -24,21 +27,17 @@ int	builtin_unset(t_shell *state, t_vec argv)
 	int		fmode;
 
 	av = (char **)argv.ctx;
-	i = 1;
 	fmode = 0;
-	while (i < argv.len && av[i][0] == '-' && av[i][1])
+	i = 0;
+	while (++i < argv.len && av[i][0] == '-' && av[i][1]
+		&& ft_strcmp(av[i], "--") != 0)
 	{
-		if (!ft_strcmp(av[i], "--"))
-		{
-			i++;
-			break ;
-		}
 		if (bad_opt_word(av[i], "vf"))
 			return (ft_eprintf("%s: unset: %s: invalid option\n",
 					state->ctx, av[i]), 2);
 		fmode = (ft_strchr(av[i], 'f') != NULL);
-		i++;
 	}
+	i += (i < argv.len && !ft_strcmp(av[i], "--"));
 	while (i < argv.len)
 	{
 		if (fmode)

--- a/src/builtins/exit_helpers.c
+++ b/src/builtins/exit_helpers.c
@@ -19,21 +19,22 @@
    accepts the entire long long range so `exit 9223372036854775807` is a
    valid status that later gets masked to 8 bits.  A non-numeric operand or
    a value that overflows long long returns -1 -> "numeric argument
-   required".  On success stores the value and returns 0. */
+   required".  On success stores the value and returns 0.  The sign is
+   consumed by a boolean increment (i += ...) — one line, not an if, to
+   keep the body inside the 42-norm 25-line ceiling. */
 int	exit_parse_ll(const char *s, long long *out)
 {
 	long long	n;
 	int			i;
 	int			neg;
 
-	i = 0;
-	while (s && (s[i] == ' ' || s[i] == '\t'))
-		i++;
 	if (!s)
 		return (-1);
-	neg = (s[i] == '-');
-	if (s[i] == '-' || s[i] == '+')
+	i = 0;
+	while (s[i] == ' ' || s[i] == '\t')
 		i++;
+	neg = (s[i] == '-');
+	i += (s[i] == '-' || s[i] == '+');
 	if (!ft_isdigit(s[i]))
 		return (-1);
 	n = 0;

--- a/src/builtins/hash_builtins_dispatch.c
+++ b/src/builtins/hash_builtins_dispatch.c
@@ -14,14 +14,18 @@
 
 /* The dispatch table lives in a static t_hash inside builtin_func() and is
    built exactly once (lazy-init on first call). We split the registration
-   into two helpers only to stay within the 42-norm 25-line limit per
-   function — both fill the same hash table `h`.
+   into three helpers only to stay within the 42-norm 25-line limit per
+   function — all of them fill the same hash table `h`.
 
    Why a hash table and not a switch? The builtin name arrives as a string;
    hashing gives O(1) lookup with no strcmp chain and no need to intern the
    name. The function pointers are cast to void* for storage and back to
    t_builtin_fn on retrieval — ugly but correct because data/code pointer
-   sizes match on all the targets we care about (Linux x86-64/arm64). */
+   sizes match on all the targets we care about (Linux x86-64/arm64).
+
+   env is NOT a builtin: real env execs its command arg (env cmd, env -i
+   cmd) and prints the environment with no args -- external /usr/bin/env
+   does both identically, so registering a builtin only broke `env cmd`. */
 static void	fill_builtin_hash1(t_hash *h)
 {
 	hash_set(h, "echo", (void *)builtin_echo);
@@ -32,9 +36,6 @@ static void	fill_builtin_hash1(t_hash *h)
 	hash_set(h, "[[", (void *)builtin_test);
 	hash_set(h, "exit", (void *)builtin_exit);
 	hash_set(h, "pwd", (void *)builtin_pwd);
-	/* env is NOT a builtin: real env execs its command arg (env cmd, env -i
-	   cmd) and prints the environment with no args -- external /usr/bin/env
-	   does both identically, so registering a builtin only broke `env cmd`. */
 	hash_set(h, "unset", (void *)builtin_unset);
 	hash_set(h, "type", (void *)builtin_type);
 	hash_set(h, "set", (void *)builtin_set);
@@ -77,6 +78,12 @@ static void	fill_builtin_hash2(t_hash *h)
 	hash_set(h, "printf", (void *)builtin_printf);
 	hash_set(h, "ulimit", (void *)builtin_ulimit);
 	hash_set(h, "update", (void *)builtin_update);
+}
+
+/* Registration overflow: fill_builtin_hash2 hit the 25-line ceiling, so
+   the newest builtins spill over here. */
+static void	fill_builtin_hash3(t_hash *h)
+{
 	hash_set(h, "mapfile", (void *)builtin_mapfile);
 	hash_set(h, "readarray", (void *)builtin_mapfile);
 	hash_set(h, "declare", (void *)builtin_declare);
@@ -89,6 +96,7 @@ static void	init_builtin_hash(t_hash *h)
 	hash_init(h, 32);
 	fill_builtin_hash1(h);
 	fill_builtin_hash2(h);
+	fill_builtin_hash3(h);
 }
 
 /* Look up a builtin by name. The hash table is initialised on the first call

--- a/src/builtins/printf_private.h
+++ b/src/builtins/printf_private.h
@@ -57,5 +57,6 @@ void		pf_emit_b(t_string *out, const char *arg, bool *stop);
 void		pf_conv(t_pf *pf, t_spec *sp, char conv);
 void		pf_parse_spec(t_pf *pf, const char *fmt, int *i, t_spec *sp);
 void		pf_build_spec(char *dst, t_spec *sp, char conv);
+int			pf_fmt_index(t_vec argv, char **vname);
 
 #endif

--- a/src/builtins/set_opts.c
+++ b/src/builtins/set_opts.c
@@ -104,39 +104,3 @@ int	set_long_option(t_shell *state, char sign, const char *name)
 		set_opt_edit_mode(state, name, on);
 	return (0);
 }
-
-/* Apply one flag word like "-e", "+e", "-eux". Returns false when the
-   word contains a letter this shell does not implement, so the caller
-   can emit bash's "invalid option" error + status 2 instead of silently
-   swallowing it (a lie about what the shell honours). */
-bool	apply_flag_word(t_shell *state, const char *w)
-{
-	char	sign;
-	int		j;
-
-	sign = w[0];
-	j = 1;
-	while (w[j])
-	{
-		if (!ft_strchr("euxfCanv", w[j]))
-			return (false);
-		if (w[j] == 'e')
-			state->opt_errexit = (sign == '-');
-		else if (w[j] == 'u')
-			state->opt_nounset = (sign == '-');
-		else if (w[j] == 'x')
-			state->opt_xtrace = (sign == '-');
-		else if (w[j] == 'f')
-			state->opt_noglob = (sign == '-');
-		else if (w[j] == 'C')
-			state->opt_noclobber = (sign == '-');
-		else if (w[j] == 'a')
-			state->opt_allexport = (sign == '-');
-		else if (w[j] == 'n')
-			state->opt_noexec = (sign == '-');
-		else if (w[j] == 'v')
-			state->opt_verbose = (sign == '-');
-		j++;
-	}
-	return (true);
-}

--- a/src/builtins/set_opts2.c
+++ b/src/builtins/set_opts2.c
@@ -54,6 +54,26 @@ static int	set_lone_dash(t_shell *state, t_vec argv, size_t from)
 	return (0);
 }
 
+/* Consume one option word: `-o`/`+o` (plus the name that may follow, via
+   set_o_word), a ±letter cluster, or the lone `+` no-op.  Advances *i past
+   what was eaten; returns 2 on an unimplemented letter so the caller can
+   emit bash's "invalid option" error, 0 otherwise. */
+static int	set_flag_arg(t_shell *state, char **av, size_t len, size_t *i)
+{
+	if (!ft_strcmp(av[*i], "-o") || !ft_strcmp(av[*i], "+o"))
+		*i += set_o_word(state, av[*i][0], av + *i, len - *i);
+	else if (av[*i][1])
+	{
+		if (!apply_flag_word(state, av[*i]))
+			return (ft_eprintf("%s: set: invalid option\n",
+					state->ctx), 2);
+		(*i)++;
+	}
+	else
+		(*i)++;
+	return (0);
+}
+
 /* POSIX `set` argument scan: flag words are consumed left to right until
    `--`, a lone `-`, or the first non-option word.  `--` always replaces the
    positional parameters — clearing them when nothing follows; a lone `+` is
@@ -64,8 +84,10 @@ int	apply_set_flags(t_shell *state, t_vec argv)
 {
 	char	**av;
 	size_t	i;
+	int		rc;
 
 	av = (char **)argv.ctx;
+	rc = 0;
 	i = 1;
 	while (i < argv.len)
 	{
@@ -74,52 +96,12 @@ int	apply_set_flags(t_shell *state, t_vec argv)
 					argv.len - i - 1));
 		if (ft_strcmp(av[i], "-") == 0)
 			return (set_lone_dash(state, argv, i + 1));
-		if (!ft_strcmp(av[i], "-o") || !ft_strcmp(av[i], "+o"))
-			i += set_o_word(state, av[i][0], av + i, argv.len - i);
-		else if ((av[i][0] == '-' || av[i][0] == '+') && av[i][1])
-		{
-			if (!apply_flag_word(state, av[i]))
-				return (ft_eprintf("%s: set: invalid option\n",
-						state->ctx), 2);
-			i++;
-		}
-		else if (av[i][0] == '+')
-			i++;
+		if (av[i][0] == '+' || (av[i][0] == '-' && av[i][1]))
+			rc = set_flag_arg(state, av, argv.len, &i);
 		else
 			return (set_positional_args(state, av + i, argv.len - i));
+		if (rc)
+			return (rc);
 	}
 	return (0);
-}
-
-/* Build the value of $- (the flag string): append one letter for each
-   currently-enabled option. The 'i' flag appears when the shell is running
-   interactively (INP_RL), not as a separately toggled option — POSIX says
-   $- must include 'i' for interactive shells. We write into state->flagbuf
-   (a fixed-size field in t_shell) so the returned pointer stays valid until
-   the next call. env_expand("−") calls this to get the current value. */
-char	*build_flagstr(t_shell *state)
-{
-	int	k;
-
-	k = 0;
-	if (state->opt_allexport)
-		state->flagbuf[k++] = 'a';
-	if (state->opt_errexit)
-		state->flagbuf[k++] = 'e';
-	if (state->opt_noglob)
-		state->flagbuf[k++] = 'f';
-	if (state->metinp == INP_RL || state->opt_interactive)
-		state->flagbuf[k++] = 'i';
-	if (state->opt_noexec)
-		state->flagbuf[k++] = 'n';
-	if (state->opt_nounset)
-		state->flagbuf[k++] = 'u';
-	if (state->opt_verbose)
-		state->flagbuf[k++] = 'v';
-	if (state->opt_xtrace)
-		state->flagbuf[k++] = 'x';
-	if (state->opt_noclobber)
-		state->flagbuf[k++] = 'C';
-	state->flagbuf[k] = '\0';
-	return (state->flagbuf);
 }

--- a/src/builtins/set_opts3.c
+++ b/src/builtins/set_opts3.c
@@ -1,0 +1,111 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   set_opts3.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/06/02 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/06/02 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins_private.h"
+#include "sh_input.h"
+
+/* Set one of set's short-option letters to `on`. The caller has already
+   vetted the letter against the supported set, so anything unknown is
+   simply ignored here. */
+static void	set_flag_char(t_shell *state, char c, bool on)
+{
+	if (c == 'e')
+		state->opt_errexit = on;
+	else if (c == 'u')
+		state->opt_nounset = on;
+	else if (c == 'x')
+		state->opt_xtrace = on;
+	else if (c == 'f')
+		state->opt_noglob = on;
+	else if (c == 'C')
+		state->opt_noclobber = on;
+	else if (c == 'a')
+		state->opt_allexport = on;
+	else if (c == 'n')
+		state->opt_noexec = on;
+	else if (c == 'v')
+		state->opt_verbose = on;
+}
+
+/* Apply one flag word like "-e", "+e", "-eux". Returns false when the
+   word contains a letter this shell does not implement, so the caller
+   can emit bash's "invalid option" error + status 2 instead of silently
+   swallowing it (a lie about what the shell honours). */
+bool	apply_flag_word(t_shell *state, const char *w)
+{
+	char	sign;
+	int		j;
+
+	sign = w[0];
+	j = 1;
+	while (w[j])
+	{
+		if (!ft_strchr("euxfCanv", w[j]))
+			return (false);
+		set_flag_char(state, w[j], sign == '-');
+		j++;
+	}
+	return (true);
+}
+
+/* Build the value of $- (the flag string): append one letter for each
+   currently-enabled option. The 'i' flag appears when the shell is running
+   interactively (INP_RL), not as a separately toggled option — POSIX says
+   $- must include 'i' for interactive shells. We write into state->flagbuf
+   (a fixed-size field in t_shell) so the returned pointer stays valid until
+   the next call. env_expand("−") calls this to get the current value. */
+char	*build_flagstr(t_shell *state)
+{
+	int	k;
+
+	k = 0;
+	if (state->opt_allexport)
+		state->flagbuf[k++] = 'a';
+	if (state->opt_errexit)
+		state->flagbuf[k++] = 'e';
+	if (state->opt_noglob)
+		state->flagbuf[k++] = 'f';
+	if (state->metinp == INP_RL || state->opt_interactive)
+		state->flagbuf[k++] = 'i';
+	if (state->opt_noexec)
+		state->flagbuf[k++] = 'n';
+	if (state->opt_nounset)
+		state->flagbuf[k++] = 'u';
+	if (state->opt_verbose)
+		state->flagbuf[k++] = 'v';
+	if (state->opt_xtrace)
+		state->flagbuf[k++] = 'x';
+	if (state->opt_noclobber)
+		state->flagbuf[k++] = 'C';
+	state->flagbuf[k] = '\0';
+	return (state->flagbuf);
+}
+
+/* Like pos_build but the strings are BORROWED (pointer copy, no strdup): used
+   for a function call's $1.. which live in the caller's argv for the call's
+   duration. shift/set promote to an owned copy (pos_build) before mutating, so
+   the borrowed strings are never freed by pos_free. */
+void	pos_borrow(t_pos *pos, char **args, size_t n)
+{
+	size_t	i;
+
+	pos->args = ft_calloc(n + 1, sizeof(char *));
+	i = 0;
+	while (pos->args && args && i < n)
+	{
+		pos->args[i] = args[i];
+		i++;
+	}
+	pos->count = (int)n;
+	pos->args_owned = false;
+	pos_set_cnt(pos);
+}

--- a/src/builtins/try_unset.c
+++ b/src/builtins/try_unset.c
@@ -14,13 +14,6 @@
 #include "env.h"
 #include "builtins_private.h"
 
-/* Remove the variable `key` from the env table in-place. We find its slot
-   via pointer arithmetic (e - arr), free the strings, then compact the array
-   by shifting everything after it one position left. This keeps the table a
-   flat contiguous array — no holes — at the cost of O(n) per unset. For the
-   typical number of variables that is fine and much simpler than a linked
-   list. env_index_mark_dirty() invalidates any cached pointer-by-name index
-   so the next lookup does a fresh linear scan. */
 /* unset arr[i]: evaluate the subscript, rebuild the value without that
    record. The variable itself survives (possibly as an empty array). */
 static bool	unset_array_elem(t_shell *state, char *key, char *br)
@@ -49,23 +42,19 @@ static bool	unset_array_elem(t_shell *state, char *key, char *br)
 	return (true);
 }
 
-void	try_unset(t_shell *state, char *key)
+/* Remove the entry `e` from the env table in-place. We find its slot
+   via pointer arithmetic (e - arr), free the strings, then compact the array
+   by shifting everything after it one position left. This keeps the table a
+   flat contiguous array — no holes — at the cost of O(n) per unset. For the
+   typical number of variables that is fine and much simpler than a linked
+   list. env_index_mark_dirty() invalidates any cached pointer-by-name index
+   so the next lookup does a fresh linear scan. */
+static void	env_drop_entry(t_shell *state, t_env *e)
 {
-	t_env	*e;
-	size_t	idx;
 	t_env	*arr;
+	size_t	idx;
 	size_t	i;
-	char	*br;
 
-	if (!state || state->env.ctx == NULL)
-		return ;
-	br = ft_strchr(key, '[');
-	if (br && key[ft_strlen(key) - 1] == ']'
-		&& unset_array_elem(state, key, br))
-		return ;
-	e = env_get(&state->env, key);
-	if (!e)
-		return ;
 	arr = (t_env *)state->env.ctx;
 	idx = (size_t)(e - arr);
 	xfree(arr[idx].key);
@@ -78,4 +67,21 @@ void	try_unset(t_shell *state, char *key)
 	}
 	state->env.len--;
 	env_index_mark_dirty();
+}
+
+void	try_unset(t_shell *state, char *key)
+{
+	t_env	*e;
+	char	*br;
+
+	if (!state || state->env.ctx == NULL)
+		return ;
+	br = ft_strchr(key, '[');
+	if (br && key[ft_strlen(key) - 1] == ']'
+		&& unset_array_elem(state, key, br))
+		return ;
+	e = env_get(&state->env, key);
+	if (!e)
+		return ;
+	env_drop_entry(state, e);
 }

--- a/src/core/on.c
+++ b/src/core/on.c
@@ -23,11 +23,23 @@
 
 static char	*shell_basename(char *arg0);
 
-/* --help: dump the flag reference, free everything, and exit cleanly.
-   Calling free_all_state first means valgrind/ASan stay quiet even when
-   --help is the only thing the user asked for. */
-static void	print_opts(char **argv, t_shell *state)
+/* The two invocations that never reach the REPL, checked in the order the
+   old inline pair used: --help wins and dumps the flag reference, exit 0;
+   otherwise an unrecognised option (e.g. `hellish -z`, `hellish -c -q`)
+   aborts startup with usage status 2 like bash and dash, naming the shell
+   by argv[0]'s basename. Both paths free_all_state first so valgrind/ASan
+   stay quiet; state is still mostly zero here, which free_all_state
+   tolerates. */
+static void	cli_early_exit(t_shell *state, char **argv, t_cli *cli)
 {
+	if (!(state->option_flags & OPT_FLAG_HELP))
+	{
+		if (!cli->err)
+			return ;
+		ft_eprintf("%s: invalid option\n", shell_basename(argv[0]));
+		free_all_state(state);
+		exit(2);
+	}
 	ft_printf("Usage: %s [options] [file]\n", argv[0]);
 	ft_printf("  --help           Show this help\n");
 	ft_printf("  -c <script>      Execute script string\n");
@@ -38,17 +50,6 @@ static void	print_opts(char **argv, t_shell *state)
 	ft_printf("  --debug=ast      Debug AST only\n");
 	free_all_state(state);
 	exit(0);
-}
-
-/* An unrecognised invocation option (e.g. `hellish -z`, `hellish -c -q`):
-   bash and dash both abort startup with usage status 2.  argv[0]'s basename
-   names the shell in the diagnostic; state is still mostly zero here, which
-   free_all_state tolerates. */
-static void	cli_usage_error(t_shell *state, char **argv)
-{
-	ft_eprintf("%s: invalid option\n", shell_basename(argv[0]));
-	free_all_state(state);
-	exit(2);
 }
 
 /* Zero-initialise every table that survives across commands: redirect list,
@@ -81,6 +82,17 @@ static char	*shell_basename(char *arg0)
 	return (arg0);
 }
 
+/* Readline-buffer defaults that are non-zero, so shell_init()'s zeroing
+   cannot provide them (the on.c contract): a byte-granular input buffer
+   and edit_mode 1, the emacs keymap. */
+static void	init_rl_buffer(t_shell *state)
+{
+	buff_readline_init(&state->rl);
+	vec_init(&state->rl.buff);
+	state->rl.buff.elem_size = 1;
+	state->rl.edit_mode = 1;
+}
+
 /* Bootstrap the whole shell. Order matters: signals first (Ctrl-C must be
    safe the moment we start reading), then env (commands may read it during
    init), then tables (used by init_history / mode_input), then the input
@@ -96,14 +108,8 @@ void	on(t_shell *state, char **argv, char **envp)
 	*state = shell_init();
 	state->shopt = SHOPT_CHECKWINSIZE;
 	cli_parse(state, argv, &cli);
-	if (state->option_flags & OPT_FLAG_HELP)
-		print_opts(argv, state);
-	if (cli.err)
-		cli_usage_error(state, argv);
-	buff_readline_init(&state->rl);
-	vec_init(&state->rl.buff);
-	state->rl.buff.elem_size = 1;
-	state->rl.edit_mode = 1;
+	cli_early_exit(state, argv, &cli);
+	init_rl_buffer(state);
 	state->pid = ft_itoa((int)getpid());
 	state->ctx = ft_strdup(shell_basename(argv[0]));
 	state->dft_ctx = ft_strdup(shell_basename(argv[0]));

--- a/src/core/opt2.c
+++ b/src/core/opt2.c
@@ -38,7 +38,7 @@ void	cli_apply_short(t_shell *state, char sign, char c)
    `-o bogus` fails like bash instead of being silently swallowed. */
 int	cli_apply_long(t_shell *state, char sign, const char *name)
 {
-	static const char	*const	ok[] = {"errexit", "nounset", "xtrace",
+	static const char *const	ok[] = {"errexit", "nounset", "xtrace",
 		"noglob", "noclobber", "allexport", "noexec", "verbose", "pipefail",
 		"vi", "emacs", NULL};
 	int							i;

--- a/src/core/shell.c
+++ b/src/core/shell.c
@@ -90,21 +90,20 @@ int	main(int argc, char **argv, char **envp)
 	off(&state);
 }
 
-/* The read-eval-print loop -- the beating heart of the shell. Each turn hands
-   out a fresh input buffer, clears the "Ctrl-C just unwound us" flag, reports
-   any background jobs that finished, then parses and runs exactly one command.
-   The pile of frees at the bottom is the whole trick to staying leak-flat: the
-   AST, redirects, input and heredoc scratch are per-command, so we drop them
-   each turn. A script can run for an hour and memory just stays flat. */
-/* PROMPT_COMMAND: run its value in the current shell right before each
-   interactive primary prompt (bash behaviour). Non-interactive shells
-   never touch it. The last command's status is preserved so the prompt's
-   $? badge reflects the user's command, not PROMPT_COMMAND's. */
-static void	run_prompt_command(t_shell *state)
+/* Open one REPL turn: hand out a fresh input buffer and clear the "Ctrl-C
+   just unwound us" flag, then run $PROMPT_COMMAND in the current shell
+   right before each interactive primary prompt (bash behaviour).
+   Non-interactive shells never touch it. The last command's status is
+   preserved so the prompt's $? badge reflects the user's command, not
+   PROMPT_COMMAND's. */
+static void	open_cycle(t_shell *state)
 {
 	t_execution_state	saved;
 	char				*pc;
 
+	vec_init(&state->input);
+	state->input.elem_size = 1;
+	get_g_sig()->should_unwind = 0;
 	if (state->metinp != INP_RL)
 		return ;
 	pc = env_expand(state, "PROMPT_COMMAND");
@@ -115,6 +114,12 @@ static void	run_prompt_command(t_shell *state)
 	set_cmd_status(state, saved);
 }
 
+/* The read-eval-print loop -- the beating heart of the shell. Each turn hands
+   out a fresh input buffer, clears the "Ctrl-C just unwound us" flag, reports
+   any background jobs that finished, then parses and runs exactly one command.
+   The pile of frees at the bottom is the whole trick to staying leak-flat: the
+   AST, redirects, input and heredoc scratch are per-command, so we drop them
+   each turn. A script can run for an hour and memory just stays flat. */
 static void	repl_shell(t_shell *state)
 {
 	int	buf_fd;
@@ -123,10 +128,7 @@ static void	repl_shell(t_shell *state)
 	buf_fd = setup_output_buffer(state, &stdout_bak);
 	while (!state->should_exit)
 	{
-		vec_init(&state->input);
-		state->input.elem_size = 1;
-		get_g_sig()->should_unwind = 0;
-		run_prompt_command(state);
+		open_cycle(state);
 		job_notify(state);
 		parse_and_execute_input(state);
 		run_pending_traps(state);

--- a/src/environment/env_assoc.c
+++ b/src/environment/env_assoc.c
@@ -6,7 +6,7 @@
 /*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/07/21 00:00:00 by dlesieur          #+#    #+#             */
-/*   Updated: 2026/07/21 00:00:00 by dlesieur         ###   ########.fr       */
+/*   Updated: 2026/07/28 00:00:00 by dlesieur         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,55 +17,55 @@
    joined by RS, prefixed with ARR_ASSOC_MAGIC; keys are arbitrary strings
    (kept in insertion order, no numeric semantics). */
 
-static char	*assoc_join(const char *val, char sep, int want_keys);
-
 bool	assoc_is(const char *val)
 {
 	return (val != NULL && val[0] == ARR_ASSOC_MAGIC);
 }
 
-/* Record iterator: *cur starts at val+1. Yields key slice and value
-   slice; false at end. */
-bool	assoc_next(const char **cur, const char **k, int *kl,
-			const char **v, int *vl)
+/* Prime an iterator on any value: a non-assoc value yields an empty
+   iteration rather than a crash, so callers need no pre-check. */
+void	assoc_it_init(t_assoc_it *it, const char *val)
+{
+	it->cur = "";
+	if (assoc_is(val))
+		it->cur = val + 1;
+}
+
+/* Record iterator: fills the key slice (k/kl) and value slice (v/vl);
+   false at end. */
+bool	assoc_next(t_assoc_it *it)
 {
 	const char	*p;
 
-	p = *cur;
+	p = it->cur;
 	if (!p || !*p)
 		return (false);
-	*k = p;
-	*kl = 0;
-	while (p[*kl] && p[*kl] != ARR_US)
-		(*kl)++;
-	p += *kl;
+	it->k = p;
+	it->kl = 0;
+	while (p[it->kl] && p[it->kl] != ARR_US)
+		it->kl++;
+	p += it->kl;
 	if (*p == ARR_US)
 		p++;
-	*v = p;
-	*vl = 0;
-	while (p[*vl] && p[*vl] != ARR_RS)
-		(*vl)++;
-	p += *vl;
+	it->v = p;
+	it->vl = 0;
+	while (p[it->vl] && p[it->vl] != ARR_RS)
+		it->vl++;
+	p += it->vl;
 	if (*p == ARR_RS)
 		p++;
-	*cur = p;
+	it->cur = p;
 	return (true);
 }
 
 int	assoc_count(const char *val)
 {
-	const char	*cur;
-	const char	*k;
-	const char	*v;
-	int			kl;
-	int			vl;
+	t_assoc_it	it;
 	int			n;
 
-	if (!assoc_is(val))
-		return (0);
-	cur = val + 1;
+	assoc_it_init(&it, val);
 	n = 0;
-	while (assoc_next(&cur, &k, &kl, &v, &vl))
+	while (assoc_next(&it))
 		n++;
 	return (n);
 }
@@ -73,56 +73,13 @@ int	assoc_count(const char *val)
 /* Heap copy of the value stored under `key` (klen bytes), or NULL. */
 char	*assoc_get(const char *val, const char *key, int klen)
 {
-	const char	*cur;
-	const char	*k;
-	const char	*v;
-	int			kl;
-	int			vl;
+	t_assoc_it	it;
 
-	if (!assoc_is(val))
-		return (NULL);
-	cur = val + 1;
-	while (assoc_next(&cur, &k, &kl, &v, &vl))
+	assoc_it_init(&it, val);
+	while (assoc_next(&it))
 	{
-		if (kl == klen && ft_strncmp(k, key, klen) == 0)
-			return (ft_strndup(v, vl));
+		if (it.kl == klen && ft_strncmp(it.k, key, klen) == 0)
+			return (ft_strndup(it.v, it.vl));
 	}
 	return (NULL);
-}
-
-/* Space-joined keys (${!h[@]}) or values (${h[@]}, sep=' '). */
-static char	*assoc_join(const char *val, char sep, int want_keys)
-{
-	t_string	out;
-	const char	*cur;
-	const char	*k;
-	const char	*v;
-	int			kl;
-	int			vl;
-
-	vec_init(&out);
-	out.elem_size = 1;
-	cur = "";
-	if (assoc_is(val))
-		cur = val + 1;
-	while (assoc_next(&cur, &k, &kl, &v, &vl))
-	{
-		if (out.len && sep)
-			vec_push_char(&out, sep);
-		if (want_keys)
-			vec_push_nstr(&out, (char *)k, kl);
-		else
-			vec_push_nstr(&out, (char *)v, vl);
-	}
-	return (vec_push_char(&out, '\0'), (char *)out.ctx);
-}
-
-char	*assoc_keys(const char *val)
-{
-	return (assoc_join(val, ' ', 1));
-}
-
-char	*assoc_values(const char *val, char sep)
-{
-	return (assoc_join(val, sep, 0));
 }

--- a/src/environment/env_assoc2.c
+++ b/src/environment/env_assoc2.c
@@ -6,7 +6,7 @@
 /*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/07/21 00:00:00 by dlesieur          #+#    #+#             */
-/*   Updated: 2026/07/21 00:00:00 by dlesieur         ###   ########.fr       */
+/*   Updated: 2026/07/28 00:00:00 by dlesieur         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,17 +17,16 @@
    fresh encoded value; insertion order is preserved (an existing key is
    updated in place, a new key is appended). */
 
-/* Append one "key<US>value" record. */
-static void	arec_append(t_string *out, const char *k, int kl,
-				const char *v, int vl)
+/* Append one "key<US>value" record taken from an iterator slice. */
+static void	arec_append(t_string *out, const t_assoc_it *r)
 {
 	if (out->len > 1)
 		vec_push_char(out, ARR_RS);
-	if (k && kl > 0)
-		vec_push_nstr(out, (char *)k, kl);
+	if (r->k && r->kl > 0)
+		vec_push_nstr(out, (char *)r->k, r->kl);
 	vec_push_char(out, ARR_US);
-	if (v && vl > 0)
-		vec_push_nstr(out, (char *)v, vl);
+	if (r->v && r->vl > 0)
+		vec_push_nstr(out, (char *)r->v, r->vl);
 }
 
 /* New value = `old` with `key` set to `nv`. If the key exists its value
@@ -36,30 +35,26 @@ char	*assoc_with_set(const char *old, const char *key, int klen,
 			const char *nv)
 {
 	t_string	out;
-	const char	*cur;
-	const char	*k;
-	const char	*v;
-	int			kl;
-	int			vl;
+	t_assoc_it	it;
+	t_assoc_it	rec;
 	bool		done;
 
 	vec_init(&out);
 	out.elem_size = 1;
 	vec_push_char(&out, ARR_ASSOC_MAGIC);
-	cur = "";
-	if (assoc_is(old))
-		cur = old + 1;
+	rec = (t_assoc_it){.k = key, .kl = klen,
+		.v = nv, .vl = (int)ft_strlen(nv)};
+	assoc_it_init(&it, old);
 	done = false;
-	while (assoc_next(&cur, &k, &kl, &v, &vl))
+	while (assoc_next(&it))
 	{
-		if (kl == klen && ft_strncmp(k, key, klen) == 0)
-			(arec_append(&out, key, klen, nv, (int)ft_strlen(nv)),
-				done = true);
+		if (it.kl == klen && ft_strncmp(it.k, key, klen) == 0)
+			(arec_append(&out, &rec), done = true);
 		else
-			arec_append(&out, k, kl, v, vl);
+			arec_append(&out, &it);
 	}
 	if (!done)
-		arec_append(&out, key, klen, nv, (int)ft_strlen(nv));
+		arec_append(&out, &rec);
 	return (vec_push_char(&out, '\0'), (char *)out.ctx);
 }
 
@@ -67,22 +62,16 @@ char	*assoc_with_set(const char *old, const char *key, int klen,
 char	*assoc_without(const char *old, const char *key, int klen)
 {
 	t_string	out;
-	const char	*cur;
-	const char	*k;
-	const char	*v;
-	int			kl;
-	int			vl;
+	t_assoc_it	it;
 
 	vec_init(&out);
 	out.elem_size = 1;
 	vec_push_char(&out, ARR_ASSOC_MAGIC);
-	cur = "";
-	if (assoc_is(old))
-		cur = old + 1;
-	while (assoc_next(&cur, &k, &kl, &v, &vl))
+	assoc_it_init(&it, old);
+	while (assoc_next(&it))
 	{
-		if (!(kl == klen && ft_strncmp(k, key, klen) == 0))
-			arec_append(&out, k, kl, v, vl);
+		if (!(it.kl == klen && ft_strncmp(it.k, key, klen) == 0))
+			arec_append(&out, &it);
 	}
 	return (vec_push_char(&out, '\0'), (char *)out.ctx);
 }
@@ -93,24 +82,20 @@ char	*assoc_without(const char *old, const char *key, int klen)
 char	*assoc_format(const char *val)
 {
 	t_string	out;
-	const char	*cur;
-	const char	*k;
-	const char	*v;
-	int			kl;
-	int			vl;
+	t_assoc_it	it;
 
 	vec_init(&out);
 	out.elem_size = 1;
 	vec_push_char(&out, '(');
-	cur = val + 1;
-	while (assoc_next(&cur, &k, &kl, &v, &vl))
+	assoc_it_init(&it, val);
+	while (assoc_next(&it))
 	{
 		if (out.len > 1)
 			vec_push_char(&out, ' ');
 		vec_push_char(&out, '[');
-		vec_push_nstr(&out, (char *)k, kl);
+		vec_push_nstr(&out, (char *)it.k, it.kl);
 		vec_push_str(&out, "]=\"");
-		vec_push_nstr(&out, (char *)v, vl);
+		vec_push_nstr(&out, (char *)it.v, it.vl);
 		vec_push_char(&out, '"');
 	}
 	if (out.len > 1)

--- a/src/environment/env_assoc3.c
+++ b/src/environment/env_assoc3.c
@@ -1,0 +1,48 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env_assoc3.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/07/28 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/07/28 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "env.h"
+#include "shell.h"
+
+/* Whole-array views of an associative value (split out of env_assoc.c
+   for the 42-norm five-function file limit). */
+
+/* Space-joined keys (${!h[@]}) or values (${h[@]}, sep=' '). */
+static char	*assoc_join(const char *val, char sep, int want_keys)
+{
+	t_string	out;
+	t_assoc_it	it;
+
+	vec_init(&out);
+	out.elem_size = 1;
+	assoc_it_init(&it, val);
+	while (assoc_next(&it))
+	{
+		if (out.len && sep)
+			vec_push_char(&out, sep);
+		if (want_keys)
+			vec_push_nstr(&out, (char *)it.k, it.kl);
+		else
+			vec_push_nstr(&out, (char *)it.v, it.vl);
+	}
+	return (vec_push_char(&out, '\0'), (char *)out.ctx);
+}
+
+char	*assoc_keys(const char *val)
+{
+	return (assoc_join(val, ' ', 1));
+}
+
+char	*assoc_values(const char *val, char sep)
+{
+	return (assoc_join(val, sep, 0));
+}

--- a/src/environment/env_attr.c
+++ b/src/environment/env_attr.c
@@ -56,6 +56,15 @@ char	*attr_target(t_shell *state, const char *name, int nlen)
 	return (NULL);
 }
 
+/* Duplicate the optional nameref target: NULL stays NULL so plain -i
+   entries carry no target allocation. */
+static char	*dup_or_null(const char *target)
+{
+	if (target)
+		return (ft_strdup(target));
+	return (NULL);
+}
+
 /* Set (or replace) the attribute of `name`. */
 void	attr_set(t_shell *state, const char *name, char kind,
 			const char *target)
@@ -77,13 +86,13 @@ void	attr_set(t_shell *state, const char *name, char kind,
 		{
 			e->kind = kind;
 			xfree(e->target);
-			e->target = (target ? ft_strdup(target) : NULL);
+			e->target = dup_or_null(target);
 			return ;
 		}
 	}
 	a.name = ft_strdup(name);
 	a.kind = kind;
-	a.target = (target ? ft_strdup(target) : NULL);
+	a.target = dup_or_null(target);
 	vec_push(&state->var_attrs, &a);
 }
 

--- a/src/environment/expand2.c
+++ b/src/environment/expand2.c
@@ -25,7 +25,7 @@ bool	is_readonly_var(t_shell *state, const char *key);
 void	exit_clean(t_shell *state, int code);
 char	*lineno_str(t_shell *state);
 
-int	tok_lineno(t_shell *state);
+int		tok_lineno(t_shell *state);
 
 /* Dynamic special variables computed at expansion time, second tier of
    expand_special: $LINENO, plus the bash-isms $RANDOM (0..32767 from the

--- a/src/environment/helpers.c
+++ b/src/environment/helpers.c
@@ -20,6 +20,7 @@
 #include "env.h"
 #include "libft.h"
 #include "sys.h"
+#include <pwd.h>
 
 /* Seed state->cwd from getcwd().  If the syscall fails (deleted dir,
    permissions) we emit a warning and leave cwd empty rather than crash.
@@ -52,6 +53,24 @@ void	set_cwd(t_shell *state)
 	else
 		ft_eprintf(MSG_GETCWD_SHINIT);
 	xfree(cwd);
+}
+
+/* bash synthesises $SHELL from the user's passwd login shell when the
+   parent left it entirely ABSENT (an inherited empty SHELL= stays
+   empty), and keeps it un-exported — children only see it once the user
+   exports it themselves. Docker containers and scrubbed CI runners hit
+   this path; interactive sessions normally inherit the real value. */
+void	set_shell_var(t_shell *state)
+{
+	struct passwd	*pw;
+
+	if (env_get(&state->env, "SHELL"))
+		return ;
+	pw = getpwuid(getuid());
+	if (!pw || !pw->pw_shell || !pw->pw_shell[0])
+		return ;
+	env_set(&state->env, env_create(ft_strdup("SHELL"),
+			ft_strdup(pw->pw_shell), false));
 }
 
 /* Increment SHLVL (capped via ft_checked_atoi's flags=42 to avoid huge

--- a/src/environment/init_dft_env.c
+++ b/src/environment/init_dft_env.c
@@ -110,6 +110,7 @@ void	ensure_essential_env_vars(t_shell *state)
 	cwd = NULL;
 	set_path(state);
 	set_shlvl(state);
+	set_shell_var(state);
 	set_underscore(state);
 	set_optind(state);
 	set_id_vars(state);

--- a/src/execution/exe_bg.c
+++ b/src/execution/exe_bg.c
@@ -56,7 +56,7 @@ t_execution_state	execute_cmd_bg(t_shell *state,
 		default_signal_handlers();
 		set_up_redirection(state, exe);
 		env_extend(&state->env, &cmd->pre_assigns, true);
-		exit(actually_run(state, &cmd->argv));
+		_exit(actually_run(state, &cmd->argv));
 	}
 	procsub_close_fds_parent(state);
 	free_executable_cmd(state, *cmd);

--- a/src/execution/exec_string.c
+++ b/src/execution/exec_string.c
@@ -93,12 +93,34 @@ static int	exec_string_inner(t_shell *state, char *str)
 	return (status);
 }
 
-/* Extract heredoc bodies up front (so they aren't parsed as commands) and feed
-   them to the heredoc reader via state->hd_src. hd_src is saved/restored so
-   nested command substitutions each get their own body stream. */
-int	exec_string(t_shell *state, char *str)
+/* Extract heredoc bodies up front (so they aren't parsed as commands),
+   feed them to the heredoc reader via state->hd_src, and run the stripped
+   text.  A string without << (or where splitting finds nothing) runs
+   as-is, under whatever hd_src the caller already installed. */
+static int	exec_split_heredocs(t_shell *state, char *str, char **bodies)
 {
 	char	*stripped;
+	int		status;
+
+	stripped = NULL;
+	if (ft_strnstr(str, "<<", ft_strlen(str))
+		&& split_heredocs(str, &stripped, bodies))
+	{
+		state->hd_src = *bodies;
+		state->hd_pos = 0;
+		status = exec_string_inner(state, stripped);
+		xfree(stripped);
+	}
+	else
+		status = exec_string_inner(state, str);
+	return (status);
+}
+
+/* Alias-expand the line, then execute it, routing any heredoc bodies
+   aside first.  hd_src/hd_pos are saved/restored so nested command
+   substitutions each get their own body stream. */
+int	exec_string(t_shell *state, char *str)
+{
 	char	*bodies;
 	char	*prev_src;
 	size_t	prev_pos;
@@ -106,19 +128,9 @@ int	exec_string(t_shell *state, char *str)
 
 	prev_src = state->hd_src;
 	prev_pos = state->hd_pos;
-	stripped = NULL;
 	bodies = NULL;
 	str = alias_scan_line(&state->aliases, str);
-	if (ft_strnstr(str, "<<", ft_strlen(str))
-		&& split_heredocs(str, &stripped, &bodies))
-	{
-		state->hd_src = bodies;
-		state->hd_pos = 0;
-		status = exec_string_inner(state, stripped);
-		xfree(stripped);
-	}
-	else
-		status = exec_string_inner(state, str);
+	status = exec_split_heredocs(state, str, &bodies);
 	xfree(str);
 	xfree(bodies);
 	state->hd_src = prev_src;

--- a/src/execution/execute_command.c
+++ b/src/execution/execute_command.c
@@ -127,11 +127,6 @@ t_execution_state	execute_command(t_shell *state, t_executable_node *exe)
 	if (ft == AST_COPROC)
 		return (exe->node = &((t_ast_node *)exe->node->children.ctx)[0],
 			execute_coproc(state, exe));
-	if (!exe->redirs.ctx)
-	{
-		vec_init(&exe->redirs);
-		exe->redirs.elem_size = sizeof(int);
-	}
 	if (collect_redirects_from_ast(state, exe))
 		return (res_status(AMBIGUOUS_REDIRECT));
 	exe->node = vec_idx(&exe->node->children, 0);
@@ -147,13 +142,20 @@ t_execution_state	execute_command(t_shell *state, t_executable_node *exe)
    redirect_from_ast_redir and push its index into exe->redirs.  The
    indices rather than the t_redir structs are stored so the redirect
    table lives in one place (state->redirects) and children can share an
-   entry if the same redirect appears twice. */
+   entry if the same redirect appears twice.  The redirs vec is created
+   lazily on first use: an exe inherited from an enclosing command may
+   already carry redirect indices we must append to, never clobber. */
 static int	collect_redirects_from_ast(t_shell *state, t_executable_node *exe)
 {
 	size_t		i;
 	t_ast_node	*curr;
 	int			redir_idx;
 
+	if (!exe->redirs.ctx)
+	{
+		vec_init(&exe->redirs);
+		exe->redirs.elem_size = sizeof(int);
+	}
 	i = 0;
 	while (++i < exe->node->children.len)
 	{

--- a/src/execution/execute_range.c
+++ b/src/execution/execute_range.c
@@ -12,26 +12,8 @@
 
 #include "execution_private.h"
 
-void	exit_clean(t_shell *state, int code);
-
-/* set -e: exit when the AND-OR list's last *executed* command failed. This
-   excludes the left operand of && / || (it isn't the one that ran last, e.g.
-   `false && true` skips true so `false` is non-terminal), a negated pipeline
-   (! ...), and any list run as an if/while/until condition (errexit_off). */
-static void	errexit_check(t_shell *state, t_execution_state st,
-				bool ran, t_ast_node *last)
-{
-	if (state->errexit_off || !ran || st.status == 0)
-		return ;
-	if (last && last->node_type == AST_COMMAND_PIPELINE && last->negate)
-		return ;
-	if (state->should_exit || state->func_return || state->loop_break
-		|| state->loop_continue || get_g_sig()->should_unwind)
-		return ;
-	fire_err_trap(state, st.status);
-	if (state->opt_errexit)
-		exit_clean(state, st.status);
-}
+void	errexit_check(t_shell *state, t_execution_state st, bool ran,
+			t_ast_node *last);
 
 /* Run one pipeline/command node from the sequence, inheriting the
    surrounding exe's fds and redirects (via struct copy).  We immediately
@@ -83,6 +65,17 @@ static void	execute_lhs(t_executable_node *exe, t_ast_node *child,
 	state->errexit_off = saved;
 }
 
+/* An AST_TOKEN child carries the list operator (&&, ||, ;, newline).
+   It executes nothing itself: it only becomes the pending operator that
+   should_execute consults for the next command child. */
+static bool	take_operator(t_ast_node *child, t_tt *op)
+{
+	if (child->node_type != AST_TOKEN)
+		return (false);
+	*op = child->token.tt;
+	return (true);
+}
+
 /* Execute the range of AST children [start, end) as a sequential
    AND-OR list.  AST_TOKEN children carry the operator (&&, ||, ;, etc.)
    and shift the `op` variable that should_execute reads.  Non-token
@@ -106,11 +99,8 @@ t_execution_state	execute_range(t_shell *state, t_executable_node *exe,
 	while (i < end)
 	{
 		child = &((t_ast_node *)exe->node->children.ctx)[i++];
-		if (child->node_type == AST_TOKEN)
-		{
-			op = child->token.tt;
+		if (take_operator(child, &op))
 			continue ;
-		}
 		ran = should_execute(status, op);
 		if (ran && next_is_andor(exe->node, i, end))
 			execute_lhs(exe, child, state, &status);

--- a/src/execution/execute_range2.c
+++ b/src/execution/execute_range2.c
@@ -13,6 +13,8 @@
 #include "execution_private.h"
 #include "ft_builtins.h"
 
+void	exit_clean(t_shell *state, int code);
+
 /* Child body for a background command group (& operator).  We move into
    our own process group (setpgid) so job-control signals from the terminal
    don't reach us.  stdin is redirected from /dev/null (POSIX: background
@@ -100,4 +102,45 @@ t_execution_state	execute_range_background(t_shell *state,
 	else if (state->metinp == INP_RL)
 		ft_printf("[%d] %d\n", state->bg_job_count, pid);
 	return (res_status(0));
+}
+
+/* Decide whether to run the next command based on the operator that
+   separates it from the previous one.  ; and newline always run.  &&
+   short-circuits on failure; || short-circuits on success.  Ctrl-C
+   (ctrl_c=true) stops execution regardless of operator so an interrupted
+   pipeline does not stumble forward into the right-hand side. */
+bool	should_execute(t_execution_state prev_status, t_tt prev_op)
+{
+	if (prev_status.ctrl_c)
+		return (false);
+	ft_assert(prev_status.status != -1);
+	ft_assert(prev_op == TT_SEMICOLON || prev_op == TT_NEWLINE
+		|| prev_op == TT_AND || prev_op == TT_OR || prev_op == TT_AMPERSAND);
+	if (prev_op == TT_SEMICOLON || prev_op == TT_NEWLINE
+		|| prev_op == TT_AMPERSAND)
+		return (true);
+	if (prev_op == TT_AND && prev_status.status == 0)
+		return (true);
+	if (prev_op == TT_OR && prev_status.status != 0)
+		return (true);
+	return (false);
+}
+
+/* set -e: exit when the AND-OR list's last *executed* command failed. This
+   excludes the left operand of && / || (it isn't the one that ran last, e.g.
+   `false && true` skips true so `false` is non-terminal), a negated pipeline
+   (! ...), and any list run as an if/while/until condition (errexit_off). */
+void	errexit_check(t_shell *state, t_execution_state st,
+			bool ran, t_ast_node *last)
+{
+	if (state->errexit_off || !ran || st.status == 0)
+		return ;
+	if (last && last->node_type == AST_COMMAND_PIPELINE && last->negate)
+		return ;
+	if (state->should_exit || state->func_return || state->loop_break
+		|| state->loop_continue || get_g_sig()->should_unwind)
+		return ;
+	fire_err_trap(state, st.status);
+	if (state->opt_errexit)
+		exit_clean(state, st.status);
 }

--- a/src/execution/execute_simple_list.c
+++ b/src/execution/execute_simple_list.c
@@ -32,28 +32,6 @@ void	reap_background_children(t_shell *state)
 	}
 }
 
-/* Decide whether to run the next command based on the operator that
-   separates it from the previous one.  ; and newline always run.  &&
-   short-circuits on failure; || short-circuits on success.  Ctrl-C
-   (ctrl_c=true) stops execution regardless of operator so an interrupted
-   pipeline does not stumble forward into the right-hand side. */
-bool	should_execute(t_execution_state prev_status, t_tt prev_op)
-{
-	if (prev_status.ctrl_c)
-		return (false);
-	ft_assert(prev_status.status != -1);
-	ft_assert(prev_op == TT_SEMICOLON || prev_op == TT_NEWLINE
-		|| prev_op == TT_AND || prev_op == TT_OR || prev_op == TT_AMPERSAND);
-	if (prev_op == TT_SEMICOLON || prev_op == TT_NEWLINE
-		|| prev_op == TT_AMPERSAND)
-		return (true);
-	if (prev_op == TT_AND && prev_status.status == 0)
-		return (true);
-	if (prev_op == TT_OR && prev_status.status != 0)
-		return (true);
-	return (false);
-}
-
 /* Find the next & or ; operator in the children list starting from index i.
    Returns the index of the operator, or children.len if not found.
    Also sets *found_amp to true if & was found before ; */
@@ -103,6 +81,28 @@ static void	gather_range_heredocs(t_shell *state, t_ast_node *node,
 	}
 }
 
+/* One separator-delimited range of the list: find where it ends and
+   whether that separator is &, gather its deferred heredocs just in
+   time, run it as a foreground or background group, then advance *i
+   past the separator token. */
+static t_execution_state	run_list_range(t_shell *state,
+								t_executable_node *exe, size_t *i, bool defer)
+{
+	t_execution_state	status;
+	size_t				sep_idx;
+	bool				is_background;
+
+	sep_idx = find_next_separator(exe->node, *i, &is_background);
+	if (defer)
+		gather_range_heredocs(state, exe->node, *i, sep_idx);
+	if (is_background)
+		status = execute_range_background(state, exe, *i, sep_idx);
+	else
+		status = execute_range(state, exe, *i, sep_idx);
+	*i = sep_idx + 1;
+	return (status);
+}
+
 /* Run an AST_SIMPLE_LIST or AST_COMPOUND_LIST.  These are sequences of
    pipelines separated by ; & newline && ||.  We scan forward from the
    current index to the next separator, execute the range as a foreground
@@ -116,8 +116,6 @@ t_execution_state	execute_simple_list(t_shell *state, t_executable_node *exe)
 {
 	t_execution_state	status;
 	size_t				i;
-	size_t				sep_idx;
-	bool				is_background;
 	bool				defer;
 
 	defer = state->hd_defer;
@@ -127,14 +125,7 @@ t_execution_state	execute_simple_list(t_shell *state, t_executable_node *exe)
 	i = 0;
 	while (i < exe->node->children.len)
 	{
-		sep_idx = find_next_separator(exe->node, i, &is_background);
-		if (defer)
-			gather_range_heredocs(state, exe->node, i, sep_idx);
-		if (is_background)
-			status = execute_range_background(state, exe, i, sep_idx);
-		else
-			status = execute_range(state, exe, i, sep_idx);
-		i = sep_idx + 1;
+		status = run_list_range(state, exe, &i, defer);
 		run_pending_traps(state);
 		if (state->should_exit || state->loop_break || state->loop_continue
 			|| state->func_return || get_g_sig()->should_unwind)

--- a/src/execution/execute_top_level.c
+++ b/src/execution/execute_top_level.c
@@ -13,14 +13,6 @@
 #include "execution_private.h"
 #include <time.h>
 
-/* Entry point called once per parsed statement by the REPL.  It wraps the
-   whole execution lifecycle for one top-level tree: pre-scan heredocs
-   (gather_heredocs fills temp files before any child forks), execute the
-   tree, clean up process-substitution fds, and record the exit status.
-   Ctrl-C while running a script (non-interactive: metinp != INP_RL) sets
-   should_exit so the script aborts rather than just printing a newline.
-   The verbose(CLAP_PRINT) call at the end is the "execution applause"
-   hook -- a hook for debug/test output after each top-level command. */
 /* Monotonic wall clock in milliseconds, for the prompt's "took Ns"
    segment. CLOCK_MONOTONIC so a system clock change mid-command can't
    produce a negative or absurd duration. */
@@ -33,6 +25,39 @@ static long long	now_ms(void)
 	return ((long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
 }
 
+/* Heredoc pre-pass for this cycle: gather_heredocs fills temp files
+   before any child forks.  Top-level lists defer instead (hd_defer):
+   execute_simple_list gathers each ;/&-range just before it runs, so a
+   body like `$(f)` expands after the earlier commands have executed. */
+static void	prepare_heredocs(t_shell *state)
+{
+	state->heredoc_idx = 0;
+	state->hd_defer = state->cycle_has_hd
+		&& (state->tree.node_type == AST_SIMPLE_LIST
+			|| state->tree.node_type == AST_COMPOUND_LIST);
+	if (!get_g_sig()->should_unwind && !state->hd_defer
+		&& state->cycle_has_hd)
+		gather_heredocs(state, &state->tree, false);
+}
+
+/* Ctrl-C interactively just needs the newline the killed foreground
+   command never printed.  While running a script (non-interactive:
+   metinp != INP_RL) it must set should_exit so the script aborts rather
+   than stumbling on to the next command. */
+static void	report_ctrl_c(t_shell *state)
+{
+	if (state->metinp == INP_RL)
+		ft_eprintf("\n");
+	else
+		state->should_exit = true;
+}
+
+/* Entry point called once per parsed statement by the REPL.  It wraps the
+   whole execution lifecycle for one top-level tree: pre-scan heredocs,
+   execute the tree, clean up process-substitution fds, and record the
+   exit status.  The verbose(CLAP_PRINT) call at the end is the
+   "execution applause" hook -- a hook for debug/test output after each
+   top-level command. */
 void	execute_top_level(t_shell *state)
 {
 	t_executable_node	exe;
@@ -43,25 +68,14 @@ void	execute_top_level(t_shell *state)
 	exe = create_exe_node(0, 1, &state->tree, true);
 	vec_init(&exe.redirs);
 	exe.redirs.elem_size = sizeof(int);
-	state->heredoc_idx = 0;
-	state->hd_defer = state->cycle_has_hd
-		&& (state->tree.node_type == AST_SIMPLE_LIST
-			|| state->tree.node_type == AST_COMPOUND_LIST);
-	if (!get_g_sig()->should_unwind && !state->hd_defer
-		&& state->cycle_has_hd)
-		gather_heredocs(state, &state->tree, false);
+	prepare_heredocs(state);
 	if (!get_g_sig()->should_unwind)
 		res = execute_tree_node(state, &exe);
 	else
 		res = res_status(CANCELED);
 	cleanup_proc_subs(state);
 	if (res.ctrl_c)
-	{
-		if (state->metinp == INP_RL)
-			ft_eprintf("\n");
-		else
-			state->should_exit = true;
-	}
+		report_ctrl_c(state);
 	state->last_cmd_st_exe = res;
 	state->last_cmd_ms = now_ms() - t0;
 	verbose(CLAP_PRINT, "");

--- a/src/expander/assignment_to_env.c
+++ b/src/expander/assignment_to_env.c
@@ -15,6 +15,9 @@
 #include "env.h"
 #include "arith.h"
 
+void	apply_var_attrs(t_shell *state, t_env *ret);
+void	scalar_append(t_shell *state, t_env *ret);
+
 /* Copy the assignment LHS (variable name) out of the first child token of
    an AST_ASSIGNMENT_WORD node.  The first child is always a TT_WORD whose
    content is the bare name without the trailing '='. */
@@ -91,96 +94,6 @@ static void	subscript_assign(t_shell *state, t_env *ret)
 	nv = arr_with_set(old, idx, ret->value);
 	xfree(ret->value);
 	ret->value = nv;
-}
-
-/* NAME+=value: the key still carries its trailing '+'. Prepend the
-   variable's current value (string concatenation, bash scalar +=) and
-   drop the '+'. A subscript key (a[i]+=) keeps its brackets for
-   subscript_assign; only the plain-scalar case concatenates here. */
-static void	scalar_append(t_shell *state, t_env *ret)
-{
-	int		klen;
-	char	*old;
-	char	*joined;
-
-	klen = (int)ft_strlen(ret->key);
-	if (klen < 1 || ret->key[klen - 1] != '+' || !ret->value)
-		return ;
-	ret->key[klen - 1] = '\0';
-	if (ft_strchr(ret->key, '['))
-		return ;
-	old = env_expand(state, ret->key);
-	if (!old)
-		old = "";
-	joined = ft_strjoin(old, ret->value);
-	xfree(ret->value);
-	ret->value = joined;
-}
-
-/* Bare variable name in a key that may carry a trailing '+' (append) or
-   a '[sub]' element: everything up to the first of those. */
-static int	bare_name_len(const char *key)
-{
-	int	i;
-
-	i = 0;
-	while (key[i] && key[i] != '[' && key[i] != '+' && key[i] != '=')
-		i++;
-	return (i);
-}
-
-/* Integer attribute: replace the value with the arithmetic evaluation of
-   the RHS (n="3*4" -> "12"). For += the new value is old+rhs. */
-static void	apply_int_attr(t_shell *state, t_env *ret, int append)
-{
-	t_string	expr;
-	char		*old;
-	char		*res;
-
-	vec_init(&expr);
-	expr.elem_size = 1;
-	old = env_expand(state, ret->key);
-	if (append && old && *old)
-	{
-		vec_push_str(&expr, old);
-		vec_push_char(&expr, '+');
-	}
-	vec_push_str(&expr, ret->value);
-	vec_push_char(&expr, '\0');
-	res = arith_expand(state, (char *)expr.ctx, (int)expr.len - 1);
-	xfree(expr.ctx);
-	xfree(ret->value);
-	ret->value = (res ? res : ft_strdup("0"));
-}
-
-/* Resolve declare -n / -i attributes on a scalar assignment. A nameref
-   retargets the write to its target name (re-checked for int-ness);
-   an integer attribute arithmetic-evaluates the RHS. Array-element and
-   append+nameref combos fall through unchanged (v1). */
-static void	apply_var_attrs(t_shell *state, t_env *ret)
-{
-	int		nl;
-	int		append;
-	char	*tgt;
-	char	*suffix;
-
-	nl = bare_name_len(ret->key);
-	tgt = attr_target(state, ret->key, nl);
-	if (tgt && *tgt)
-	{
-		suffix = ft_strdup(ret->key + nl);
-		xfree(ret->key);
-		ret->key = ft_strjoin(tgt, suffix);
-		xfree(suffix);
-		nl = bare_name_len(ret->key);
-	}
-	if (attr_kind(state, ret->key, nl) != 'i' || ret->key[nl] == '[')
-		return ;
-	append = (ret->key[nl] == '+');
-	if (append)
-		ret->key[nl] = '\0';
-	if (ret->value)
-		apply_int_attr(state, ret, append);
 }
 
 /* Convert a VAR=value AST node into a t_env ready to be pushed into the

--- a/src/expander/assignment_to_env2.c
+++ b/src/expander/assignment_to_env2.c
@@ -1,0 +1,114 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   assignment_to_env2.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/01/22 19:08:32 by marvin            #+#    #+#             */
+/*   Updated: 2026/01/22 19:08:32 by marvin           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+/* Continuation of assignment_to_env.c: the pre-store rewrites that a
+   scalar assignment goes through before the t_env is committed — the +=
+   append form (scalar_append) and the declare -n / -i attribute
+   resolution (apply_var_attrs). */
+
+#include "expander_private.h"
+#include "sys.h"
+#include "env.h"
+#include "arith.h"
+
+/* NAME+=value: the key still carries its trailing '+'. Prepend the
+   variable's current value (string concatenation, bash scalar +=) and
+   drop the '+'. A subscript key (a[i]+=) keeps its brackets for
+   subscript_assign; only the plain-scalar case concatenates here. */
+void	scalar_append(t_shell *state, t_env *ret)
+{
+	int		klen;
+	char	*old;
+	char	*joined;
+
+	klen = (int)ft_strlen(ret->key);
+	if (klen < 1 || ret->key[klen - 1] != '+' || !ret->value)
+		return ;
+	ret->key[klen - 1] = '\0';
+	if (ft_strchr(ret->key, '['))
+		return ;
+	old = env_expand(state, ret->key);
+	if (!old)
+		old = "";
+	joined = ft_strjoin(old, ret->value);
+	xfree(ret->value);
+	ret->value = joined;
+}
+
+/* Bare variable name in a key that may carry a trailing '+' (append) or
+   a '[sub]' element: everything up to the first of those. */
+static int	bare_name_len(const char *key)
+{
+	int	i;
+
+	i = 0;
+	while (key[i] && key[i] != '[' && key[i] != '+' && key[i] != '=')
+		i++;
+	return (i);
+}
+
+/* Integer attribute: replace the value with the arithmetic evaluation of
+   the RHS (n="3*4" -> "12"). For += the new value is old+rhs. */
+static void	apply_int_attr(t_shell *state, t_env *ret, int append)
+{
+	t_string	expr;
+	char		*old;
+	char		*res;
+
+	vec_init(&expr);
+	expr.elem_size = 1;
+	old = env_expand(state, ret->key);
+	if (append && old && *old)
+	{
+		vec_push_str(&expr, old);
+		vec_push_char(&expr, '+');
+	}
+	vec_push_str(&expr, ret->value);
+	vec_push_char(&expr, '\0');
+	res = arith_expand(state, (char *)expr.ctx, (int)expr.len - 1);
+	xfree(expr.ctx);
+	xfree(ret->value);
+	if (res)
+		ret->value = res;
+	else
+		ret->value = ft_strdup("0");
+}
+
+/* Resolve declare -n / -i attributes on a scalar assignment. A nameref
+   retargets the write to its target name (re-checked for int-ness);
+   an integer attribute arithmetic-evaluates the RHS. Array-element and
+   append+nameref combos fall through unchanged (v1). */
+void	apply_var_attrs(t_shell *state, t_env *ret)
+{
+	int		nl;
+	int		append;
+	char	*tgt;
+	char	*suffix;
+
+	nl = bare_name_len(ret->key);
+	tgt = attr_target(state, ret->key, nl);
+	if (tgt && *tgt)
+	{
+		suffix = ft_strdup(ret->key + nl);
+		xfree(ret->key);
+		ret->key = ft_strjoin(tgt, suffix);
+		xfree(suffix);
+		nl = bare_name_len(ret->key);
+	}
+	if (attr_kind(state, ret->key, nl) != 'i' || ret->key[nl] == '[')
+		return ;
+	append = (ret->key[nl] == '+');
+	if (append)
+		ret->key[nl] = '\0';
+	if (ret->value)
+		apply_int_attr(state, ret, append);
+}

--- a/src/expander/cmdsub_inplace.c
+++ b/src/expander/cmdsub_inplace.c
@@ -53,21 +53,13 @@ static bool	cs_word_opaque(t_shell *state, const char *s, int len)
    spans and nested $( ) / ${ } are skipped wholesale, and $(( )) rejects.
    Aliases reject outright: exec_string splices them AFTER this scan, so
    `alias f='a; b'` could otherwise smuggle a second command past us. */
-bool	cs_single_cmd(t_shell *state, const char *s)
-{
-	int	i;
-	int	w;
 
-	if (!alias_table_empty(&state->aliases))
-		return (false);
-	i = 0;
-	while (s[i] == ' ' || s[i] == '\t')
-		i++;
-	w = i;
-	while (s[w] && !ft_strchr(" \t", s[w]))
-		w++;
-	if (cs_word_opaque(state, s + i, w - i))
-		return (false);
+/* The byte walk itself, from position i: false the moment any byte could
+   start a second command; quoted spans and nested $( ) / ${ } are skipped
+   wholesale (a skip helper answers -1 on an unterminated span, which the
+   i >= 0 guard turns into a reject). */
+static bool	cs_scan_rest(const char *s, int i)
+{
 	while (i >= 0 && s[i])
 	{
 		if (s[i] == '\'' || s[i] == '"')
@@ -84,4 +76,22 @@ bool	cs_single_cmd(t_shell *state, const char *s)
 			i++;
 	}
 	return (i >= 0);
+}
+
+bool	cs_single_cmd(t_shell *state, const char *s)
+{
+	int	i;
+	int	w;
+
+	if (!alias_table_empty(&state->aliases))
+		return (false);
+	i = 0;
+	while (s[i] == ' ' || s[i] == '\t')
+		i++;
+	w = i;
+	while (s[w] && !ft_strchr(" \t", s[w]))
+		w++;
+	if (cs_word_opaque(state, s + i, w - i))
+		return (false);
+	return (cs_scan_rest(s, i));
 }

--- a/src/expander/expand_array.c
+++ b/src/expander/expand_array.c
@@ -117,16 +117,7 @@ static void	arr_element(t_shell *state, t_token *tt, char *val, int nl)
 		elem = arr_get_idx(val, idx);
 	else if (val && idx == 0)
 		elem = ft_strdup(val);
-	if (elem)
-	{
-		tt->start = elem;
-		tt->len = (int)ft_strlen(elem);
-		tt->allocated = true;
-		return ((void)parena_note_attach());
-	}
-	tt->start = "";
-	tt->len = 0;
-	tt->allocated = false;
+	arr_elem_emit(tt, elem);
 }
 
 /* Entry, tried before the ${p-w} operator family: recognise NAME[...]

--- a/src/expander/expand_array3.c
+++ b/src/expander/expand_array3.c
@@ -33,16 +33,29 @@ static bool	arr_emit(t_token *tt, char *owned)
 	return (parena_note_attach(), true);
 }
 
+/* Space-join the indices of an encoded indexed array into `out`. */
+static void	arr_keys_join(const char *val, t_string *out)
+{
+	const char	*cur;
+	const char	*v;
+	long		idx;
+	int			vl;
+
+	cur = val + 1;
+	while (arr_next(&cur, &idx, &v, &vl))
+	{
+		if (out->len)
+			vec_push_char(out, ' ');
+		vec_push_str(out, (char *)(idx_str(idx)));
+	}
+}
+
 /* ${!name[@]} / ${!name[*]}: space-joined index list of the array (or
    "0" for a set scalar, nothing for unset — bash semantics). */
 bool	arr_keys(t_shell *state, t_token *tt, bool split_ctx)
 {
 	t_string	out;
 	char		*val;
-	const char	*cur;
-	const char	*v;
-	long		idx;
-	int			vl;
 
 	if (split_ctx)
 		return (arr_keys_defer(state, tt));
@@ -58,15 +71,7 @@ bool	arr_keys(t_shell *state, t_token *tt, bool split_ctx)
 	if (val && !arr_is(val))
 		vec_push_str(&out, "0");
 	else if (val)
-	{
-		cur = val + 1;
-		while (arr_next(&cur, &idx, &v, &vl))
-		{
-			if (out.len)
-				vec_push_char(&out, ' ');
-			vec_push_str(&out, (char *)(idx_str(idx)));
-		}
-	}
+		arr_keys_join(val, &out);
 	vec_push_char(&out, '\0');
 	return (arr_emit(tt, (char *)out.ctx));
 }

--- a/src/expander/expand_array4.c
+++ b/src/expander/expand_array4.c
@@ -79,31 +79,32 @@ int	slice_name_len(const char *s, int len, int *colon)
 	return (i);
 }
 
-/* Build the space-joined element slice from the resolved context. */
+/* Build the space-joined element slice from the resolved context.
+   nth[0] is the element counter, nth[1] the element length out-param
+   (the split_array.c pairing, to stay under the norm's five locals). */
 char	*arr_slice_build(t_slice_ctx *c)
 {
 	t_string	out;
 	const char	*cur;
 	const char	*v;
 	long		idx;
-	int			vl;
-	int			k;
+	int			nth[2];
 
 	vec_init(&out);
 	out.elem_size = 1;
-	k = 0;
+	nth[0] = 0;
 	cur = "";
 	if (arr_is(c->val))
 		cur = c->val + 1;
-	while (arr_next(&cur, &idx, &v, &vl))
+	while (arr_next(&cur, &idx, &v, &nth[1]))
 	{
-		if (k >= c->off && k < c->lim)
+		if (nth[0] >= c->off && nth[0] < c->lim)
 		{
 			if (out.len)
 				vec_push_char(&out, ' ');
-			vec_push_nstr(&out, (char *)v, vl);
+			vec_push_nstr(&out, (char *)v, nth[1]);
 		}
-		k++;
+		nth[0]++;
 	}
 	return (vec_push_char(&out, '\0'), (char *)out.ctx);
 }

--- a/src/expander/expand_array_assign.c
+++ b/src/expander/expand_array_assign.c
@@ -74,19 +74,21 @@ static void	persist_array(t_shell *state, t_executable_cmd *ret, t_env ev)
 int	handle_array_assign(t_shell *state, t_expander_simple_cmd *exp,
 		t_executable_cmd *ret)
 {
-	t_vec	args;
-	t_token	key;
-	t_env	ev;
-	int		append;
+	t_vec			args;
+	t_token			key;
+	t_env			ev;
+	t_arr_assign	aa;
 
 	key = ((t_ast_node *)exp->curr->children.ctx)[0].token;
 	vec_init(&args);
 	args.elem_size = sizeof(char *);
 	expand_elems(state, exp->curr, &args);
-	append = (key.len >= 2 && key.start[key.len - 2] == '+');
-	ev.key = ft_strndup(key.start, key.len - 1 - append);
+	aa.append = (key.len >= 2 && key.start[key.len - 2] == '+');
+	ev.key = ft_strndup(key.start, key.len - 1 - aa.append);
 	ev.exported = state->opt_allexport;
-	ev.value = build_array_value(state, ret, &ev, &args, append);
+	aa.ev = &ev;
+	aa.args = &args;
+	ev.value = build_array_value(state, ret, &aa);
 	if (is_assign_builtin(ret))
 		persist_array(state, ret, ev);
 	else

--- a/src/expander/expand_array_assign2.c
+++ b/src/expander/expand_array_assign2.c
@@ -20,25 +20,6 @@
    target and builds the associative form; the indexed form lives in
    expand_array_assign3.c. */
 
-/* Split one expanded element into "[sub]=value": true with sub/subl/val
-   filled when it starts '[' and has a "]=", false (bare value) otherwise.
-   Quoting that would suppress the subscript is already lost by word
-   expansion — a documented element-level v1 divergence. */
-int	parse_sub_elem(char *elem, char **sub, int *subl, char **val)
-{
-	char	*rb;
-
-	if (elem[0] != '[')
-		return (0);
-	rb = ft_strchr(elem, ']');
-	if (!rb || rb[1] != '=')
-		return (0);
-	*sub = elem + 1;
-	*subl = (int)(rb - (elem + 1));
-	*val = rb + 2;
-	return (1);
-}
-
 /* Does any element carry an explicit [subscript]= prefix? Plain lists
    (a=(x y z)) skip the incremental builder and keep the fast path. */
 int	has_subscript(t_vec *args)
@@ -80,6 +61,18 @@ static int	is_assoc_target(t_executable_cmd *ret, const char *base)
 	return (0);
 }
 
+/* assoc_with_set on `cur`, freeing the old buffer; returns the new one
+   (the assoc twin of idx_set_free in expand_array_assign3.c). */
+static char	*assoc_set_free(char *cur, const char *sub, int subl,
+				const char *val)
+{
+	char	*nv;
+
+	nv = assoc_with_set(cur, sub, subl, val);
+	xfree(cur);
+	return (nv);
+}
+
 /* Build an associative value from [key]=value elements. A plain `=`
    assignment starts from an empty array (bash replaces the whole map);
    `+=` starts from the current value and merges. Bare elements (no
@@ -87,7 +80,6 @@ static int	is_assoc_target(t_executable_cmd *ret, const char *base)
 static char	*build_assoc(t_vec *args, const char *base, int append)
 {
 	char	*cur;
-	char	*nv;
 	char	*sub;
 	char	*val;
 	int		subl;
@@ -101,11 +93,7 @@ static char	*build_assoc(t_vec *args, const char *base, int append)
 	while (i < args->len)
 	{
 		if (parse_sub_elem(((char **)args->ctx)[i++], &sub, &subl, &val))
-		{
-			nv = assoc_with_set(cur, sub, subl, val);
-			xfree(cur);
-			cur = nv;
-		}
+			cur = assoc_set_free(cur, sub, subl, val);
 	}
 	return (cur);
 }
@@ -113,18 +101,21 @@ static char	*build_assoc(t_vec *args, const char *base, int append)
 /* Decide the encoded form for a compound array assignment and build it:
    associative when the target is assoc-typed, indexed-with-subscripts
    when any element is [i]=v, else the plain sequential fast path. base
-   aliases the current value (never freed here). */
+   aliases the current value (never freed here). aa bundles the half-built
+   env entry, the element list and the += flag (norm: four args max). */
 char	*build_array_value(t_shell *state, t_executable_cmd *ret,
-			t_env *ev, t_vec *args, int append)
+			t_arr_assign *aa)
 {
 	const char	*base;
 
-	base = env_expand(state, ev->key);
+	base = env_expand(state, aa->ev->key);
 	if (is_assoc_target(ret, base))
-		return (build_assoc(args, base, append));
-	if (has_subscript(args))
-		return (build_indexed_sub(state, args, base, append));
-	if (append)
-		return (arr_from_elems((char **)args->ctx, (int)args->len, base));
-	return (arr_from_elems((char **)args->ctx, (int)args->len, NULL));
+		return (build_assoc(aa->args, base, aa->append));
+	if (has_subscript(aa->args))
+		return (build_indexed_sub(state, aa->args, base, aa->append));
+	if (aa->append)
+		return (arr_from_elems((char **)aa->args->ctx,
+				(int)aa->args->len, base));
+	return (arr_from_elems((char **)aa->args->ctx,
+			(int)aa->args->len, NULL));
 }

--- a/src/expander/expand_array_assign3.c
+++ b/src/expander/expand_array_assign3.c
@@ -20,6 +20,27 @@
    current counter and bumps it — exactly bash's rule. Built incrementally
    through arr_with_set so ordering and replacement stay correct. */
 
+/* Split one expanded element into "[sub]=value": true with sub/subl/val
+   filled when it starts '[' and has a "]=", false (bare value) otherwise.
+   Quoting that would suppress the subscript is already lost by word
+   expansion — a documented element-level v1 divergence. Shared with the
+   assoc builder in expand_array_assign2.c; it lives here so both files
+   stay at the norm's five functions. */
+int	parse_sub_elem(char *elem, char **sub, int *subl, char **val)
+{
+	char	*rb;
+
+	if (elem[0] != '[')
+		return (0);
+	rb = ft_strchr(elem, ']');
+	if (!rb || rb[1] != '=')
+		return (0);
+	*sub = elem + 1;
+	*subl = (int)(rb - (elem + 1));
+	*val = rb + 2;
+	return (1);
+}
+
 /* Arithmetic value of a subscript slice (already word-expanded, so only
    arithmetic remains: [1+1] -> 2, [$k] came through as its value). */
 static long	sub_index(t_shell *state, const char *sub, int subl)
@@ -46,14 +67,23 @@ static char	*idx_set_free(char *cur, long idx, const char *val)
 	return (nv);
 }
 
+/* One compound element onto `cur`: an explicit [expr]= resets the
+   running counter first, then the value lands there and it advances. */
+static char	*idx_elem(t_shell *state, char *cur, long *run, char *val)
+{
+	char	*sub;
+	int		subl;
+
+	if (parse_sub_elem(val, &sub, &subl, &val))
+		*run = sub_index(state, sub, subl);
+	return (idx_set_free(cur, (*run)++, val));
+}
+
 char	*build_indexed_sub(t_shell *state, t_vec *args,
 			const char *base, int append)
 {
 	char	*cur;
-	char	*sub;
-	char	*val;
 	long	run;
-	int		subl;
 	size_t	i;
 
 	cur = ft_strdup((char [2]){ARR_MAGIC});
@@ -67,10 +97,8 @@ char	*build_indexed_sub(t_shell *state, t_vec *args,
 	i = 0;
 	while (i < args->len)
 	{
-		val = ((char **)args->ctx)[i++];
-		if (parse_sub_elem(val, &sub, &subl, &val))
-			run = sub_index(state, sub, subl);
-		cur = idx_set_free(cur, run++, val);
+		cur = idx_elem(state, cur, &run, ((char **)args->ctx)[i]);
+		i++;
 	}
 	return (cur);
 }

--- a/src/expander/expand_array_elem_op.c
+++ b/src/expander/expand_array_elem_op.c
@@ -20,15 +20,14 @@
 bool	is_valid_ident(char *s, int len);
 void	try_unset(t_shell *state, char *key);
 
-/* ${name[sub]OP} for a single element (sub is not the @ or star form), OP any parameter
-   operator (default/alt/trim/subst/case). The element is
-   resolved, bound to a scratch var (UNSET when the element is unset, so
-   :- vs - distinguish correctly), then `scratch OP` runs through the
+/* ${name[sub]OP} for a single element (sub is not the @ or star form),
+   OP any parameter operator (default/alt/trim/subst/case). The element
+   is resolved, bound to a scratch var (UNSET when the element is unset,
+   so :- vs - distinguish correctly), then `scratch OP` runs through the
    scalar engine — so ${c[x]:-0}, ${a[i]#pre}, ${h[k]:+1} all work. */
 
-/* Resolve the value of name[sub]; *found=0 when the element is unset. */
-static char	*elem_value(t_shell *state, const char *s, int nl, int sublen,
-				int *found)
+/* Resolve the value of name[sub]; NULL when the element is unset. */
+static char	*elem_value(t_shell *state, const char *s, int nl, int sublen)
 {
 	char	*val;
 	char	*sub;
@@ -37,10 +36,12 @@ static char	*elem_value(t_shell *state, const char *s, int nl, int sublen,
 
 	val = env_expand_n(state, (char *)s, nl);
 	sub = expand_param_word(state, (char *)s + nl + 1, sublen, false);
-	*found = 1;
 	if (assoc_is(val))
-		return (r = assoc_get(val, sub, (int)ft_strlen(sub)),
-			xfree(sub), (r ? r : (*found = 0, ft_strdup(""))));
+	{
+		r = assoc_get(val, sub, (int)ft_strlen(sub));
+		xfree(sub);
+		return (r);
+	}
 	r = arith_expand(state, sub, (int)ft_strlen(sub));
 	idx = 0;
 	if (r)
@@ -48,14 +49,10 @@ static char	*elem_value(t_shell *state, const char *s, int nl, int sublen,
 	xfree(r);
 	xfree(sub);
 	if (arr_is(val))
-		r = arr_get_idx(val, idx);
-	else if (val && idx == 0)
-		r = ft_strdup(val);
-	else
-		r = NULL;
-	if (!r)
-		*found = 0;
-	return (r ? r : ft_strdup(""));
+		return (arr_get_idx(val, idx));
+	if (val && idx == 0)
+		return (ft_strdup(val));
+	return (NULL);
 }
 
 /* Split name[sub]OP: *nl name length, *sublen subscript length, *opat
@@ -84,18 +81,19 @@ static bool	elem_op_split(const char *s, int len, int *nl, int sublen[2])
 	return (true);
 }
 
-/* Apply OP to the element via the scratch var + scalar engine. */
-static char	*elem_apply(t_shell *state, const char *op, int oplen,
-				char *elem, int found)
+/* Apply OP to the element via the scratch var + scalar engine.  elem is
+   moved into the scratch var; a NULL elem means the element is unset, so
+   the scratch var is unset too and :- vs - distinguish correctly. */
+static char	*elem_apply(t_shell *state, const char *op, int oplen, char *elem)
 {
 	char	*body;
 	char	*res;
 	int		kl;
 
-	if (found)
+	if (elem)
 		env_set(&state->env, env_create(ft_strdup(AEOP_VAR), elem, false));
 	else
-		(try_unset(state, AEOP_VAR), xfree(elem));
+		try_unset(state, AEOP_VAR);
 	kl = (int)ft_strlen(AEOP_VAR);
 	body = xmalloc((size_t)kl + oplen + 1);
 	ft_memcpy(body, AEOP_VAR, kl);
@@ -115,16 +113,14 @@ bool	expand_array_elem_op(t_shell *state, t_token *tt)
 	char	*res;
 	int		nl;
 	int		sub[2];
-	int		found;
 
 	if ((tt->tt != TT_ENVVAR && tt->tt != TT_DQENVVAR)
 		|| !elem_op_split(tt->start, tt->len, &nl, sub))
 		return (false);
 	if (sub[1] >= tt->len)
 		return (false);
-	elem = elem_value(state, tt->start, nl, sub[0], &found);
-	res = elem_apply(state, tt->start + sub[1], tt->len - sub[1],
-			elem, found);
+	elem = elem_value(state, tt->start, nl, sub[0]);
+	res = elem_apply(state, tt->start + sub[1], tt->len - sub[1], elem);
 	tt->start = res;
 	tt->len = (int)ft_strlen(res);
 	tt->allocated = true;

--- a/src/expander/expand_array_op.c
+++ b/src/expander/expand_array_op.c
@@ -48,25 +48,26 @@ static bool	array_op_split(const char *s, int len, int *nl, int *opat)
 	return (s[*opat] == '#' || s[*opat] == '%' || s[*opat] == '/');
 }
 
-/* Expand OP against one element via the scratch var + scalar engine. */
-static char	*array_op_elem(t_shell *state, const char *op, int oplen,
-				const char *elem)
+/* Expand OP against one element (the [v, v+vl) slice) via the scratch
+   var + scalar engine. Takes the raw slice rather than a C string so the
+   caller does not need its own elem temporary. */
+static char	*array_op_elem(t_shell *state, t_pe_op op, const char *v, int vl)
 {
 	char	*body;
 	char	*res;
 	int		kl;
 
 	env_set(&state->env, env_create(ft_strdup(AOP_VAR),
-			ft_strdup(elem), false));
+			ft_strndup(v, vl), false));
 	kl = (int)ft_strlen(AOP_VAR);
-	body = xmalloc((size_t)kl + oplen + 1);
+	body = xmalloc((size_t)kl + op.wlen + 1);
 	ft_memcpy(body, AOP_VAR, kl);
-	ft_memcpy(body + kl, op, oplen);
-	body[kl + oplen] = '\0';
-	res = expand_param_format(state, body, kl + oplen, false);
+	ft_memcpy(body + kl, op.word, op.wlen);
+	body[kl + op.wlen] = '\0';
+	res = expand_param_format(state, body, kl + op.wlen, false);
 	xfree(body);
 	if (!res)
-		res = ft_strdup(elem);
+		res = ft_strndup(v, vl);
 	return (res);
 }
 
@@ -81,20 +82,17 @@ static void	array_op_loop(t_shell *state, const char *val, t_string *out,
 	long		idx;
 	int			vl;
 	char		*r;
-	char		*el;
 
 	cur = "";
 	if (arr_is(val))
 		cur = val + 1;
 	while (arr_next(&cur, &idx, &v, &vl))
 	{
-		el = ft_strndup(v, vl);
-		r = array_op_elem(state, op.word, op.wlen, el);
+		r = array_op_elem(state, op, v, vl);
 		if (out->len)
 			vec_push_char(out, ' ');
 		vec_push_str(out, r);
 		xfree(r);
-		xfree(el);
 	}
 }
 

--- a/src/expander/expand_param_format.c
+++ b/src/expander/expand_param_format.c
@@ -54,14 +54,6 @@ char	*expand_param_word(t_shell *state, const char *word, int wlen, bool dq)
 	return (ret);
 }
 
-/* Thin wrapper: look up `name[0..len)` in the environment.  Returns NULL if
-   the variable is unset (distinct from set-but-empty, which returns "").
-   Centralised here so every expand_param_* helper uses the same lookup. */
-char	*pf_get_var_value(t_shell *state, const char *name, int len)
-{
-	return (env_expand_n(state, (char *)name, len));
-}
-
 static bool	is_unset_or_null(const char *val)
 {
 	return (val == NULL || *val == '\0');

--- a/src/expander/expand_param_format2.c
+++ b/src/expander/expand_param_format2.c
@@ -94,6 +94,24 @@ bool	find_param_op(const char *s, int slen, t_pe_op *o)
 	return (true);
 }
 
+/* The '*' arm of pat_match_pub: swallow the star run, then advance `s` one
+   character at a time until the rest of the pattern matches — the shortest
+   viable position.  Split out to keep pat_match_pub in the line budget. */
+static bool	pat_match_star(const char *p, const char *s)
+{
+	while (*p == '*')
+		p++;
+	if (*p == '\0')
+		return (true);
+	while (*s)
+	{
+		if (pat_match_pub(p, s))
+			return (true);
+		s++;
+	}
+	return (pat_match_pub(p, s));
+}
+
 /* Minimal shell-pattern matcher used by prefix/suffix trimming and ${/} subst.
    Handles * (any sequence) and ? (any single character) only — not [ranges].
    Recursive descent: consume one pattern unit and recurse on the rest.
@@ -110,42 +128,10 @@ bool	pat_match_pub(const char *p, const char *s)
 		return (false);
 	}
 	if (*p == '*')
-	{
-		while (*p == '*')
-			p++;
-		if (*p == '\0')
-			return (true);
-		while (*s)
-		{
-			if (pat_match_pub(p, s))
-				return (true);
-			s++;
-		}
-		return (pat_match_pub(p, s));
-	}
+		return (pat_match_star(p, s));
 	if (*p == '?' && *s != '\0')
 		return (pat_match_pub(p + 1, s + 1));
 	if (*p == *s && *s != '\0')
 		return (pat_match_pub(p + 1, s + 1));
 	return (false);
-}
-
-/* ${val%pattern} — remove the SHORTEST suffix of `val` that matches
-   `pattern`.  We scan from the end of val backwards until we find the
-   rightmost position where pat_match_pub(pattern, val+i) succeeds.
-   Shortest means we try from the end first and stop at the first match. */
-char	*trim_suffix_shortest(const char *val, const char *pattern)
-{
-	int	vlen;
-	int	i;
-
-	vlen = ft_strlen(val);
-	i = vlen;
-	while (i >= 0)
-	{
-		if (pat_match_pub(pattern, val + i))
-			return (ft_strndup(val, i));
-		i--;
-	}
-	return (ft_strdup(val));
 }

--- a/src/expander/expand_param_format3.c
+++ b/src/expander/expand_param_format3.c
@@ -12,6 +12,26 @@
 
 #include "expander_private.h"
 
+/* ${val%pattern} — remove the SHORTEST suffix of `val` that matches
+   `pattern`.  We scan from the end of val backwards until we find the
+   rightmost position where pat_match_pub(pattern, val+i) succeeds.
+   Shortest means we try from the end first and stop at the first match. */
+char	*trim_suffix_shortest(const char *val, const char *pattern)
+{
+	int	vlen;
+	int	i;
+
+	vlen = ft_strlen(val);
+	i = vlen;
+	while (i >= 0)
+	{
+		if (pat_match_pub(pattern, val + i))
+			return (ft_strndup(val, i));
+		i--;
+	}
+	return (ft_strdup(val));
+}
+
 /* ${val%%pattern} — remove the LONGEST suffix of `val` that matches
    `pattern`.  Scan from i=0 forward: the first position where the remainder
    of val matches the pattern gives the longest possible suffix to remove. */

--- a/src/expander/expand_param_format4.c
+++ b/src/expander/expand_param_format4.c
@@ -64,6 +64,27 @@ static const char	*find_subst_op(const char *s, int slen, int *name_len)
 	return (NULL);
 }
 
+/* The lower-priority ${...} forms tried after the operator and trim/subst
+   scans: transforms (@Q family), case conversion (^ , ~), substrings, then
+   the plain-parameter validity gate.  NULL keeps the "plain $v, caller
+   falls through" contract.  Split out of expand_param_format only to stay
+   inside the norm line budget — the priority order is unchanged. */
+static char	*pf_tail_dispatch(t_shell *state, const char *s, int slen)
+{
+	int		name_len;
+	char	xop;
+
+	if (find_xform_op(s, slen, &name_len, &xop))
+		return (expand_xform(state, s, name_len, xop));
+	if (find_case_op(s, slen, &name_len))
+		return (expand_case(state, s, slen, name_len));
+	if (pf_find_substr(s, slen, &name_len))
+		return (expand_substr(state, s, slen, name_len));
+	if (!pf_valid_plain(s, slen))
+		return (pf_bad_subst(state, s, slen));
+	return (NULL);
+}
+
 /* Top-level ${...} dispatcher.  `s` is the raw text between the braces,
    `slen` its byte count.  Priority order — first match wins:
      ${#v}      → length of v                  (expand_strlen)
@@ -80,7 +101,6 @@ char	*expand_param_format(t_shell *state, const char *s, int slen, bool dq)
 	const char	*op;
 	int			name_len;
 	t_pe_op		o;
-	char		xop;
 
 	if (slen <= 0)
 		return (pf_bad_subst(state, s, slen));
@@ -96,13 +116,5 @@ char	*expand_param_format(t_shell *state, const char *s, int slen, bool dq)
 	if (op)
 		return (pf_trim_or_subst(state,
 				pf_make_ctx(s, slen, op, name_len)));
-	if (find_xform_op(s, slen, &name_len, &xop))
-		return (expand_xform(state, s, name_len, xop));
-	if (find_case_op(s, slen, &name_len))
-		return (expand_case(state, s, slen, name_len));
-	if (pf_find_substr(s, slen, &name_len))
-		return (expand_substr(state, s, slen, name_len));
-	if (!pf_valid_plain(s, slen))
-		return (pf_bad_subst(state, s, slen));
-	return (NULL);
+	return (pf_tail_dispatch(state, s, slen));
 }

--- a/src/expander/expand_param_format5.c
+++ b/src/expander/expand_param_format5.c
@@ -86,27 +86,6 @@ char	*pf_bad_subst(t_shell *state, const char *s, int slen)
 	return (ft_strdup(""));
 }
 
-/* Route a trim/substitution ctx to the right evaluator (split out of
-   expand_param_format to keep it inside the norm line budget). */
-char	*pf_trim_or_subst(t_shell *state, t_trim_ctx ctx)
-{
-	if (*ctx.op == '/')
-		return (expand_subst(state, ctx));
-	return (expand_trim(state, ctx));
-}
-
-/* Assemble the trim/subst context handed to the evaluators. */
-t_trim_ctx	pf_make_ctx(const char *s, int slen, const char *op, int nlen)
-{
-	t_trim_ctx	ctx;
-
-	ctx.name = s;
-	ctx.name_len = nlen;
-	ctx.op = op;
-	ctx.slen = slen;
-	return (ctx);
-}
-
 /* Detect the substring form NAME:... — a valid plain parameter followed by
    a ':' that find_param_op did not already claim as :-/:=/:?/:+ — and hand
    back the name length. */

--- a/src/expander/expand_param_format6.c
+++ b/src/expander/expand_param_format6.c
@@ -62,28 +62,6 @@ char	*pf_assign_err(t_shell *state, t_pe_op o)
 	return (ft_strdup(""));
 }
 
-/* Expand an operator word that sits inside double quotes.  Rather than
-   duplicating the reparser's dq escape rules, wrap the raw word in a pair
-   of double quotes and run it through the normal unquoted pipeline: the
-   reparser then applies exactly the "..." semantics — \$ \" \\ \` stay
-   active escapes, any other backslash is kept literally ("${u-\z}" prints
-   \z), tilde stays literal, and embedded quotes behave as they do in bash
-   ("${u-'a b'}" keeps the single quotes). */
-char	*expand_param_word_dq(t_shell *state, const char *word, int wlen)
-{
-	char	*buf;
-	char	*ret;
-
-	buf = xmalloc((size_t)wlen + 3);
-	buf[0] = '"';
-	ft_memcpy(buf + 1, word, (size_t)wlen);
-	buf[wlen + 1] = '"';
-	buf[wlen + 2] = '\0';
-	ret = expand_param_word(state, buf, wlen + 2, false);
-	xfree(buf);
-	return (ret);
-}
-
 /* Token-level entry for the ${p-w} operator family: unlike the generic
    expand_param_format path (arith, heredoc) this one knows the enclosing
    token type, so it threads the double-quote context into the word

--- a/src/expander/expand_param_format7.c
+++ b/src/expander/expand_param_format7.c
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_param_format7.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/07/28 12:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/07/28 12:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "expander_private.h"
+#include "env.h"
+
+/* Thin wrapper: look up `name[0..len)` in the environment.  Returns NULL if
+   the variable is unset (distinct from set-but-empty, which returns "").
+   Centralised here so every expand_param_* helper uses the same lookup. */
+char	*pf_get_var_value(t_shell *state, const char *name, int len)
+{
+	return (env_expand_n(state, (char *)name, len));
+}
+
+/* Route a trim/substitution ctx to the right evaluator (split out of
+   expand_param_format to keep it inside the norm line budget). */
+char	*pf_trim_or_subst(t_shell *state, t_trim_ctx ctx)
+{
+	if (*ctx.op == '/')
+		return (expand_subst(state, ctx));
+	return (expand_trim(state, ctx));
+}
+
+/* Assemble the trim/subst context handed to the evaluators. */
+t_trim_ctx	pf_make_ctx(const char *s, int slen, const char *op, int nlen)
+{
+	t_trim_ctx	ctx;
+
+	ctx.name = s;
+	ctx.name_len = nlen;
+	ctx.op = op;
+	ctx.slen = slen;
+	return (ctx);
+}
+
+/* Expand an operator word that sits inside double quotes.  Rather than
+   duplicating the reparser's dq escape rules, wrap the raw word in a pair
+   of double quotes and run it through the normal unquoted pipeline: the
+   reparser then applies exactly the "..." semantics — \$ \" \\ \` stay
+   active escapes, any other backslash is kept literally ("${u-\z}" prints
+   \z), tilde stays literal, and embedded quotes behave as they do in bash
+   ("${u-'a b'}" keeps the single quotes). */
+char	*expand_param_word_dq(t_shell *state, const char *word, int wlen)
+{
+	char	*buf;
+	char	*ret;
+
+	buf = xmalloc((size_t)wlen + 3);
+	buf[0] = '"';
+	ft_memcpy(buf + 1, word, (size_t)wlen);
+	buf[wlen + 1] = '"';
+	buf[wlen + 2] = '\0';
+	ret = expand_param_word(state, buf, wlen + 2, false);
+	xfree(buf);
+	return (ret);
+}

--- a/src/expander/expand_pos_slice.c
+++ b/src/expander/expand_pos_slice.c
@@ -49,14 +49,69 @@ static char	*pos_join(t_shell *state, int from, int to)
 	return (vec_push_char(&out, '\0'), (char *)out.ctx);
 }
 
+/* Join all positional parameters into a single string separated by the first
+   character of IFS (space by default).  This is the $* / unquoted $@
+   expansion: POSIX says "$@" in a split context should produce one field per
+   positional — that case is handled separately in emit_positional_at.
+   env_get_ifs never returns NULL (unset falls back to " \t\n"), so the
+   separator test must look at the first CHARACTER: with IFS='' there is no
+   separator at all and "$*" concatenates ("ab", not "a<NUL>b").
+   Note: getting $# as a string to do ft_atoi on it is slightly clunky but
+   avoids adding a separate counter field to t_shell. */
+char	*join_positionals(t_shell *state)
+{
+	t_string	out;
+	char		*cnt;
+	char		*k;
+	char		*v;
+	int			i;
+
+	cnt = env_expand(state, "#");
+	i = 0;
+	vec_init(&out);
+	out.elem_size = 1;
+	while (cnt && ++i <= ft_atoi(cnt))
+	{
+		k = ft_itoa(i);
+		v = env_expand(state, k);
+		xfree(k);
+		if (i > 1 && env_get_ifs(&state->env)[0])
+			vec_push(&out, &env_get_ifs(&state->env)[0]);
+		if (v)
+			vec_push_str(&out, v);
+	}
+	return (vec_push(&out, &(char){0}), (char *)out.ctx);
+}
+
+/* Compute the [*off, *to) window of an "@:off[:len]" body.  slice_off_len
+   (pure — it just finds the second ':', or tt->len when there is no length
+   field) is cached in `ol`; a negative offset counts back from $# plus one
+   so the $0 slot stays addressable, exactly as the inline code did. */
+static void	pos_slice_range(t_shell *state, t_token *tt, int *off, int *to)
+{
+	char	*cnt;
+	int		n;
+	int		ol;
+
+	cnt = env_expand(state, "#");
+	n = 0;
+	if (cnt)
+		n = ft_atoi(cnt);
+	ol = slice_off_len(tt->start, tt->len, 1);
+	*off = arith_num(state, tt->start + 2, ol - 2);
+	if (*off < 0)
+		*off += n + 1;
+	*to = n + 1;
+	if (ol < tt->len)
+		*to = *off + arith_num(state, tt->start + ol + 1, tt->len - ol - 1);
+}
+
 /* Recognise "@:..." / "*:..." and emit the slice. tt->start[0] is @ or *,
    [1] is ':'. Returns false otherwise. */
 bool	expand_pos_slice(t_shell *state, t_token *tt)
 {
-	char	*cnt;
-	int		n;
-	int		off;
-	int		to;
+	int	off;
+	int	to;
 
 	if (tt->len < 3 || (tt->start[0] != '@' && tt->start[0] != '*')
 		|| tt->start[1] != ':')
@@ -64,19 +119,7 @@ bool	expand_pos_slice(t_shell *state, t_token *tt)
 	if (tt->start[2] == '-' || tt->start[2] == '+'
 		|| tt->start[2] == '=' || tt->start[2] == '?')
 		return (false);
-	cnt = env_expand(state, "#");
-	n = 0;
-	if (cnt)
-		n = ft_atoi(cnt);
-	off = arith_num(state, tt->start + 2, slice_off_len(tt->start, tt->len, 1)
-			- 2);
-	if (off < 0)
-		off += n + 1;
-	to = n + 1;
-	if (slice_off_len(tt->start, tt->len, 1) < tt->len)
-		to = off + arith_num(state,
-				tt->start + slice_off_len(tt->start, tt->len, 1) + 1,
-				tt->len - slice_off_len(tt->start, tt->len, 1) - 1);
+	pos_slice_range(state, tt, &off, &to);
 	tt->start = pos_join(state, off, to);
 	tt->len = (int)ft_strlen(tt->start);
 	tt->allocated = true;

--- a/src/expander/expand_tilde_token.c
+++ b/src/expander/expand_tilde_token.c
@@ -61,6 +61,22 @@ static void	expand_tilde_user(t_token *t)
 	parena_note_attach();
 }
 
+/* Splice `val` over the first `plen` bytes of token `t`, keeping the rest
+   of the word.  The joined buffer is a fresh allocation the token now owns
+   (allocated flag) and the parena is told about the attachment. */
+static void	tilde_splice(t_token *t, char *val, int plen)
+{
+	t_string	s;
+
+	vec_init(&s);
+	vec_push_str(&s, val);
+	t->allocated = true;
+	parena_note_attach();
+	vec_push_nstr(&s, t->start + plen, t->len - plen);
+	t->start = (char *)s.ctx;
+	t->len = s.len;
+}
+
 /* Replace the leading tilde prefix of token `t` with the appropriate path.
    Dispatch: ~+ → $PWD, ~- → $OLDPWD, ~name → getpwnam(name)->pw_dir,
    ~ alone → $HOME (or the passwd home when HOME is unset, see tilde_home_dir).
@@ -68,9 +84,8 @@ static void	expand_tilde_user(t_token *t)
    unresolvable tilde stays literal). */
 void	expand_tilde_token(t_shell *state, t_token *t)
 {
-	int			template_len;
-	char		*env_val;
-	t_string	s;
+	int		template_len;
+	char	*env_val;
 
 	template_len = 2;
 	if (token_starts_with(*t, CUR_DIR))
@@ -86,12 +101,5 @@ void	expand_tilde_token(t_shell *state, t_token *t)
 	}
 	if (!env_val)
 		return ;
-	vec_init(&s);
-	if (env_val)
-		vec_push_str(&s, env_val);
-	t->allocated = true;
-	parena_note_attach();
-	vec_push_nstr(&s, t->start + template_len, t->len - template_len);
-	t->start = (char *)s.ctx;
-	t->len = s.len;
+	tilde_splice(t, env_val, template_len);
 }

--- a/src/expander/expand_token.c
+++ b/src/expander/expand_token.c
@@ -16,40 +16,6 @@
 char	*expand_param_format(t_shell *state, const char *s, int slen, bool dq);
 void	nounset_abort(t_shell *state, const char *name, int len);
 
-/* Join all positional parameters into a single string separated by the first
-   character of IFS (space by default).  This is the $* / unquoted $@
-   expansion: POSIX says "$@" in a split context should produce one field per
-   positional — that case is handled separately in emit_positional_at.
-   env_get_ifs never returns NULL (unset falls back to " \t\n"), so the
-   separator test must look at the first CHARACTER: with IFS='' there is no
-   separator at all and "$*" concatenates ("ab", not "a<NUL>b").
-   Note: getting $# as a string to do ft_atoi on it is slightly clunky but
-   avoids adding a separate counter field to t_shell. */
-char	*join_positionals(t_shell *state)
-{
-	t_string	out;
-	char		*cnt;
-	char		*k;
-	char		*v;
-	int			i;
-
-	cnt = env_expand(state, "#");
-	i = 0;
-	vec_init(&out);
-	out.elem_size = 1;
-	while (cnt && ++i <= ft_atoi(cnt))
-	{
-		k = ft_itoa(i);
-		v = env_expand(state, k);
-		xfree(k);
-		if (i > 1 && env_get_ifs(&state->env)[0])
-			vec_push(&out, &env_get_ifs(&state->env)[0]);
-		if (v)
-			vec_push_str(&out, v);
-	}
-	return (vec_push(&out, &(char){0}), (char *)out.ctx);
-}
-
 static bool	handle_empty_token(t_token *curr_tt)
 {
 	if (curr_tt->len != 0)
@@ -122,6 +88,23 @@ static bool	expand_positional(t_shell *state, t_token *curr_tt, bool split_ctx)
 	return (true);
 }
 
+/* The array-flavoured ${...} shapes, tried in the exact dispatch order the
+   inline chain used: positional slices, ${#a[@]}, element operators, the
+   extended forms, then plain subscripts.  Split out of expand_token only to
+   stay inside the norm line budget. */
+static bool	try_array_forms(t_shell *state, t_token *curr_tt, bool split_ctx)
+{
+	if (expand_pos_slice(state, curr_tt))
+		return (true);
+	if (expand_array_op(state, curr_tt))
+		return (true);
+	if (expand_array_elem_op(state, curr_tt))
+		return (true);
+	if (expand_array_ext(state, curr_tt, split_ctx))
+		return (true);
+	return (expand_array_token(state, curr_tt, split_ctx));
+}
+
 /* Expand a single $-token (TT_ENVVAR or TT_DQENVVAR) in place.  Priority:
      1. $@ / $* in a split context (emit_positional_at or join_positionals)
      2. Empty-token edge cases (bare $ or $'')
@@ -139,15 +122,7 @@ void	expand_token(t_shell *state, t_token *curr_tt, bool split_ctx)
 		return ;
 	if (handle_empty_token(curr_tt))
 		return ;
-	if (expand_pos_slice(state, curr_tt))
-		return ;
-	if (expand_array_op(state, curr_tt))
-		return ;
-	if (expand_array_elem_op(state, curr_tt))
-		return ;
-	if (expand_array_ext(state, curr_tt, split_ctx))
-		return ;
-	if (expand_array_token(state, curr_tt, split_ctx))
+	if (try_array_forms(state, curr_tt, split_ctx))
 		return ;
 	if (expand_op_token(state, curr_tt, split_ctx))
 		return ;

--- a/src/expander/expander_private.h
+++ b/src/expander/expander_private.h
@@ -296,13 +296,13 @@ char		*arr_mark_name(t_shell *state, const char *p);
 void		arr_marks_clear(t_shell *state);
 bool		arr_keys_defer(t_shell *state, t_token *tt);
 void		emit_keys_fields(t_shell *state, const char *name,
-			t_ast_node *curr_node, t_vec_nd *ret);
+				t_ast_node *curr_node, t_vec_nd *ret);
 void		emit_array_at(t_shell *state, const char *name,
-			t_ast_node *curr_node, t_vec_nd *ret);
+				t_ast_node *curr_node, t_vec_nd *ret);
 void		emit_array_split(t_shell *state, const char *name,
-			t_ast_node *curr_node, t_vec_nd *ret);
+				t_ast_node *curr_node, t_vec_nd *ret);
 void		emit_assoc_fields(char *val, t_ast_node *curr_node, t_vec_nd *ret,
-			int want_keys);
+				int want_keys);
 typedef struct s_slice_ctx
 {
 	char	*val;
@@ -324,12 +324,24 @@ int			slice_name_len(const char *s, int len, int *colon);
 char		*arr_slice_build(t_slice_ctx *c);
 int			herestring_redir(t_shell *state, t_ast_node *curr, int src_fd);
 int			handle_array_assign(t_shell *state, t_expander_simple_cmd *exp,
-			t_executable_cmd *ret);
+				t_executable_cmd *ret);
 int			is_assign_builtin(t_executable_cmd *ret);
 int			parse_sub_elem(char *elem, char **sub, int *subl, char **val);
 int			has_subscript(t_vec *args);
+
+/* One compound assignment name=(...) being applied: the half-built env
+   entry (key already stripped of any +=), the expanded element strings,
+   and whether the spelling was +=. Bundled so build_array_value keeps a
+   four-argument signature (same move as t_expand_glob_ctx above). */
+typedef struct s_arr_assign
+{
+	t_env	*ev;
+	t_vec	*args;
+	int		append;
+}	t_arr_assign;
+
 char		*build_array_value(t_shell *state, t_executable_cmd *ret,
-				t_env *ev, t_vec *args, int append);
+				t_arr_assign *aa);
 char		*build_indexed_sub(t_shell *state, t_vec *args,
 				const char *base, int append);
 bool		is_ifs_char(char c, const char *ifs);

--- a/src/expander/split_array.c
+++ b/src/expander/split_array.c
@@ -52,44 +52,33 @@ void	emit_array_at(t_shell *state, const char *name, t_ast_node *curr_node,
 void	emit_assoc_fields(char *val, t_ast_node *curr_node, t_vec_nd *ret,
 			int want_keys)
 {
-	const char	*cur;
-	const char	*k;
-	const char	*v;
-	int			kl;
-	int			nth[2];
+	t_assoc_it	it;
+	int			nth;
 
-	cur = val + 1;
-	nth[0] = 0;
-	while (assoc_next(&cur, &k, &kl, &v, &nth[1]))
+	assoc_it_init(&it, val);
+	nth = 0;
+	while (assoc_next(&it))
 	{
-		if (nth[0]++ > 0)
+		if (nth++ > 0)
 			push_and_reinit_curr_node(ret, curr_node);
 		if (want_keys)
-			push_new_env_child(curr_node, ft_strndup(k, kl));
+			push_new_env_child(curr_node, ft_strndup(it.k, it.kl));
 		else
-			push_new_env_child(curr_node, ft_strndup(v, nth[1]));
+			push_new_env_child(curr_node, ft_strndup(it.v, it.vl));
 	}
 }
 
-/* Unquoted ${arr[@]} / ${arr[*]}: one field per element, each element
-   itself IFS-split, exactly like unquoted $@. */
-void	emit_array_split(t_shell *state, const char *name,
-			t_ast_node *curr_node, t_vec_nd *ret)
+/* Element walk of the unquoted form: hard field break between elements,
+   then each element runs through the ordinary IFS splitter. */
+static void	emit_split_loop(t_shell *state, const char *val,
+				t_ast_node *curr_node, t_vec_nd *ret)
 {
-	char		*val;
 	char		*elem;
 	const char	*cur;
 	const char	*v;
 	long		idx;
 	int			nth[2];
 
-	val = env_expand(state, (char *)name);
-	if (!val)
-		return ;
-	if (assoc_is(val))
-		return (emit_assoc_fields(val, curr_node, ret, 0));
-	if (!arr_is(val))
-		return (split_value(state, val, curr_node, ret));
 	cur = val + 1;
 	nth[0] = 0;
 	while (arr_next(&cur, &idx, &v, &nth[1]))
@@ -102,8 +91,26 @@ void	emit_array_split(t_shell *state, const char *name,
 	}
 }
 
+/* Unquoted ${arr[@]} / ${arr[*]}: one field per element, each element
+   itself IFS-split, exactly like unquoted $@. */
+void	emit_array_split(t_shell *state, const char *name,
+			t_ast_node *curr_node, t_vec_nd *ret)
+{
+	char	*val;
+
+	val = env_expand(state, (char *)name);
+	if (!val)
+		return ;
+	if (assoc_is(val))
+		return (emit_assoc_fields(val, curr_node, ret, 0));
+	if (!arr_is(val))
+		return (split_value(state, val, curr_node, ret));
+	emit_split_loop(state, val, curr_node, ret);
+}
+
 /* Emit one field per index (indexed) or key (assoc) for a deferred
-   ${!name[@]} keys-marker; `name` still has its leading '!'. */
+   ${!name[@]} keys-marker; `name` still has its leading '!'. nth pairs
+   the field counter with arr_next's length out-param like above. */
 void	emit_keys_fields(t_shell *state, const char *name,
 			t_ast_node *curr_node, t_vec_nd *ret)
 {
@@ -111,8 +118,7 @@ void	emit_keys_fields(t_shell *state, const char *name,
 	const char	*cur;
 	const char	*v;
 	long		idx;
-	int			vl;
-	int			nth;
+	int			nth[2];
 
 	val = env_expand(state, (char *)name + 1);
 	if (!val)
@@ -122,10 +128,10 @@ void	emit_keys_fields(t_shell *state, const char *name,
 	cur = "";
 	if (arr_is(val))
 		cur = val + 1;
-	nth = 0;
-	while (arr_next(&cur, &idx, &v, &vl))
+	nth[0] = 0;
+	while (arr_next(&cur, &idx, &v, &nth[1]))
 	{
-		if (nth++ > 0)
+		if (nth[0]++ > 0)
 			push_and_reinit_curr_node(ret, curr_node);
 		push_new_env_child(curr_node, ft_itoa((int)idx));
 	}

--- a/src/glob/glob_expand2.c
+++ b/src/glob/glob_expand2.c
@@ -82,14 +82,30 @@ static bool	glob_has_wildcard(t_vec_glob glob)
 	return (false);
 }
 
+/* Expansions that need no directory walk: an empty token list yields one
+   empty string, and a pattern with no wildcards can never expand to more
+   than itself, so the word is returned as-is (after converting to string)
+   without any filesystem access. True means args is already final. */
+static bool	glob_trivial(t_vec *args, t_vec_glob *glob, t_ast_node word)
+{
+	if (glob->len == 0)
+		return (vec_push(args, &(char *){ft_strdup("")}), true);
+	if (!glob_has_wildcard(*glob))
+	{
+		vec_push(args, &(char *){(char *)word_to_string(word).ctx});
+		return (glob_free_tokens(glob), true);
+	}
+	return (false);
+}
+
 /* Expand a word node by glob matching and return a vector of malloc'd path
-   strings. If the pattern has no wildcards, the word is returned as-is
-   (after converting to string) without any filesystem access. If wildcards
-   exist, we start the directory walk at "/" for absolute patterns (first token
-   is G_SLASH) or at "" (meaning CWD) for relative ones. When the walk finds
-   nothing, the original word is pushed unchanged -- POSIX "no-match = literal".
-   Results are sorted with glob_sort after the walk. If a signal arrived during
-   the walk (should_unwind), we destroy the partial results and return empty. */
+   strings. Trivial cases (no tokens, no wildcards) are settled by
+   glob_trivial; otherwise we start the directory walk at "/" for absolute
+   patterns (first token is G_SLASH) or at "" (meaning CWD) for relative
+   ones. When the walk finds nothing, the original word is pushed unchanged
+   -- POSIX "no-match = literal". Results are sorted with glob_sort after
+   the walk. If a signal arrived during the walk (should_unwind), we
+   destroy the partial results and return empty. */
 t_vec	expand_word_glob(t_ast_node word)
 {
 	t_vec		args;
@@ -98,13 +114,8 @@ t_vec	expand_word_glob(t_ast_node word)
 	vec_init(&args);
 	args.elem_size = sizeof(char *);
 	glob = word_to_glob(word);
-	if (glob.len == 0)
-		return (vec_push(&args, &(char *){ft_strdup("")}), args);
-	if (!glob_has_wildcard(glob))
-	{
-		vec_push(&args, &(char *){(char *)word_to_string(word).ctx});
-		return (glob_free_tokens(&glob), args);
-	}
+	if (glob_trivial(&args, &glob, word))
+		return (args);
 	if (((t_glob *)glob.ctx)[0].ty == G_SLASH)
 		match_dir(&args, glob, "/", 1);
 	else

--- a/src/helpers/free_utils.c
+++ b/src/helpers/free_utils.c
@@ -71,43 +71,13 @@ static void	free_functions(t_vec *fns)
 	xfree(fns->ctx);
 }
 
-/* trap handler strings (ft_strdup'd in set_one_trap) live for the session and
-   were never released at exit — free the whole table so a script using trap is
-   leak-clean like any other. */
-static void	free_traps(t_shell *state)
+/* Session-lifetime strings and caches, in the exact order free_all_state
+   always released them: input buffer, alias-expansion scratch, the pid /
+   $! / ctx strings, the readline buffer, then the split-$PATH cache (see
+   path_cache_sync — free_tab is not NULL-safe, hence the guard, and the
+   pointers are NULLed so a stray re-entry cannot double-free). */
+static void	free_session_strings(t_shell *state)
 {
-	int	i;
-
-	i = -1;
-	while (++i < SH_NTRAP)
-	{
-		xfree(state->traps[i]);
-		state->traps[i] = NULL;
-	}
-}
-
-/* Drop the split-$PATH cache (see path_cache_sync). free_tab is not
-   NULL-safe, hence the guard; the pointers are NULLed so a stray re-entry
-   cannot double-free. */
-static void	free_path_cache(t_shell *state)
-{
-	if (state->path_dirs)
-		free_tab(state->path_dirs);
-	state->path_dirs = NULL;
-	xfree(state->path_dirs_src);
-	state->path_dirs_src = NULL;
-}
-
-/* The single canonical shutdown path. Order is deliberate: functions first
-   (they may reference variables), then per-command scratch (input, AST,
-   redirects, proc subs), then session data (history, cwd, positional args,
-   the argv pool, traps). env_index_free() must come after all env lookups;
-   word_slab_teardown() is last so any stray word_free() calls during the
-   earlier steps still work. alloc_live_report() is the ft_malloc leak oracle
-   -- it's a no-op on libc builds and a canary for the slab backend. */
-void	free_all_state(t_shell *state)
-{
-	free_functions(&state->functions);
 	xfree(state->input.ctx);
 	state->input = (t_string){};
 	if (state->alias_exp_owned)
@@ -121,21 +91,56 @@ void	free_all_state(t_shell *state)
 	state->ctx = 0;
 	state->dft_ctx = 0;
 	xfree(state->rl.buff.ctx);
-	free_path_cache(state);
+	if (state->path_dirs)
+		free_tab(state->path_dirs);
+	state->path_dirs = NULL;
+	xfree(state->path_dirs_src);
+	state->path_dirs_src = NULL;
+}
+
+/* Session data, still in free_all_state's order: history, cwd, positional
+   args, the argv pool, the trap table (handler strings are ft_strdup'd in
+   set_one_trap and live for the whole session — freeing them here keeps a
+   script using trap leak-clean like any other), then the dirstack and the
+   for-loop positional snapshot. */
+static void	free_session_data(t_shell *state)
+{
+	int	i;
+
+	free_hist(state);
+	xfree(state->cwd.ctx);
+	pos_free(&state->pos);
+	free_argv_pool(state);
+	i = -1;
+	while (++i < SH_NTRAP)
+	{
+		xfree(state->traps[i]);
+		state->traps[i] = NULL;
+	}
+	free_dirstack(state);
+	if (state->for_snapshot)
+		free_positional_snapshot(state->for_snapshot);
+	state->for_snapshot = NULL;
+}
+
+/* The single canonical shutdown path. Order is deliberate: functions first
+   (they may reference variables), then the owned strings and caches, then
+   per-command scratch (redirects, proc subs, AST), then session data
+   (history, cwd, positional args, the argv pool, traps). env_index_free()
+   must come after all env lookups; word_slab_teardown() is last so any
+   stray word_free() calls during the earlier steps still work.
+   alloc_live_report() is the ft_malloc leak oracle -- it's a no-op on libc
+   builds and a canary for the slab backend. */
+void	free_all_state(t_shell *state)
+{
+	free_functions(&state->functions);
+	free_session_strings(state);
 	free_redirects(&state->redirects);
 	cleanup_proc_subs(state);
 	free_ast(&state->tree);
 	arr_marks_clear(state);
 	attr_clear(state);
-	free_hist(state);
-	xfree(state->cwd.ctx);
-	pos_free(&state->pos);
-	free_argv_pool(state);
-	free_traps(state);
-	free_dirstack(state);
-	if (state->for_snapshot)
-		free_positional_snapshot(state->for_snapshot);
-	state->for_snapshot = NULL;
+	free_session_data(state);
 	env_index_free();
 	parena_destroy();
 	word_slab_teardown();

--- a/src/helpers/parse_arena.c
+++ b/src/helpers/parse_arena.c
@@ -83,7 +83,7 @@ void	*parena_alloc(size_t n)
 {
 	void	*p;
 
-	n = PARENA_ROUND(n);
+	n = parena_round(n);
 	if (!g_parena.on)
 		return (xmalloc(n));
 	if (g_parena.n_chunks == 0
@@ -122,15 +122,4 @@ bool	parena_owns(const void *p)
 		return (false);
 	c = (const char *)g_parena.chunk[lo];
 	return ((const char *)p >= c && (const char *)p < c + g_parena.size[lo]);
-}
-
-/* Free router: arena blocks are reclaimed wholesale by parena_reset, so
-   they are a no-op here; anything else goes to the real heap free. This
-   lets one call site tear down both arena-backed cycle trees and
-   heap-backed clones (function bodies, eval ASTs). */
-void	parena_free(void *p)
-{
-	if (!p || parena_owns(p))
-		return ;
-	xfree(p);
 }

--- a/src/helpers/parse_arena2.c
+++ b/src/helpers/parse_arena2.c
@@ -75,8 +75,8 @@ bool	parena_try_extend(void *p, size_t old_n, size_t new_n)
 	a = parena();
 	if (!a->on || !p || a->n_chunks == 0)
 		return (false);
-	old_n = PARENA_ROUND(old_n);
-	new_n = PARENA_ROUND(new_n);
+	old_n = parena_round(old_n);
+	new_n = parena_round(new_n);
 	base = (char *)a->chunk[a->cur];
 	if ((char *)p < base || (char *)p + old_n != base + a->off)
 		return (false);

--- a/src/helpers/parse_arena3.c
+++ b/src/helpers/parse_arena3.c
@@ -1,0 +1,33 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_arena3.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/07/20 19:00:00 by marvin            #+#    #+#             */
+/*   Updated: 2026/07/20 19:00:00 by marvin           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "parena.h"
+#include "ft_memory.h"
+
+/* Free router: arena blocks are reclaimed wholesale by parena_reset, so
+   they are a no-op here; anything else goes to the real heap free. This
+   lets one call site tear down both arena-backed cycle trees and
+   heap-backed clones (function bodies, eval ASTs). */
+void	parena_free(void *p)
+{
+	if (!p || parena_owns(p))
+		return ;
+	xfree(p);
+}
+
+/* The shared rounding step of the bump allocator: parena_alloc and
+   parena_try_extend must agree byte-for-byte on rounded sizes or the
+   arena-tip test misfires and extends the wrong block. */
+size_t	parena_round(size_t n)
+{
+	return ((n + 7) & ~(size_t)7);
+}

--- a/src/infrastructure/ast_utils6.c
+++ b/src/infrastructure/ast_utils6.c
@@ -13,43 +13,47 @@
 #include "ast_private.h"
 #include "parena.h"
 
+/* Double the children capacity (seed at 2).  Growth first tries
+   parena_try_extend: the array being appended to is usually the arena's
+   tip (depth-first construction), so most doublings are a pure offset
+   bump — no memcpy, no abandoned block.  Otherwise a fresh block is
+   bump-allocated and the outgrown one handed to parena_free. */
+static void	ast_children_grow(t_vec *v)
+{
+	void	*nb;
+	size_t	old;
+
+	old = v->cap * sizeof(t_ast_node);
+	if (v->cap == 0)
+		v->cap = 2;
+	else
+		v->cap = v->cap * 2;
+	if (v->ctx && parena_try_extend(v->ctx, old, v->cap * sizeof(t_ast_node)))
+		return ;
+	nb = parena_alloc(v->cap * sizeof(t_ast_node));
+	if (!parena()->on)
+		parena_note_attach();
+	if (v->len > 0)
+		ft_memcpy(nb, v->ctx, v->len * sizeof(t_ast_node));
+	parena_free(v->ctx);
+	v->ctx = nb;
+}
+
 /* Append a child node, growing the children buffer from the parse arena.
    This replaces vec_push in the parser and reparser hot paths: the buffer
    comes from parena_alloc (bump) and the outgrown one goes to parena_free,
    which no-ops arena blocks and really frees heap blocks — so a vec that
    started on the heap (or the whole call happening while the arena gate is
    closed, e.g. inside eval) behaves exactly like the old vec_push path.
-   Growth first tries parena_try_extend: the array being appended to is
-   usually the arena's tip (depth-first construction), so most doublings
-   are a pure offset bump — no memcpy, no abandoned block.
    Clone code keeps plain vec_push: cloned trees must outlive the cycle. */
 void	ast_push_child(t_ast_node *parent, t_ast_node *child)
 {
 	t_vec	*v;
-	void	*nb;
-	size_t	old;
 
 	v = &parent->children;
 	v->elem_size = sizeof(t_ast_node);
 	if (v->len + 1 > v->cap)
-	{
-		old = v->cap * sizeof(t_ast_node);
-		if (v->cap == 0)
-			v->cap = 2;
-		else
-			v->cap = v->cap * 2;
-		if (!v->ctx || !parena_try_extend(v->ctx, old,
-				v->cap * sizeof(t_ast_node)))
-		{
-			nb = parena_alloc(v->cap * sizeof(t_ast_node));
-			if (!parena()->on)
-				parena_note_attach();
-			if (v->len > 0)
-				ft_memcpy(nb, v->ctx, v->len * sizeof(t_ast_node));
-			parena_free(v->ctx);
-			v->ctx = nb;
-		}
-	}
+		ast_children_grow(v);
 	ft_memcpy((char *)v->ctx + v->len * sizeof(t_ast_node),
 		child, sizeof(t_ast_node));
 	v->len++;

--- a/src/infrastructure/prompt_git3.c
+++ b/src/infrastructure/prompt_git3.c
@@ -6,7 +6,7 @@
 /*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/07/21 00:00:00 by dlesieur          #+#    #+#             */
-/*   Updated: 2026/07/21 00:00:00 by dlesieur         ###   ########.fr       */
+/*   Updated: 2026/07/28 00:00:00 by dlesieur         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,16 +14,16 @@
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <errno.h>
+#include <poll.h>
+#include <signal.h>
 
-/* TTL cache for the dirty check: one git subprocess at most every 3s of
-   prompting, keyed on the repo root. */
-typedef struct s_dcache
-{
-	char	root[PATH_MAX];
-	time_t	at;
-	int		dirty;
-	int		init;
-}	t_dcache;
+/* Async dirty check. The prompt must NEVER wait for git: on a huge repo
+   `git status` stats every tracked file and can take seconds, and the old
+   blocking read froze the first prompt after every cd (and every TTL
+   refresh) for the whole scan. Now a freshly entered repo gets one small
+   bounded wait (fast repos keep their exact star); past that the child
+   keeps running and a later render harvests it from the pipe — the star
+   arrives a render late instead of the prompt arriving seconds late. */
 
 /* Child body: stdout into the pipe, stderr silenced, then git status.
    --no-optional-locks keeps git from touching .git/index behind the
@@ -44,46 +44,114 @@ static void	dirty_child(int *fd, const char *root)
 		close(nul);
 	}
 	execlp("git", "git", "-C", root, "--no-optional-locks", "status",
-		"--porcelain", "-uno", (char *)NULL);
+		"--porcelain", "-uno", NULL);
 	_exit(127);
 }
 
-/* Any output byte at all means the tree is dirty — we never need the rest,
-   so read exactly one byte and reap. A missing git (exec fails, 0 bytes)
-   degrades to "clean" rather than an error in the prompt. */
-static int	run_git_check(const char *root)
+/* Fork the checker for c->root. The read end is non-blocking (harvest
+   polls must never stall a render) and cloexec (it outlives this call, so
+   command children forked while the check runs must not inherit it). */
+static void	spawn_check(t_dcache *c)
 {
-	int		fd[2];
-	pid_t	pid;
-	ssize_t	n;
-	char	c;
+	int	fd[2];
 
+	c->pid = 0;
 	if (pipe(fd) != 0)
-		return (0);
-	pid = fork();
-	if (pid == 0)
-		dirty_child(fd, root);
+		return ;
+	c->pid = fork();
+	if (c->pid == 0)
+		dirty_child(fd, c->root);
 	close(fd[1]);
-	n = 0;
-	if (pid > 0)
-		n = read(fd[0], &c, 1);
-	close(fd[0]);
-	while (pid > 0 && waitpid(pid, NULL, 0) < 0 && errno == EINTR)
-		continue ;
-	return (n > 0);
+	if (c->pid < 0)
+	{
+		c->pid = 0;
+		close(fd[0]);
+		return ;
+	}
+	c->fd = fd[0];
+	fcntl(c->fd, F_SETFL, O_NONBLOCK);
+	fcntl(c->fd, F_SETFD, FD_CLOEXEC);
+	c->spawned = time(NULL);
 }
 
+/* Retire the in-flight child (SIGKILL first when abandoning it — e.g. a
+   cd to another repo — so the reap cannot block on a live scan). Returns
+   the raw wait status, or -1 when someone else already reaped it: the
+   background-job WNOHANG loop does waitpid(-1) and may win the race. */
+static int	drop_check(t_dcache *c, int killit)
+{
+	int	st;
+	int	r;
+
+	if (killit)
+		kill(c->pid, SIGKILL);
+	close(c->fd);
+	r = waitpid(c->pid, &st, 0);
+	while (r < 0 && errno == EINTR)
+		r = waitpid(c->pid, &st, 0);
+	c->pid = 0;
+	if (r < 0)
+		return (-1);
+	return (st);
+}
+
+/* Harvest attempt with a wait budget. Any output byte means dirty; EOF
+   with none means clean. A child that died on a signal (Ctrl-C at the
+   prompt reaches it — same process group) proved nothing: drop the
+   sample and let the stale c->at trigger a fresh spawn next render.
+   Slow repos (scan >= 1s) stretch the TTL so git is not re-run near
+   continuously; the checks are async either way. */
+static int	poll_done(t_dcache *c, int wait_ms)
+{
+	struct pollfd	p;
+	ssize_t			n;
+	int				st;
+	char			ch;
+
+	p.fd = c->fd;
+	p.events = POLLIN;
+	if (poll(&p, 1, wait_ms) <= 0)
+		return (0);
+	n = read(c->fd, &ch, 1);
+	if (n < 0)
+		return (0);
+	st = drop_check(c, 0);
+	if (st != -1 && WIFSIGNALED(st))
+		return (1);
+	c->dirty = (n > 0);
+	c->at = time(NULL);
+	c->ttl = 3;
+	if (c->at - c->spawned >= 1)
+		c->ttl = 30;
+	return (1);
+}
+
+/* Non-blocking dirty flag for the repo rooted at `root`. A change of root
+   abandons any in-flight check (its answer is for a repo we left). Only a
+   freshly entered root gets a bounded wait — TTL refreshes poll with a
+   zero budget, so a render never stalls once the shell is inside a repo. */
 int	git_dirty_cached(const char *root)
 {
 	static t_dcache	c;
-	time_t			now;
+	int				wait_ms;
 
-	now = time(NULL);
-	if (c.init && now - c.at < 3 && ft_strcmp(c.root, root) == 0)
+	if (c.pid > 0 && ft_strcmp(c.root, root) != 0)
+		drop_check(&c, 1);
+	if (c.pid > 0)
+		return (poll_done(&c, 0), c.dirty);
+	if (c.init && ft_strcmp(c.root, root) == 0
+		&& time(NULL) - c.at < c.ttl)
 		return (c.dirty);
+	wait_ms = 0;
+	if (ft_strcmp(c.root, root) != 0)
+	{
+		wait_ms = 60;
+		c.dirty = 0;
+	}
 	c.init = 1;
-	c.at = now;
 	ft_strlcpy(c.root, root, sizeof(c.root));
-	c.dirty = run_git_check(root);
+	spawn_check(&c);
+	if (c.pid > 0)
+		poll_done(&c, wait_ms);
 	return (c.dirty);
 }

--- a/src/infrastructure/prompt_private.h
+++ b/src/infrastructure/prompt_private.h
@@ -102,6 +102,21 @@ typedef struct s_gitloc
 	int		init;
 }	t_gitloc;
 
+/* State of the async dirty check: the cached answer for `root` (valid for
+   `ttl` seconds past `at`) plus the in-flight `git status` child, if any
+   (pid > 0, `fd` its non-blocking read end, forked at `spawned`). */
+typedef struct s_dcache
+{
+	char	root[PATH_MAX];
+	time_t	at;
+	time_t	ttl;
+	time_t	spawned;
+	pid_t	pid;
+	int		fd;
+	int		dirty;
+	int		init;
+}	t_dcache;
+
 void		vec_push_ansi(t_string *v, const char *seq);
 int			get_cols(void);
 int			measure_width(const char *str);

--- a/src/infrastructure/prompt_utils.c
+++ b/src/infrastructure/prompt_utils.c
@@ -72,9 +72,10 @@ void	prompt_user_and_cwd(t_string *ret, t_prompt *p)
 }
 
 /* Append " on <branch>" when inside a git repo, plus an amber "*" when the
-   working tree has tracked modifications (git_dirty_cached — a TTL-throttled
-   `git status -uno`, so the star is at most 3s stale and costs nothing on
-   the prompts in between). Branch names count display columns, not bytes. */
+   working tree has tracked modifications (git_dirty_cached — an async,
+   TTL-throttled `git status -uno`: the render never waits for the scan, so
+   on a huge repo the star may arrive a render late rather than the prompt
+   arriving seconds late). Branch names count display columns, not bytes. */
 void	prompt_branch(t_string *ret, t_prompt *p)
 {
 	p->branch = NULL;

--- a/src/lexer/keywords2.c
+++ b/src/lexer/keywords2.c
@@ -54,10 +54,10 @@ static bool	step_token(t_ltoken *t, bool *cmd_pos,
    `in` is handled separately by the parser, not here. */
 void	reclassify_keywords(t_deque_tok *tokens)
 {
-	size_t	i;
+	size_t		i;
 	t_ltoken	*t;
-	bool	cmd_pos;
-	bool	flags[3];
+	bool		cmd_pos;
+	bool		flags[3];
 
 	cmd_pos = true;
 	flags[0] = false;

--- a/src/parsing/parse_array.c
+++ b/src/parsing/parse_array.c
@@ -40,14 +40,38 @@ static bool	is_array_assign_start(t_token *w, t_ltoken *open, char *base)
 	return (is_valid_ident(w->start, n));
 }
 
+/* Consume the element words up to the closing ')'. Each element is a
+   normal AST_WORD that the reparse pass refines like any other word.
+   Newlines inside the parens are separators (bash allows multi-line
+   arrays); end of input inside the parens asks for more; anything else
+   before the closing brace is a syntax error. */
+static void	collect_array_elems(t_parser *parser, t_deque_tok *tokens,
+				t_ast_node *node)
+{
+	t_token	curr;
+
+	curr = ltok2tok(*(t_ltoken *)deque_peek(&tokens->deqtok), tokens->base);
+	while (curr.tt == TT_WORD || curr.tt == TT_NEWLINE)
+	{
+		if (curr.tt == TT_WORD)
+			push_parsed_word(tokens, node);
+		else
+			(void)deque_pop_start(&tokens->deqtok);
+		curr = ltok2tok(*(t_ltoken *)deque_peek(&tokens->deqtok), tokens->base);
+	}
+	if (curr.tt == TT_BRACE_RIGHT)
+		(void)deque_pop_start(&tokens->deqtok);
+	else if (curr.tt == TT_END)
+		parser->res = RES_GETMOREINPUT;
+	else
+		parser->res = RES_ERR;
+}
+
 /* Try to consume WORD=( word... ) from the stream into an
    AST_ARRAY_ASSIGN node: child[0] is the raw key token (kept with its
    trailing '=' or '+=' so the expander can see the append flag), the
-   rest are the element words, each a normal AST_WORD that the reparse
-   pass refines like any other word. Newlines inside the parens are
-   separators (bash allows multi-line arrays); end of input inside the
-   parens asks for more. Returns false when the shape does not match and
-   the caller should treat the word normally. */
+   rest are the element words. Returns false when the shape does not
+   match and the caller should treat the word normally. */
 bool	try_push_array_assign(t_parser *parser, t_deque_tok *tokens,
 			t_ast_node *ret)
 {
@@ -63,20 +87,6 @@ bool	try_push_array_assign(t_parser *parser, t_deque_tok *tokens,
 	node.children.elem_size = sizeof(t_ast_node);
 	add_op_token_child(&node, pop_tok(tokens));
 	(void)deque_pop_start(&tokens->deqtok);
-	curr = ltok2tok(*(t_ltoken *)deque_peek(&tokens->deqtok), tokens->base);
-	while (curr.tt == TT_WORD || curr.tt == TT_NEWLINE)
-	{
-		if (curr.tt == TT_WORD)
-			push_parsed_word(tokens, &node);
-		else
-			(void)deque_pop_start(&tokens->deqtok);
-		curr = ltok2tok(*(t_ltoken *)deque_peek(&tokens->deqtok), tokens->base);
-	}
-	if (curr.tt == TT_BRACE_RIGHT)
-		(void)deque_pop_start(&tokens->deqtok);
-	else if (curr.tt == TT_END)
-		parser->res = RES_GETMOREINPUT;
-	else
-		parser->res = RES_ERR;
+	collect_array_elems(parser, tokens, &node);
 	return (ast_push_child(ret, &node), true);
 }

--- a/src/parsing/parse_for.c
+++ b/src/parsing/parse_for.c
@@ -71,7 +71,7 @@ static void	collect_word_list(t_deque_tok *tokens, t_ast_node *ret)
 static bool	parse_for_in_clause(t_shell *state, t_parser *parser,
 								t_deque_tok *tokens, t_ast_node *ret)
 {
-	t_tt	next;
+	t_tt		next;
 	t_ltoken	*peek;
 
 	(void)state;

--- a/src/parsing/parser_private.h
+++ b/src/parsing/parser_private.h
@@ -47,7 +47,7 @@ t_ast_node	parse_pipeline(t_shell *state,
 				t_parser *parser,
 				t_deque_tok *tokens);
 bool		try_push_array_assign(t_parser *parser, t_deque_tok *tokens,
-			t_ast_node *ret);
+				t_ast_node *ret);
 t_ast_node	parse_tokens(t_shell *state,
 				t_parser *parser,
 				t_deque_tok *tokens);

--- a/src/word_splitting/reparse_assign_words.c
+++ b/src/word_splitting/reparse_assign_words.c
@@ -16,7 +16,7 @@
    node has no children or the first child is not a plain AST_TOKEN. This is
    where we verify the shape is what we expect before mutating it; bailing out
    on unexpected shapes avoids crashes on malformed ASTs during fuzzing. */
-static t_token	*get_first_token_ptr(t_ast_node *word)
+t_token	*get_first_token_ptr(t_ast_node *word)
 {
 	if (!word->children.ctx || word->children.len == 0)
 		return (NULL);
@@ -29,7 +29,7 @@ static t_token	*get_first_token_ptr(t_ast_node *word)
    or if the token is empty/NULL. We use ft_strnchr (bounded search) rather
    than strchr because tok->start is not necessarily NUL-terminated -- it is a
    slice into the raw input buffer. */
-static int	find_eq_pos(t_token *tok)
+int	find_eq_pos(t_token *tok)
 {
 	char	*eq;
 
@@ -48,8 +48,8 @@ static int	find_eq_pos(t_token *tok)
    original raw text is not duplicated -- everything still points into the
    same input buffer. This is the cheapest correct way to split KEY=val
    without re-allocating the token strings. */
-static void	apply_assignment_split(t_ast_node *word,
-				t_token *first_token, int eq_pos)
+void	apply_assignment_split(t_ast_node *word,
+			t_token *first_token, int eq_pos)
 {
 	t_ast_node	new_root;
 
@@ -67,7 +67,7 @@ static void	apply_assignment_split(t_ast_node *word,
 /* NAME[subscript] as an assignment left side: a valid identifier, an
    opening bracket, anything (an arithmetic expression) and the closing
    bracket exactly at the end — arr[i+1]=v assigns an array element. */
-static bool	is_subscript_key(char *s, int len)
+bool	is_subscript_key(char *s, int len)
 {
 	int	i;
 
@@ -82,101 +82,9 @@ static bool	is_subscript_key(char *s, int len)
 /* NAME+=value: a valid identifier (or NAME[sub]) followed by '+='. The
    append is applied at assignment time (assignment_to_env sees the
    trailing '+' on the key). */
-static bool	is_append_key(char *s, int len)
+bool	is_append_key(char *s, int len)
 {
 	if (len < 2 || s[len - 1] != '+')
 		return (false);
 	return (is_valid_ident(s, len - 1) || is_subscript_key(s, len - 1));
-}
-
-/* Attempt to re-classify one AST_WORD as an AST_ASSIGNMENT_WORD if it
-   matches the pattern IDENT=value (or IDENT[expr]=value for an array
-   element). Guard order matters: we check tt, then the '=' exists, then
-   the left side is valid -- all must pass before we mutate the node.
-   Early returns on any failure leave the node unchanged so normal word
-   expansion picks it up. */
-void	reparse_assignment_word(t_ast_node *word)
-{
-	t_token	*first_token;
-	int		eq_pos;
-
-	first_token = get_first_token_ptr(word);
-	if (!first_token)
-		return ;
-	if (first_token->tt != TT_WORD)
-		return ;
-	if (!first_token->start || first_token->len <= 0)
-		return ;
-	eq_pos = find_eq_pos(first_token);
-	if (eq_pos < 0)
-		return ;
-	if (!is_valid_ident(first_token->start, eq_pos)
-		&& !is_subscript_key(first_token->start, eq_pos)
-		&& !is_append_key(first_token->start, eq_pos))
-		return ;
-	apply_assignment_split(word, first_token, eq_pos);
-}
-
-/* Pre-pass (runs BEFORE reparse_words): a raw word matching NAME[...]=value
-   is classified as an assignment while still a single token, so a '$' in
-   the subscript (a[$i]=x, h[$key]=v) does not split the word out from
-   under the classifier. Only words with a '[' before the '=' are touched;
-   plain NAME=value is left to the normal post-split pass. subscript_assign
-   later expands the raw subscript (arith for indexed, param for assoc). */
-static void	subscript_assign_word(t_ast_node *word)
-{
-	t_token	*ft;
-	int		eq;
-
-	ft = get_first_token_ptr(word);
-	if (!ft || ft->tt != TT_WORD || !ft->start || ft->len <= 0)
-		return ;
-	eq = find_eq_pos(ft);
-	if (eq < 1 || !is_subscript_key(ft->start, eq))
-		return ;
-	if (!ft_strnchr(ft->start, '[', eq))
-		return ;
-	apply_assignment_split(word, ft, eq);
-}
-
-void	reparse_subscript_assigns(t_ast_node *node)
-{
-	size_t	i;
-
-	if (!node->children.ctx)
-		return ;
-	if (node->node_type == AST_PROC_SUB)
-		return ;
-	if (node->node_type != AST_REDIRECT)
-	{
-		i = 0;
-		while (i < node->children.len)
-			reparse_subscript_assigns(
-				&((t_ast_node *)node->children.ctx)[i++]);
-	}
-	if (node->node_type == AST_WORD)
-		subscript_assign_word(node);
-}
-
-/* Recursively walk the AST and promote eligible word nodes to assignment
-   words. We skip AST_REDIRECT subtrees (the filename in `>foo=bar` is not an
-   assignment) and AST_PROC_SUB bodies (they are their own shell context).
-   Every AST_WORD leaf gets tried last, after its children have been walked,
-   matching the depth-first order that the POSIX spec implies. */
-void	reparse_assignment_words(t_ast_node *node)
-{
-	size_t	i;
-
-	if (!node->children.ctx)
-		return ;
-	if (node->node_type == AST_PROC_SUB)
-		return ;
-	if (node->node_type != AST_REDIRECT)
-	{
-		i = 0;
-		while (i < node->children.len)
-			reparse_assignment_words(&((t_ast_node *)node->children.ctx)[i++]);
-	}
-	if (node->node_type == AST_WORD)
-		reparse_assignment_word(node);
 }

--- a/src/word_splitting/reparse_assign_words2.c
+++ b/src/word_splitting/reparse_assign_words2.c
@@ -1,0 +1,112 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   reparse_assign_words2.c                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/01/20 22:08:37 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/01/20 23:44:28 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "reparser_private.h"
+
+t_token	*get_first_token_ptr(t_ast_node *word);
+int		find_eq_pos(t_token *tok);
+void	apply_assignment_split(t_ast_node *word, t_token *first_token,
+			int eq_pos);
+bool	is_subscript_key(char *s, int len);
+bool	is_append_key(char *s, int len);
+
+/* Attempt to re-classify one AST_WORD as an AST_ASSIGNMENT_WORD if it
+   matches the pattern IDENT=value (or IDENT[expr]=value for an array
+   element). Guard order matters: we check tt, then the '=' exists, then
+   the left side is valid -- all must pass before we mutate the node.
+   Early returns on any failure leave the node unchanged so normal word
+   expansion picks it up. */
+void	reparse_assignment_word(t_ast_node *word)
+{
+	t_token	*first_token;
+	int		eq_pos;
+
+	first_token = get_first_token_ptr(word);
+	if (!first_token)
+		return ;
+	if (first_token->tt != TT_WORD)
+		return ;
+	if (!first_token->start || first_token->len <= 0)
+		return ;
+	eq_pos = find_eq_pos(first_token);
+	if (eq_pos < 0)
+		return ;
+	if (!is_valid_ident(first_token->start, eq_pos)
+		&& !is_subscript_key(first_token->start, eq_pos)
+		&& !is_append_key(first_token->start, eq_pos))
+		return ;
+	apply_assignment_split(word, first_token, eq_pos);
+}
+
+/* Pre-pass (runs BEFORE reparse_words): a raw word matching NAME[...]=value
+   is classified as an assignment while still a single token, so a '$' in
+   the subscript (a[$i]=x, h[$key]=v) does not split the word out from
+   under the classifier. Only words with a '[' before the '=' are touched;
+   plain NAME=value is left to the normal post-split pass. subscript_assign
+   later expands the raw subscript (arith for indexed, param for assoc). */
+static void	subscript_assign_word(t_ast_node *word)
+{
+	t_token	*ft;
+	int		eq;
+
+	ft = get_first_token_ptr(word);
+	if (!ft || ft->tt != TT_WORD || !ft->start || ft->len <= 0)
+		return ;
+	eq = find_eq_pos(ft);
+	if (eq < 1 || !is_subscript_key(ft->start, eq))
+		return ;
+	if (!ft_strnchr(ft->start, '[', eq))
+		return ;
+	apply_assignment_split(word, ft, eq);
+}
+
+void	reparse_subscript_assigns(t_ast_node *node)
+{
+	size_t	i;
+
+	if (!node->children.ctx)
+		return ;
+	if (node->node_type == AST_PROC_SUB)
+		return ;
+	if (node->node_type != AST_REDIRECT)
+	{
+		i = 0;
+		while (i < node->children.len)
+			reparse_subscript_assigns(
+				&((t_ast_node *)node->children.ctx)[i++]);
+	}
+	if (node->node_type == AST_WORD)
+		subscript_assign_word(node);
+}
+
+/* Recursively walk the AST and promote eligible word nodes to assignment
+   words. We skip AST_REDIRECT subtrees (the filename in `>foo=bar` is not an
+   assignment) and AST_PROC_SUB bodies (they are their own shell context).
+   Every AST_WORD leaf gets tried last, after its children have been walked,
+   matching the depth-first order that the POSIX spec implies. */
+void	reparse_assignment_words(t_ast_node *node)
+{
+	size_t	i;
+
+	if (!node->children.ctx)
+		return ;
+	if (node->node_type == AST_PROC_SUB)
+		return ;
+	if (node->node_type != AST_REDIRECT)
+	{
+		i = 0;
+		while (i < node->children.len)
+			reparse_assignment_words(&((t_ast_node *)node->children.ctx)[i++]);
+	}
+	if (node->node_type == AST_WORD)
+		reparse_assignment_word(node);
+}

--- a/src/word_splitting/reparse_dquote.c
+++ b/src/word_splitting/reparse_dquote.c
@@ -52,7 +52,13 @@ static int	process_dquote_char_rp(t_reparser *rp, bool *pushed_any)
    special is dispatched. The pushed_any flag catches the empty-string edge
    case: "" must still produce a TT_DQWORD subtoken (zero-length) so the
    expander knows the field exists rather than being absent entirely -- that
-   distinction matters for `set -- "" foo`, where $1 must be the empty str. */
+   distinction matters for `set -- "" foo`, where $1 must be the empty str.
+   Operand order in the closing DQ-FAIL debug check is deliberate. It runs
+   once per double-quoted word, and glibc's getenv is a linear walk of
+   environ doing a strncmp per entry -- putting it first cost 5% of every
+   parse to prove a debug flag was unset. The byte test is the
+   discriminating one and is false in every non-broken case, so it goes
+   first; both operands are pure, so the short-circuit is a pure win. */
 void	reparse_dquote(t_ast_node *ret, int *i, t_token t)
 {
 	t_reparser	rp;
@@ -71,12 +77,6 @@ void	reparse_dquote(t_ast_node *ret, int *i, t_token t)
 	flush_pending_segment_rp(&rp, &pushed_any);
 	if (!pushed_any)
 		push_dqword_subtoken_rp(&rp, rp.i, rp.i);
-	/* Operand order below is deliberate. This runs once per double-quoted
-	   word, and glibc's getenv is a linear walk of environ doing a strncmp
-	   per entry -- putting it first cost 5% of every parse to prove a debug
-	   flag was unset. The byte test is the discriminating one and is false
-	   in every non-broken case, so it goes first; both operands are pure, so
-	   the short-circuit is a pure win. */
 	if (rp.current_token.start[rp.i] != '"'
 		&& getenv("HELLISH_DBG_DQ"))
 		fprintf(stderr, "[DQ-FAIL i=%d len=%d tok=<<%.*s>>]\n",

--- a/tests/git_prompt_stall_test.py
+++ b/tests/git_prompt_stall_test.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Regression test: the git dirty check must never block the prompt.
+
+Guards the async dirty check in prompt_git3.c. The original run_git_check
+forked `git status --porcelain -uno` and then blocked in read()+waitpid()
+until the whole scan finished: cd into a repo where git status takes
+seconds froze the first prompt for the full scan (the "cd is slow" bug),
+and again on every 3s TTL refresh. The check now waits a perception-bound
+slice for a freshly entered repo and otherwise finishes in the background,
+harvested by a later render — bash-instant prompts, star at most one
+render late.
+
+Checks, in a real pty, default two-row prompt (PS1 unset):
+  1. With a `git` shim sleeping 2s, cd into a repo prompts fast
+     (well under the shim delay) instead of after the scan.
+  2. A later prompt in that repo is also fast, and the star the
+     background scan found has arrived by then (async harvest).
+  3. With real git, cd into a repo with tracked modifications still
+     shows the amber star (bounded wait keeps normal repos exact).
+  4. After the TTL expires there, the refresh keeps the prompt fast
+     and keeps showing the last known star while it re-checks.
+  5. A clean repo shows its branch and no star.
+
+Usage: python3 git_prompt_stall_test.py /path/to/hellish
+"""
+import os
+import pty
+import select
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import fcntl
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "../build/bin/hellish")
+GIT = shutil.which("git") or "/usr/bin/git"
+BOX = "╭".encode()  # one per default-prompt render
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name
+          + (" " + detail if not ok else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+class Session:
+    def __init__(self, home, cwd, path):
+        env = {
+            "HOME": home, "PATH": path,
+            "TERM": "xterm-256color", "LANG": "C.UTF-8",
+            "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+            "HELLISH_NO_ANIM": "1",
+            "ASAN_OPTIONS": "detect_leaks=0",
+        }
+        os.makedirs(os.path.join(home, ".cache", "hellish"), exist_ok=True)
+        open(os.path.join(home, ".cache", "hellish", "seen"), "w").close()
+        self.raw = b""
+        self.pid, self.fd = pty.fork()
+        if self.pid == 0:
+            os.chdir(cwd)
+            os.environ.clear()
+            os.environ.update(env)
+            os.execvp(SHELL, [SHELL])
+            os._exit(127)
+        fcntl.ioctl(self.fd, termios.TIOCSWINSZ,
+                    struct.pack("HHHH", 24, 100, 0, 0))
+
+    def drain(self, t=0.35):
+        end = time.time() + t
+        while time.time() < end:
+            r, _, _ = select.select([self.fd], [], [], 0.08)
+            if r:
+                try:
+                    self.raw += os.read(self.fd, 65536)
+                except OSError:
+                    return
+
+    def prompt_latency(self, data, timeout=10.0):
+        """Send data; seconds until the NEXT prompt render, or None."""
+        n0 = self.raw.count(BOX)
+        t0 = time.monotonic()
+        os.write(self.fd, data)
+        while time.monotonic() - t0 < timeout:
+            r, _, _ = select.select([self.fd], [], [], 0.02)
+            if not r:
+                continue
+            try:
+                self.raw += os.read(self.fd, 65536)
+            except OSError:
+                return None
+            if self.raw.count(BOX) > n0:
+                return time.monotonic() - t0
+        return None
+
+    def close(self):
+        try:
+            os.write(self.fd, b"\x04")
+            self.drain(0.3)
+            os.kill(self.pid, 9)
+        except OSError:
+            pass
+        os.waitpid(self.pid, 0)
+
+
+def make_repo(base, name, dirty):
+    d = os.path.join(base, name)
+    os.makedirs(d)
+    env = {"PATH": os.environ["PATH"], "HOME": base,
+           "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
+    run = lambda *a: subprocess.run(
+        [GIT, "-C", d] + list(a), env=env, check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    run("init", "-q", "-b", "main")
+    open(os.path.join(d, "f.txt"), "w").write("x\n")
+    run("add", "f.txt")
+    run("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "i")
+    if dirty:
+        open(os.path.join(d, "f.txt"), "a").write("y\n")
+    return d
+
+
+def main():
+    base = tempfile.mkdtemp(prefix="hellish_gitprompt_")
+    work = os.path.join(base, "work")
+    os.makedirs(work)
+    shim = os.path.join(base, "gitshim")
+    os.makedirs(shim)
+    with open(os.path.join(shim, "git"), "w") as f:
+        f.write("#!/bin/sh\nsleep 2\nexec %s \"$@\"\n" % GIT)
+    os.chmod(os.path.join(shim, "git"), 0o755)
+    slow = make_repo(base, "slow_repo", dirty=True)
+    dirty = make_repo(base, "dirty_repo", dirty=True)
+    clean = make_repo(base, "clean_repo", dirty=False)
+
+    # 1+2: a repo where git status takes 2s must not delay the prompt;
+    # the answer it eventually finds shows up on a later render
+    s = Session(base, work, shim + ":" + os.environ["PATH"])
+    s.prompt_latency(b"")
+    s.drain(0.4)
+    lat = s.prompt_latency(("cd %s\n" % slow).encode())
+    check("cd into slow-git repo prompts fast",
+          lat is not None and lat < 1.0, "latency=%s" % lat)
+    s.drain(2.6)  # background scan finishes during this idle
+    n0 = len(s.raw)
+    lat = s.prompt_latency(b"\n")
+    check("later prompt in slow repo stays fast",
+          lat is not None and lat < 1.0, "latency=%s" % lat)
+    s.drain(0.4)
+    check("slow repo star arrives async", b"*" in s.raw[n0:])
+    s.close()
+
+    # 3: normal-speed repo with tracked modifications still gets the star
+    s = Session(base, work, os.environ["PATH"])
+    s.prompt_latency(b"")
+    s.drain(0.4)
+    n0 = len(s.raw)
+    lat = s.prompt_latency(("cd %s\n" % dirty).encode())
+    s.drain(0.4)
+    win = s.raw[n0:]
+    check("dirty repo shows branch", b"on\x1b[0m" in win and b"main" in win)
+    check("dirty repo shows star", b"*" in win)
+
+    # 4: TTL refresh re-spawns with a zero budget: fast prompt, stale
+    # star kept while the fresh answer is pending
+    s.drain(3.2)  # let the 3s TTL expire
+    n0 = len(s.raw)
+    lat = s.prompt_latency(b"\n")
+    check("TTL refresh never blocks the prompt",
+          lat is not None and lat < 1.0, "latency=%s" % lat)
+    s.drain(0.4)
+    check("TTL refresh keeps last known star", b"*" in s.raw[n0:])
+
+    # 5: clean repo shows the branch and no star
+    n0 = len(s.raw)
+    s.prompt_latency(("cd %s\n" % clean).encode())
+    s.drain(0.4)
+    win = s.raw[n0:]
+    check("clean repo shows branch", b"on\x1b[0m" in win and b"main" in win)
+    check("clean repo shows no star", b"*" not in win)
+    s.close()
+
+    shutil.rmtree(base, ignore_errors=True)
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()


### PR DESCRIPTION
Gets every CI job green. Three independent root causes, plus two latent bugs found on the way:

## Why CI was red

1. **42 Norm** — norminette 3.3.59 reported **120 errors across ~60 files**, accumulated invisibly because `make norm` no-ops on hosts without norminette while CI enforces it. Fixed by a behavior-preserving refactor sweep (function splits, file rebalancing, ternary/arg-count/local-count fixes, header cleanups). Full suite stays 3051/3051.
2. **Build · opt SAFE=0 (ft_malloc)** — libft declares ft_malloc `update = none`, so `submodules: recursive` never fetches it; libft silently built its libc fallback and the link died on the force-bound `malloc_live_bytes`. The Makefile now materialises ft_malloc (`--checkout`) whenever SAFE=0 needs it. Root cause was compounded by a libft bug where **every build moved `.gitmodules` into the build tree and fclean deleted it** — fixed in libft, pointer bumped here.
3. **Tests** — the suite diffed hellish against the runner's bash **5.2**, while the project tracks **5.3**: ~30 phantom failures from oracle skew. The Tests job now builds and caches a pinned **bash 5.3.9** oracle. Two residual cases (`echo $SHELL` in scrubbed envs) exposed a real gap: hellish now synthesises `$SHELL` from passwd like bash (absent-only, un-exported).

## Latent bugs fixed along the way

- **Forked exec children ran LSan on exit**: after a failed `execve`, the child exited via `exit()`, letting the leak check scan half-execution state inherited at `fork()`. Layout-dependent, and its error status clobbered 126/127. The child now `_exit`s.
- **libft `slab_free` guessed ownership by span+magic**: a foreign heap pointer in a chunk gap could be silently dropped (leak) or corrupt a freelist. Now proves ownership per chunk via `slab_get_block_at_ptr`.
- Bonus from the same session: the prompt's git dirty check no longer blocks on `git status` — `cd` into huge repos went from multi-second prompt stalls to instant (new pty gate: `make git-prompt-test`).

## Verification

- `make test`: **3051/3051** vs bash --posix (host, bash 5.3.9)
- ubuntu-24.04 container with the pinned oracle: full suite green
- `verify_alloc.sh`: both heaps, output parity, 0 leaks / flat live-bytes
- norminette 3.3.59 over `src incs`: **0 errors**
- `make` and `make OPT=1` both build; pty gates (`git-prompt-test`, `hist-test`, `readline-test`, `anim-test`) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
