### PR TITLE
test(job-control): deflake the job-slot reuse case

### DIFF
--- a/tests/issue18_job_numbers
+++ b/tests/issue18_job_numbers
@@ -12,7 +12,7 @@ sleep 0.05 | cat & jobs; wait; sleep 0.05 | cat & jobs; wait
 sleep 0.05 & p=$!; wait; sleep 0.05 & jobs; wait; echo ok
 sleep 0.3 & jobs %1; wait
 sleep 0.05 & wait; sleep 0.3 & jobs %1; wait
-true & wait; sleep 0.3 & jobs; wait
+sleep 0.05 & wait; sleep 0.3 & jobs; wait; echo slot-reused
 sleep 0.05 & wait; sleep 0.05 & wait; sleep 0.05 & wait; sleep 0.3 & jobs; wait
 sleep 0.05 & sleep 0.5 & wait %1; jobs; wait
 sleep 0.3 & sleep 0.05 & sleep 0.5 & wait %1; jobs; wait


### PR DESCRIPTION
CI on `main` went red with one failure out of 3688, in `issue18_job_numbers`:

```
Command: true & wait; sleep 0.3 & jobs; wait

hellish: [1]+  Running                    sleep 0.3 &
bash:    [1]   Done                       true
         [2]+  Running                    sleep 0.3 &
```

**The oracle is the flaky side, not hellish.** `true` exits so fast that whether bash has retired its job slot by the time `jobs` runs is a race — the same pinned bash 5.3.9 binary prints either one line or two depending on machine load. Measured over 600 runs each at `-P32`:

| case | one-line | two-line |
|---|---|---|
| `true & wait; sleep 0.3 & jobs; wait` | 596 | **4** |
| `sleep 0.05 & wait; sleep 0.3 & jobs; wait` | 600 | 0 |

hellish was **200/200 deterministic** on the original case, which is exactly why this only ever failed on a loaded runner and never locally. A case whose expected output depends on how busy the machine is cannot grade anything.

Swapped `true` for `sleep 0.05` — matching every other line in this file — and appended an `echo` so the case still asserts something *after* the `jobs` output instead of ending on it. The intent is unchanged: a completed, waited-for job frees its number, so the next background job is `[1]` again. It is the same shape as line 2, which has always been stable.

No source touched. 3688/3688 pass, and the category is 5/5 green over repeated runs.
