### PR TITLE
fix: git-prompt zombies, job-control terminal wedge, printf length modifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,6 +578,14 @@ anim-test: all
 git-prompt-test: all
 	@python3 $(TEST_DIR)/git_prompt_stall_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
+# Background jobs and the controlling terminal. POSIX only redirects an
+# async list's stdin to /dev/null when job control is DISABLED; doing it
+# unconditionally broke `top &` interactively ("top: failed tty get")
+# instead of letting it stop on SIGTTOU the way bash does. Compares
+# against bash directly, so it also notices if bash changes its mind.
+bg-tty-test: all
+	@python3 $(TEST_DIR)/bg_tty_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
+
 # Release/update configuration, checked offline: the GitHub slug baked into
 # version.h must match the repository we actually push to, every
 # distribution channel (install.sh, npm, Dockerfile, docs) must agree with
@@ -673,6 +681,7 @@ geoman: all
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
 	docker-arch docker-clean cd-zsh-test cd-posix-test agnostic-bench \
 	hist-test readline-test anim-test git-prompt-test prompt-atomic-test \
+	bg-tty-test \
 	update-config-test update-test help-test \
 	conformance perf rss \
 	charts cli-opts-test net-redir-test login-test geoman oracle docker-suite docker widechar-test \

--- a/incs/public/signals.h
+++ b/incs/public/signals.h
@@ -24,13 +24,43 @@
 # include <signal.h>
 # include <stdint.h>
 
-/* Restore both SIGINT and SIGQUIT to default kernel action.  Called in
-   the child just before execve so the new program starts with clean
-   signal dispositions (its own handlers, not ours). */
+/* Restore the job-control and interrupt signals to their default kernel
+   action.  Called in the child just before execve so the new program starts
+   with clean dispositions (its own handlers, not ours).
+
+   SIGTSTP/SIGTTIN/SIGTTOU matter here because the interactive shell now
+   ignores them (see interactive_job_signals): SIG_IGN survives execve, so
+   without this reset every command the shell launched would inherit "^Z
+   does nothing" and could never be suspended.  A background child re-ignores
+   them right after calling us -- see bg_child_body. */
 static inline void	default_signal_handlers(void)
 {
 	signal(SIGINT, SIG_DFL);
 	signal(SIGQUIT, SIG_DFL);
+	signal(SIGTSTP, SIG_DFL);
+	signal(SIGTTIN, SIG_DFL);
+	signal(SIGTTOU, SIG_DFL);
+}
+
+/* Job-control signals for the SHELL PROCESS, interactive only.  A shell must
+   not stop when the user hits ^Z: the terminal sends SIGTSTP to the whole
+   foreground process group, which contains the shell as well as the command
+   it is waiting on, so a shell at SIG_DFL suspends itself along with the job.
+   That is what hellish did -- ^Z froze the shell instead of the command, and
+   with no outer shell to return to the terminal simply went dead while the
+   kernel kept echoing whatever was typed (issue #25).
+
+   SIGTTIN/SIGTTOU likewise: the shell reads and writes the terminal from a
+   process group that is not always the foreground one, and stopping there
+   would wedge it in the same way.  Scripts and -c keep the defaults, so a
+   non-interactive shell stays killable exactly as before. */
+static inline void	interactive_job_signals(int interactive)
+{
+	if (!interactive)
+		return ;
+	signal(SIGTSTP, SIG_IGN);
+	signal(SIGTTIN, SIG_IGN);
+	signal(SIGTTOU, SIG_IGN);
 }
 
 /* Signal setup for the readline read loop: SIGINT propagates to children

--- a/src/builtins/builtin_printf2.c
+++ b/src/builtins/builtin_printf2.c
@@ -32,7 +32,16 @@ static void	pf_bad_fmt(t_pf *pf, char c)
 /* Single pass through the format string: handle backslash escapes (passed
    to pf_escape with no stop channel — bash honours \c only inside %b
    arguments), % conversions (parse spec, then pf_conv), and literal
-   characters. pf->stop aborts both this pass and the outer loop in
+   characters.
+
+   Length modifiers (l, ll, h, hh, j, z, t, L) are skipped and discarded
+   between the spec and the conversion byte. bash accepts them and ignores
+   them -- it renders every integer through intmax_t, so `printf %hd 70000`
+   prints 70000 there rather than truncating to a short. We used to stop at
+   the modifier instead and report "`%l': invalid format character", which
+   broke every C-habit format string a user brought with them.
+
+   pf->stop aborts both this pass and the outer loop in
    builtin_printf immediately: it is set by \c inside a %b argument, or by
    a bad directive (which also sets err so the builtin exits 1). */
 static void	run_format(t_pf *pf, const char *fmt)
@@ -49,6 +58,8 @@ static void	run_format(t_pf *pf, const char *fmt)
 		{
 			i++;
 			pf_parse_spec(pf, fmt, &i, &sp);
+			while (fmt[i] && ft_strchr("lhjztL", fmt[i]))
+				i++;
 			if (!fmt[i] || !ft_strchr("diouxXeEfgGaAcsb%", fmt[i]))
 				return (pf_bad_fmt(pf, fmt[i]));
 			pf_conv(pf, &sp, fmt[i]);

--- a/src/core/on.c
+++ b/src/core/on.c
@@ -55,7 +55,9 @@ static void	cli_early_exit(t_shell *state, char **argv, t_cli *cli)
 /* Zero-initialise every table that survives across commands: redirect list,
    process-sub tracking, shell-function list, job table, alias table, and the
    command-hash cache. All use a consistent "zero-length vec" starting point
-   so any early-exit path can safely call free/cleanup on them. */
+   so any early-exit path can safely call free/cleanup on them. The line
+   editor's default mode rides along: it is the same kind of "state that
+   outlives one command", and on() is at its 25-line ceiling. */
 static void	init_tables(t_shell *state)
 {
 	vec_init(&state->redirects);
@@ -67,6 +69,7 @@ static void	init_tables(t_shell *state)
 	job_table_init(&state->job_table);
 	alias_table_init(&state->aliases);
 	cmd_hash_init(&state->cmd_cache);
+	state->edit_mode = 1;
 }
 
 /* The name the shell reports in diagnostics: the basename of argv[0]
@@ -127,8 +130,8 @@ void	on(t_shell *state, char **argv, char **envp)
 	env_set(&state->env, env_create(ft_strdup("0"),
 			ft_strdup(argv[0]), false));
 	init_tables(state);
-	state->edit_mode = 1;
 	cli_dispatch(state, &cli);
+	interactive_job_signals(state->metinp == INP_RL);
 	prng_initialize_state(&state->prng,
 		(uint32_t)(getpid() * 2654435761u ^ time(NULL)));
 	state->start_sec = (long long)time(NULL);

--- a/src/execution/execution_private.h
+++ b/src/execution/execution_private.h
@@ -97,6 +97,8 @@ size_t				find_next_separator(t_ast_node *node,
 t_execution_state	execute_range(t_shell *state, t_executable_node *exe,
 						size_t start, size_t end);
 void				async_child_signals(void);
+void				fg_job_stopped(t_shell *st, t_execution_state *res,
+						int status);
 t_execution_state	execute_range_background(t_shell *state,
 						t_executable_node *exe,
 						size_t start, size_t end);

--- a/src/execution/fg_stopped.c
+++ b/src/execution/fg_stopped.c
@@ -1,0 +1,74 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   fg_stopped.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/20 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/20 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "execution_private.h"
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* Label for a job that just stopped: the line the user typed, minus its
+   trailing whitespace. bash shows the command text there, and the raw
+   input buffer is the closest thing we have to it without rebuilding the
+   command from the AST. */
+static void	fg_stop_label(t_shell *st, char *buf, size_t size)
+{
+	size_t	n;
+	char	*s;
+
+	s = (char *)st->input.ctx;
+	n = st->input.len;
+	if (!s || !n)
+		return ((void)ft_strlcpy(buf, "command", size));
+	while (n && (s[n - 1] == '\n' || s[n - 1] == ' ' || s[n - 1] == '\t'))
+		n--;
+	if (n >= size)
+		n = size - 1;
+	ft_memcpy(buf, s, n);
+	buf[n] = '\0';
+	if (!n)
+		ft_strlcpy(buf, "command", size);
+}
+
+/* ^Z on a foreground command. The shell used to wait without WUNTRACED, so
+   a stopped child never satisfied the wait and the REPL hung there for
+   good: the tty went back to cooked mode, the kernel echoed whatever was
+   typed next, and nothing ran it -- the shell looked alive and was not
+   (issue #25). Now the wait sees the stop, we record the job so `jobs`
+   lists it, announce it the way bash does, and hand a status back so the
+   REPL draws another prompt.
+
+   $? is 128 + the stopping signal, matching bash for a stopped foreground
+   job. The leading newline puts the notice on its own line: the cursor is
+   still sitting after the echoed ^Z when we get here.
+
+   The job is filed under the child's REAL process group, not its pid.
+   Foreground commands currently run inside the shell's own group, so those
+   two differ, and `fg` drives the job by group -- kill(-pgid, SIGCONT) then
+   waitpid(-pgid). Filing the pid would make both of those miss. */
+void	fg_job_stopped(t_shell *st, t_execution_state *res, int status)
+{
+	t_job	*job;
+	char	label[128];
+	pid_t	pgid;
+
+	fg_stop_label(st, label, sizeof(label));
+	pgid = getpgid(res->pid);
+	if (pgid <= 0)
+		pgid = res->pid;
+	job = job_add(&st->job_table, pgid, label, false);
+	ft_printf("\n");
+	if (job)
+	{
+		job_record_exit(job, status);
+		job_print(job, st->job_table.current, st->job_table.previous, false);
+	}
+	res->status = 128 + WSTOPSIG(status);
+}

--- a/src/execution/res_utils.c
+++ b/src/execution/res_utils.c
@@ -43,8 +43,10 @@ void	exe_res_set_status(t_shell *st, t_execution_state *res)
 		return ;
 	ft_assert(res->pid != -1);
 	while (1)
-		if (pal_waitpid(st, res->pid, &status, 0) != -1)
+		if (pal_waitpid(st, res->pid, &status, WUNTRACED) != -1)
 			break ;
+	if (WIFSTOPPED(status))
+		return (fg_job_stopped(st, res, status));
 	if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT)
 		res->ctrl_c = true;
 	res->status = WEXITSTATUS(status)

--- a/src/infrastructure/prompt_private.h
+++ b/src/infrastructure/prompt_private.h
@@ -103,15 +103,17 @@ typedef struct s_gitloc
 }	t_gitloc;
 
 /* State of the async dirty check: the cached answer for `root` (valid for
-   `ttl` seconds past `at`) plus the in-flight `git status` child, if any
-   (pid > 0, `fd` its non-blocking read end, forked at `spawned`). */
+   `ttl` seconds past `at`) plus the in-flight `git status` scan, if any
+   (`busy`, `fd` its non-blocking read end, started at `spawned`).  The
+   scanner is deliberately NOT our child -- see prompt_git3.c -- so there
+   is no pid here to wait for; `fd` closing is the only completion signal. */
 typedef struct s_dcache
 {
 	char	root[PATH_MAX];
 	time_t	at;
 	time_t	ttl;
 	time_t	spawned;
-	pid_t	pid;
+	int		busy;
 	int		fd;
 	int		dirty;
 	int		init;

--- a/src/platform/posix/execute_range_bg.c
+++ b/src/platform/posix/execute_range_bg.c
@@ -30,14 +30,28 @@ void	async_child_signals(void)
 
 /* Child body for a background command group (& operator).  We move into
    our own process group (setpgid) so job-control signals from the terminal
-   don't reach us.  stdin is redirected from /dev/null (POSIX: background
-   commands that try to read stdin get EOF, not a blocking read from the
-   tty).  POSIX also resets the parent's traps to default on entry to an
-   async child (reset_traps_child) -- a signal aimed at this child must not
-   run the parent's handler string, and the parent's EXIT trap is not ours
-   to fire.  The reset comes first so the explicit SIG_IGNs below still win:
-   SIGINT/SIGQUIT (POSIX) plus SIGTSTP/SIGTTIN/SIGTTOU are all ignored so the
-   user can keep typing without accidentally killing the background job. */
+   don't reach us.  POSIX also resets the parent's traps to default on entry
+   to an async child (reset_traps_child) -- a signal aimed at this child must
+   not run the parent's handler string, and the parent's EXIT trap is not
+   ours to fire.  The reset comes first so the explicit SIG_IGNs below still
+   win: SIGINT/SIGQUIT (POSIX) plus SIGTSTP/SIGTTIN/SIGTTOU are ignored so
+   the user can keep typing without accidentally killing the background job.
+
+   Both the /dev/null stdin and the SIGTSTP/SIGTTIN/SIGTTOU ignores below are
+   for NON-interactive shells only.  POSIX puts the redirection under "if job
+   control is disabled" (XCU 2.9.3.1) and both used to be done here
+   unconditionally.  Interactively that broke any background job that looks at
+   the terminal: `top &` called tcgetattr on stdin, got /dev/null, and died
+   with "top: failed tty get" (issue #25).  bash instead keeps the tty
+   attached, lets the job touch it from a background process group, and lets
+   the kernel stop it -- `[1]+ Stopped`.  Ignoring SIGTTIN/SIGTTOU would
+   defeat exactly that, since an ignored SIGTTOU makes the offending
+   tcsetattr succeed instead of stopping the job.
+
+   Scripts and -c keep the old behaviour on both counts, so a background
+   `read` there still sees EOF rather than blocking on a terminal the script
+   may not even have, and nothing there can be stopped by a tty it does not
+   own. */
 
 /* The one AST shape a background child may execve in place: the range is a
    single pipeline, that pipeline is a single command, and that command is a
@@ -80,7 +94,9 @@ static void	bg_child_body(t_shell *state, t_executable_node *exe,
 
 	setpgid(0, 0);
 	state->bg_exec_node = bg_lone_command(exe->node, start, end);
-	null_fd = open("/dev/null", O_RDONLY);
+	null_fd = -1;
+	if (state->metinp != INP_RL)
+		null_fd = open("/dev/null", O_RDONLY);
 	if (null_fd >= 0)
 	{
 		dup2(null_fd, STDIN_FILENO);
@@ -88,9 +104,12 @@ static void	bg_child_body(t_shell *state, t_executable_node *exe,
 	}
 	reset_traps_child(state);
 	async_child_signals();
-	signal(SIGTSTP, SIG_IGN);
-	signal(SIGTTIN, SIG_IGN);
-	signal(SIGTTOU, SIG_IGN);
+	if (state->metinp != INP_RL)
+	{
+		signal(SIGTSTP, SIG_IGN);
+		signal(SIGTTIN, SIG_IGN);
+		signal(SIGTTOU, SIG_IGN);
+	}
 	res = execute_range(state, exe, start, end);
 	exit(res.status);
 }

--- a/src/platform/posix/prompt_git3.c
+++ b/src/platform/posix/prompt_git3.c
@@ -15,25 +15,48 @@
 #include <sys/wait.h>
 #include <errno.h>
 #include <poll.h>
-#include <signal.h>
 
 /* Async dirty check. The prompt must NEVER wait for git: on a huge repo
    `git status` stats every tracked file and can take seconds, and the old
    blocking read froze the first prompt after every cd (and every TTL
    refresh) for the whole scan. Now a freshly entered repo gets one small
-   bounded wait (fast repos keep their exact star); past that the child
+   bounded wait (fast repos keep their exact star); past that the scan
    keeps running and a later render harvests it from the pipe — the star
-   arrives a render late instead of the prompt arriving seconds late. */
+   arrives a render late instead of the prompt arriving seconds late.
 
-/* Child body: stdout into the pipe, stderr silenced, then git status.
+   The scanner is deliberately NOT our child. We double-fork and reap the
+   throwaway middle process immediately, so `git status` is orphaned onto
+   init. A direct child would have to be reaped by someone, and the only
+   code that ever looked at it was the next prompt render — so any git
+   that finished while a foreground command was running sat as a zombie
+   for the whole duration of that command. Starting a nested shell parked
+   a visible `git <defunct>` in ps for as long as the inner shell lived
+   (issue #24). Orphaning removes the reaping obligation entirely.
+
+   The scanner also puts itself in its own process group, so Ctrl-C at the
+   prompt no longer reaches it. That used to kill it mid-scan, which is
+   why the harvest had to special-case "died on a signal, sample proves
+   nothing". Out of the shell's process group there is no such case, and
+   EOF on the pipe means exactly what it says. */
+
+/* Child body, entered by the throwaway middle process. It forks once more
+   and leaves at once: the parent reaps the middle process immediately and
+   the scanner below is reparented to init, so nothing here can ever become
+   a zombie of the shell. setpgid takes the scanner out of the terminal's
+   foreground group so Ctrl-C at the prompt cannot kill it mid-scan.
+
+   Then: stdout into the pipe, stderr silenced, exec git status.
    --no-optional-locks keeps git from touching .git/index behind the
    user's back; -uno skips the (possibly huge) untracked scan, so the
-   star means "tracked changes exist". _exit, not exit: this child must
-   not run the shell's atexit/cleanup paths. */
+   star means "tracked changes exist". _exit, not exit: neither process
+   here may run the shell's atexit/cleanup paths. */
 static void	dirty_child(int *fd, const char *root)
 {
 	int	nul;
 
+	if (fork() != 0)
+		_exit(0);
+	setpgid(0, 0);
 	close(fd[0]);
 	dup2(fd[1], STDOUT_FILENO);
 	close(fd[1]);
@@ -48,64 +71,60 @@ static void	dirty_child(int *fd, const char *root)
 	_exit(127);
 }
 
-/* Fork the checker for c->root. The read end is non-blocking (harvest
-   polls must never stall a render) and cloexec (it outlives this call, so
-   command children forked while the check runs must not inherit it). */
+/* Start the scanner for c->root. `mid` is the throwaway middle process of
+   the double fork: it forks the real scanner and exits immediately, so the
+   waitpid here costs nothing and leaves us with no child to reap later.
+   The read end is non-blocking (harvest polls must never stall a render)
+   and cloexec (it outlives this call, so command children forked while the
+   scan runs must not inherit it). */
 static void	spawn_check(t_dcache *c)
 {
-	int	fd[2];
+	int		fd[2];
+	pid_t	mid;
 
-	c->pid = 0;
+	c->busy = 0;
 	if (pipe(fd) != 0)
 		return ;
-	c->pid = fork();
-	if (c->pid == 0)
+	mid = fork();
+	if (mid == 0)
 		dirty_child(fd, c->root);
 	close(fd[1]);
-	if (c->pid < 0)
+	if (mid < 0)
 	{
-		c->pid = 0;
 		close(fd[0]);
 		return ;
 	}
+	while (waitpid(mid, NULL, 0) < 0 && errno == EINTR)
+		;
+	c->busy = 1;
 	c->fd = fd[0];
 	fcntl(c->fd, F_SETFL, O_NONBLOCK);
 	fcntl(c->fd, F_SETFD, FD_CLOEXEC);
 	c->spawned = time(NULL);
 }
 
-/* Retire the in-flight child (SIGKILL first when abandoning it — e.g. a
-   cd to another repo — so the reap cannot block on a live scan). Returns
-   the raw wait status, or -1 when someone else already reaped it: the
-   background-job WNOHANG loop does waitpid(-1) and may win the race. */
-static int	drop_check(t_dcache *c, int killit)
+/* Let go of the in-flight scan. Closing the read end is the whole of it:
+   the scanner is init's child, not ours, so there is nothing to wait for.
+   Abandoning one (a cd to another repo) no longer needs a SIGKILL either —
+   that kill only existed so the reap could not block on a live scan. The
+   orphan finishes on its own, and dies on SIGPIPE the moment it writes to
+   the pipe we just closed. */
+static void	drop_check(t_dcache *c)
 {
-	int	st;
-	int	r;
-
-	if (killit)
-		kill(c->pid, SIGKILL);
 	close(c->fd);
-	r = waitpid(c->pid, &st, 0);
-	while (r < 0 && errno == EINTR)
-		r = waitpid(c->pid, &st, 0);
-	c->pid = 0;
-	if (r < 0)
-		return (-1);
-	return (st);
+	c->busy = 0;
 }
 
 /* Harvest attempt with a wait budget. Any output byte means dirty; EOF
-   with none means clean. A child that died on a signal (Ctrl-C at the
-   prompt reaches it — same process group) proved nothing: drop the
-   sample and let the stale c->at trigger a fresh spawn next render.
+   with none means clean — and now that the scanner sits in its own process
+   group, EOF really does mean the scan ran to completion rather than "the
+   prompt's Ctrl-C killed it and this sample proves nothing".
    Slow repos (scan >= 1s) stretch the TTL so git is not re-run near
    continuously; the checks are async either way. */
 static int	poll_done(t_dcache *c, int wait_ms)
 {
 	struct pollfd	p;
 	ssize_t			n;
-	int				st;
 	char			ch;
 
 	p.fd = c->fd;
@@ -115,9 +134,7 @@ static int	poll_done(t_dcache *c, int wait_ms)
 	n = read(c->fd, &ch, 1);
 	if (n < 0)
 		return (0);
-	st = drop_check(c, 0);
-	if (st != -1 && WIFSIGNALED(st))
-		return (1);
+	drop_check(c);
 	c->dirty = (n > 0);
 	c->at = time(NULL);
 	c->ttl = 3;
@@ -135,9 +152,9 @@ int	git_dirty_cached(const char *root)
 	static t_dcache	c;
 	int				wait_ms;
 
-	if (c.pid > 0 && ft_strcmp(c.root, root) != 0)
-		drop_check(&c, 1);
-	if (c.pid > 0)
+	if (c.busy && ft_strcmp(c.root, root) != 0)
+		drop_check(&c);
+	if (c.busy)
 		return (poll_done(&c, 0), c.dirty);
 	if (c.init && ft_strcmp(c.root, root) == 0
 		&& time(NULL) - c.at < c.ttl)
@@ -151,7 +168,7 @@ int	git_dirty_cached(const char *root)
 	c.init = 1;
 	ft_strlcpy(c.root, root, sizeof(c.root));
 	spawn_check(&c);
-	if (c.pid > 0)
+	if (c.busy)
 		poll_done(&c, wait_ms);
 	return (c.dirty);
 }

--- a/tests/bg_tty_test.py
+++ b/tests/bg_tty_test.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Regression test: job control and the controlling terminal.
+
+Guards the /dev/null-stdin rule in bg_child_body (execute_range_bg.c).
+
+POSIX puts "the standard input for an asynchronous list shall be assigned
+to /dev/null" under *if job control is disabled* (XCU 2.9.3.1). hellish
+used to apply it unconditionally, which is right for scripts and -c but
+wrong for an interactive shell, where bash leaves the terminal attached
+and lets the kernel's job control do the work. The visible damage was any
+background job that inspects the tty:
+
+    $ top &
+    top: failed tty get          <- tcgetattr on /dev/null
+
+instead of bash's behaviour -- keep the tty, touch it from a background
+process group, take SIGTTOU, and stop as `[1]+ Stopped`. (issue #25)
+
+Checks, in a real pty, against `bash --posix`'s own behaviour where the
+two are supposed to agree:
+  1. Interactive: a background job's stdin IS the terminal (as in bash).
+  2. Non-interactive -c: a background job's stdin is NOT the terminal,
+     so a background `read` in a script still sees EOF and never blocks.
+  3. `top &` does not fail with "failed tty get", and lands as a stopped
+     job exactly like bash.
+  4. ^Z on a foreground command does not wedge the shell. The wait had no
+     WUNTRACED, so a stopped child never satisfied it: the REPL blocked in
+     waitpid forever, the tty fell back to cooked mode, and the kernel
+     echoed everything typed afterwards while nothing ran it -- the shell
+     looked alive and was not. It must now announce `[1]+ Stopped`, prompt
+     again, run the next command, and let `fg` resume the job. (issue #25)
+
+Usage: python3 bg_tty_test.py /path/to/hellish
+"""
+import fcntl
+import os
+import pty
+import select
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "../build/bin/hellish")
+BASH = os.path.expanduser("~/bash-5.3.9/bin/bash")
+if not os.path.exists(BASH):
+    BASH = "/bin/bash"
+FAILS = []
+
+ENV = {
+    "HOME": os.environ.get("HOME", "/tmp"),
+    "PATH": os.environ["PATH"],
+    "TERM": "xterm-256color", "LANG": "C.UTF-8", "PS1": "$ ",
+    "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+    "HELLISH_NO_ANIM": "1", "ASAN_OPTIONS": "detect_leaks=0",
+}
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + (" " + detail if not ok else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def pty_run(argv, sends, settle=1.6):
+    """Run argv on a pty, feed `sends`, return everything it printed."""
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(ENV)
+        os.execvp(argv[0], argv)
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
+    out = b""
+    time.sleep(0.6)
+    for s in sends:
+        os.write(fd, s)
+        end = time.time() + settle
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.1)
+            if r:
+                try:
+                    out += os.read(fd, 65536)
+                except OSError:
+                    break
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    return out.decode(errors="replace")
+
+
+def pty_run_seq(argv, seq):
+    """Like pty_run, but each send carries its own settle time."""
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(ENV)
+        os.execvp(argv[0], argv)
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
+    out = b""
+    time.sleep(0.7)
+    for data, wait in seq:
+        os.write(fd, data)
+        end = time.time() + wait
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.1)
+            if r:
+                try:
+                    out += os.read(fd, 65536)
+                except OSError:
+                    break
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    return out.decode(errors="replace")
+
+
+def bg_stdin_verdict(argv):
+    """Run the tty probe as a background job; return "tty"/"notty"/None.
+
+    The result goes through a FILE rather than stdout on purpose. The pty
+    echoes the command line back, and that echo contains the text of both
+    branches -- grepping the transcript for a marker matches the echo and
+    passes no matter what the shell actually did. This test shipped with
+    exactly that false pass before the file was used.
+    """
+    path = tempfile.mktemp(prefix="hellish_bgtty_")
+    probe = ("{ test -t 0 && echo tty > %s || echo notty > %s; } &\n"
+             % (path, path)).encode()
+    pty_run(argv, [probe])
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except OSError:
+        return None
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def main():
+    # 1: interactive keeps the terminal, and bash agrees
+    bash = bg_stdin_verdict([BASH, "-i"])
+    hell = bg_stdin_verdict([SHELL])
+    check("interactive: bash keeps the tty on a background job",
+          bash == "tty", "bash said %r" % bash)
+    check("interactive: background job keeps the tty (matches bash)",
+          hell == "tty",
+          "got %r -- /dev/null stdin leaked into an interactive shell" % hell)
+
+    # 2: -c is job-control-less, so /dev/null still applies
+    script = "{ test -t 0 && echo BG_IS_TTY || echo BG_NOT_TTY; } & wait"
+    for name, sh in (("hellish", SHELL), ("bash", BASH)):
+        r = subprocess.run([sh, "-c", script], capture_output=True, text=True,
+                           env=dict(os.environ, **ENV))
+        check("-c (%s): background stdin is /dev/null" % name,
+              "BG_NOT_TTY" in r.stdout, "stdout=%r" % r.stdout[:80])
+
+    # 3: the exact command from the report
+    out = pty_run([SHELL], [b"top &\n", b"\n", b"jobs\n"], settle=1.8)
+    check("top & does not fail tty get", "failed tty get" not in out)
+    check("top & becomes a stopped job", "Stopped" in out,
+          "no Stopped line; output tail=%r" % out[-160:])
+
+    # 4: ^Z on a foreground command. `top` rather than `sleep` on purpose.
+    # This test drives the shell straight from pty.fork(), which makes it a
+    # session leader, and a session leader's process group is orphaned by
+    # POSIX's definition -- the kernel silently DISCARDS SIGTSTP sent to an
+    # orphaned group. `sleep` would never stop here no matter what the shell
+    # does. `top` raises SIGSTOP on itself, which cannot be discarded, so it
+    # exercises the shell's side of the contract regardless. Under a real
+    # terminal (a shell inside another shell) `sleep` stops too; that is
+    # verified by hand and tracked in the per-job process-group issue.
+    seq = [(b"top\n", 2.2), (b"\x1a", 1.5), (b"jobs\n", 1.2),
+           (b"echo AFTER_STOP\n", 1.2), (b"fg\n", 2.0), (b"q", 1.2),
+           (b"echo AFTER_FG\n", 1.2)]
+    out = pty_run_seq([SHELL], seq)
+    check("^Z on a foreground job reports Stopped", "Stopped" in out,
+          "tail=%r" % out[-200:])
+    check("^Z leaves the shell able to run the next command",
+          out.count("AFTER_STOP") >= 2,
+          "shell wedged in waitpid; tail=%r" % out[-200:])
+    check("jobs lists the stopped foreground job", "top" in out)
+    check("fg resumes it and the shell survives",
+          out.count("AFTER_FG") >= 2, "tail=%r" % out[-200:])
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/git_prompt_stall_test.py
+++ b/tests/git_prompt_stall_test.py
@@ -20,6 +20,10 @@ Checks, in a real pty, default two-row prompt (PS1 unset):
   4. After the TTL expires there, the refresh keeps the prompt fast
      and keeps showing the last known star while it re-checks.
   5. A clean repo shows its branch and no star.
+  6. The scan leaves no zombie behind while a foreground command runs
+     (issue #24): the checker is double-forked onto init, so a `git
+     <defunct>` can never sit in ps for the lifetime of whatever the
+     user is running -- a nested shell used to park one there.
 
 Usage: python3 git_prompt_stall_test.py /path/to/hellish
 """
@@ -108,6 +112,22 @@ class Session:
         os.waitpid(self.pid, 0)
 
 
+def zombie_children(pid):
+    """PIDs of processes that are zombies AND direct children of `pid`."""
+    out = []
+    for d in os.listdir("/proc"):
+        if not d.isdigit():
+            continue
+        try:
+            st = open("/proc/%s/stat" % d).read()
+            f = st[st.rindex(")") + 2:].split()
+            if f[0] == "Z" and int(f[1]) == pid:
+                out.append(d)
+        except (OSError, ValueError, IndexError):
+            pass
+    return out
+
+
 def make_repo(base, name, dirty):
     d = os.path.join(base, name)
     os.makedirs(d)
@@ -183,6 +203,28 @@ def main():
     win = s.raw[n0:]
     check("clean repo shows branch", b"on\x1b[0m" in win and b"main" in win)
     check("clean repo shows no star", b"*" not in win)
+    s.close()
+
+    # 6: no zombie while a foreground command runs. The slow shim keeps the
+    # scan alive past the prompt, so it finishes *during* `sleep`, which is
+    # exactly the window where the old code had nobody to reap it: the only
+    # harvest point was the next render, and no render happens while a
+    # foreground command owns the terminal.
+    s = Session(base, work, shim + ":" + os.environ["PATH"])
+    s.prompt_latency(b"")
+    s.drain(0.4)
+    s.prompt_latency(("cd %s\n" % slow).encode())
+    s.drain(0.3)
+    os.write(s.fd, b"sleep 5\n")
+    s.drain(0.3)
+    seen = []
+    for _ in range(8):
+        time.sleep(0.5)
+        seen = zombie_children(s.pid)
+        if seen:
+            break
+    check("no zombie git while a foreground command runs",
+          not seen, "zombie pids=%s" % seen)
     s.close()
 
     shutil.rmtree(base, ignore_errors=True)

--- a/tests/printf_length
+++ b/tests/printf_length
@@ -1,0 +1,32 @@
+printf "%ld\n" 9999999999
+printf "%lld\n" -9999999999
+printf "%zu\n" 123
+printf "%zd\n" -123
+printf "%hd\n" 70000
+printf "%hhd\n" 300
+printf "%jd\n" 42
+printf "%td\n" 42
+printf "%Lf\n" 1.5
+printf "%lf\n" 2.25
+printf "%lx\n" 4886718345
+printf "%lX\n" 4886718345
+printf "%lo\n" 8
+printf "%li\n" 77
+printf "%ls\n" abc
+printf "%lc\n" a
+printf "%5ld|\n" 42
+printf "%-8ld|\n" 42
+printf "%08ld\n" 42
+printf "%+ld\n" 42
+printf "%.3ld\n" 4
+printf "%ld %zu %hd\n" 1 2 3
+printf "a%ldb%zuc\n" 1 2
+printf "%ld\n" 1 2 3
+printf "%s=%ld\n" x 5
+printf "%ld%%\n" 7
+echo "st=$?"
+printf "%ld\n" 9999999999; echo "st=$?"
+printf "%zu-%zu\n" 10 20; echo "st=$?"
+printf "%hhu\n" 5
+printf "%llx\n" 255
+printf "%lu\n" 4294967296

--- a/tests/tester
+++ b/tests/tester
@@ -33,6 +33,7 @@ if [[ ${#test_lists[@]} -eq 0 ]]; then
         "fatal_status"
         "job_label"
         "help_builtin"
+        "printf_length"
     )
 fi
 


### PR DESCRIPTION
Four reported bugs, each reproduced first, each with a regression test that was confirmed to fail on the parent commit.

## `fix(prompt)` — `git <defunct>` zombies (#24)

The prompt's async dirty check forked `git status` as a **direct child**, and the only code that reaped it ran during a prompt render. Any scan finishing while a foreground command owned the terminal therefore sat as a zombie for that command's whole life — one per nested shell, exactly as reported.

Double-fork so the scanner is orphaned onto init; there is no child to reap, so the window does not exist rather than being smaller. `setpgid(0, 0)` also keeps Ctrl-C at the prompt from killing it mid-scan, which retires the old "died on a signal, this sample proves nothing" special case.

## `fix(job-control)` — the terminal going dead (#25)

Two independent faults.

**`top &` → `top: failed tty get`.** Background stdin was redirected from `/dev/null` unconditionally. POSIX puts that under *"if job control is disabled"*; interactively bash leaves the tty attached. Now gated on being interactive — and so are the `SIGTSTP`/`SIGTTIN`/`SIGTTOU` ignores in that child, since an ignored `SIGTTOU` makes the offending `tcsetattr` succeed instead of stopping the job.

**The wedge.** The foreground wait had no `WUNTRACED`, so a stopped child never satisfied it and the REPL blocked in `waitpid` permanently — the tty fell back to cooked mode and the kernel echoed keystrokes while nothing ran them. Separately, the shell left `SIGTSTP` at `SIG_DFL`, so `^Z` suspended **hellish itself**. Both fixed; `default_signal_handlers()` now restores the stop signals in children, because `SIG_IGN` survives `execve`.

hellish now matches bash byte for byte through `^Z` → `jobs` → `fg` → resume.

## `fix(builtins)` — `printf` length modifiers (#28 split out)

`printf "%ld\n" 9999999999` reported ``  `%l': invalid format character ``. The scanner never consumed length modifiers. bash accepts and ignores them; measured that before copying it. 32 golden cases added.

## `chore(deps)` — libft bump

libft `b1430dbb..35a1912b`: `%ld` family support plus the 64-bit truncation it exposed, a four-way CI matrix, and an LTO probe fix — a clang-built `libft.a` could not be linked by any consumer that did not itself pass `-flto`. libft CI is green on all four legs for the first time.

## Verification

- 3688 golden cases (3656 + 32 new)
- `verify_alloc` 78/78, 0 diffs, 0 leaks, both heaps
- `make re` and `make re OPT=1` clean
- norminette clean on every touched file
- readline, prompt-atomic, history, animation, widechar, git-prompt, bg-tty, cli-opts, login, help, update-config gates green

## Deliberately not included

- **#27** — foreground commands still share the shell's process group, so signals cannot be aimed at one job and `^Z` is inert when hellish is a session leader (orphaned group, `SIGTSTP` discarded). Changes the fork path of every external command; not worth bolting onto a bug-fix PR.
- **#28** — `printf` clamps `%u`/`%x`/`%o` at `LLONG_MAX`. Argument parsing, not format scanning; fails identically with no modifier.

One process note: the first draft of `tests/bg_tty_test.py` passed vacuously — it grepped the pty transcript for a marker, and the transcript carries the shell's echo of the command line, which contains both branches. It reports through a file now. Recording it because that failure mode is invisible.
