### PR TITLE
release: v2.6.0 — --version, prompt fixes, animation off, CI covers every suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -586,6 +586,14 @@ git-prompt-test: all
 bg-tty-test: all
 	@python3 $(TEST_DIR)/bg_tty_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
+# Canary (NOT a regression gate for a specific fix): drives the shell the way
+# the field reports of intermittent prompt corruption describe, and asserts no
+# escape sequence reached the screen without its ESC[ and no UTF-8 character
+# was cut. It has never reproduced that corruption -- read its docstring
+# before trusting a pass.
+prompt-integrity-test: all
+	@python3 $(TEST_DIR)/prompt_shortwrite_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
+
 # Release/update configuration, checked offline: the GitHub slug baked into
 # version.h must match the repository we actually push to, every
 # distribution channel (install.sh, npm, Dockerfile, docs) must agree with
@@ -681,7 +689,7 @@ geoman: all
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
 	docker-arch docker-clean cd-zsh-test cd-posix-test agnostic-bench \
 	hist-test readline-test anim-test git-prompt-test prompt-atomic-test \
-	bg-tty-test \
+	bg-tty-test prompt-integrity-test \
 	update-config-test update-test help-test \
 	conformance perf rss \
 	charts cli-opts-test net-redir-test login-test geoman oracle docker-suite docker widechar-test \

--- a/src/infrastructure/mascot_redraw.c
+++ b/src/infrastructure/mascot_redraw.c
@@ -94,7 +94,6 @@ void	redraw_mascot(t_string *r)
 	while (s + i < last)
 		rd_char(&f, s[i++]);
 	vec_push_str(&f, "\0338\033[?25h\033[?2026l");
-	if (write(fileno(rl_outstream), f.ctx, f.len) < 0)
-		f.len = 0;
+	tty_write_all(fileno(rl_outstream), f.ctx, f.len);
 	xfree(f.ctx);
 }

--- a/src/infrastructure/prompt_private.h
+++ b/src/infrastructure/prompt_private.h
@@ -28,6 +28,7 @@
 # include <stdlib.h>
 # include <string.h>
 # include <time.h>
+# include <errno.h>
 # include <wchar.h>
 # include <wctype.h>
 
@@ -120,6 +121,7 @@ typedef struct s_dcache
 }	t_dcache;
 
 void		vec_push_ansi(t_string *v, const char *seq);
+void		tty_write_all(int fd, const char *buf, size_t len);
 int			get_cols(void);
 int			measure_width(const char *str);
 char		*shorten_path(const char *path, int maxlen);

--- a/src/infrastructure/prompt_utils3.c
+++ b/src/infrastructure/prompt_utils3.c
@@ -120,3 +120,34 @@ void	prompt_arrow_row(t_string *ret, t_prompt *p)
 	vec_push_str(ret, G_ARR " ");
 	vec_push_ansi(ret, C_RST);
 }
+
+/* Write the WHOLE buffer, however many syscalls that takes.
+   write(2) is allowed to transfer fewer bytes than asked and report that
+   count as success -- on a terminal it happens whenever the line
+   discipline's output queue is full and a signal (SIGCHLD from a finished
+   background job, SIGWINCH from a resize) interrupts the blocked call.
+   Every prompt writer here composes the whole frame in memory and pushed
+   it out with a single unchecked write(), so those runt writes silently
+   dropped the tail of the frame. What reached the screen was a prompt cut
+   at an arbitrary byte -- mid escape sequence, so the rest of it printed
+   as literal text (`8;2;90;96;106m`), or mid UTF-8 character, so the glyph
+   came out as U+FFFD. Rare, load-dependent, and maddening to chase, which
+   is exactly why it has to be handled here rather than at each call site.
+   EINTR before any progress is a retry, not a failure. A genuine error
+   (the tty went away) just stops: there is nowhere to report it from a
+   redraw path. */
+void	tty_write_all(int fd, const char *buf, size_t len)
+{
+	ssize_t	n;
+	size_t	off;
+
+	off = 0;
+	while (off < len)
+	{
+		n = write(fd, buf + off, len - off);
+		if (n > 0)
+			off += (size_t)n;
+		else if (!(n < 0 && errno == EINTR))
+			return ;
+	}
+}

--- a/src/platform/posix/rl.c
+++ b/src/platform/posix/rl.c
@@ -47,8 +47,7 @@ static char	*split_prompt(char *prompt)
 			vec_push_char(&f, prompt[i]);
 		i++;
 	}
-	if (write(fileno(rl_outstream), f.ctx, f.len) < 0)
-		f.len = 0;
+	tty_write_all(fileno(rl_outstream), f.ctx, f.len);
 	xfree(f.ctx);
 	return (nl + 1);
 }

--- a/tests/prompt_shortwrite_test.py
+++ b/tests/prompt_shortwrite_test.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Canary: the rendered prompt must never reach the terminal malformed.
+
+This is a CANARY, not a regression test for a specific fix -- it passes on
+code both with and without tty_write_all. It exists because prompt
+corruption has been reported in the field and is hard to catch: an escape
+sequence that arrives without its ESC[ introducer prints its body as
+literal text (`8;2;90;96;106m`), and a UTF-8 character cut mid-sequence
+arrives as U+FFFD. Both are silent -- nothing errors, the screen is just
+wrong.
+
+It drives the shell the way the reports describe (wide terminal so the
+prompt frame is large and full of truecolor escapes, a reader that lags so
+the tty output queue backs up, background jobs, repeated `clear`) and
+asserts the transcript contains neither symptom.
+
+Known limitation, stated so nobody trusts it further than it goes: this
+harness has NOT reproduced the field corruption. Roughly 1MB of captured
+output across several stress shapes came back clean. So a pass here means
+"the common paths are intact", not "the reported bug is gone".
+
+Usage: python3 prompt_shortwrite_test.py /path/to/hellish
+"""
+import fcntl
+import os
+import pty
+import re
+import select
+import struct
+import sys
+import termios
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "../build/bin/hellish")
+FAILS = []
+
+# An SGR body that reached the screen without its ESC[ introducer: digits and
+# semicolons ending in 'm', sitting next to prompt text rather than after ESC.
+ORPHAN_SGR = re.compile(r'(?<!\x1b\[)(?<![\x1b\[0-9;])\b\d{1,3}(?:;\d{1,3}){2,}m')
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + (" " + detail if not ok else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def run(cols=200, rounds=14):
+    """Drive the shell with a laggy reader so the tty output queue fills."""
+    env = {
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "PATH": os.environ["PATH"],
+        "TERM": "xterm-256color", "LANG": "C.UTF-8",
+        "COLORTERM": "truecolor",
+        "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+        "ASAN_OPTIONS": "detect_leaks=0",
+    }
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(env)
+        os.execvp(SHELL, [SHELL])
+        os._exit(127)
+    # A wide terminal makes the prompt's box-drawing line long, so one frame
+    # is several hundred bytes of escapes and multibyte glyphs.
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 50, cols, 0, 0))
+    raw = b""
+    time.sleep(0.7)
+
+    def feed(data, settle, lag=0.0):
+        nonlocal raw
+        os.write(fd, data)
+        end = time.time() + settle
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.05)
+            if r:
+                if lag:
+                    time.sleep(lag)      # let the tty queue back up
+                try:
+                    raw += os.read(fd, 4096)
+                except OSError:
+                    return
+
+    for _ in range(rounds):
+        # clear floods the output queue; the background job then lands a
+        # SIGCHLD while the next prompt frame is being written.
+        feed(b"clear\n", 0.35, lag=0.02)
+        feed(b"sleep 0.05 &\n", 0.30, lag=0.02)
+        feed(b"cd /sgoinfre/students/dlesieur/hellish\n", 0.30, lag=0.02)
+        feed(b"cd vendor/libft\n", 0.30, lag=0.02)
+        feed(b"cd -\n", 0.30, lag=0.02)
+    feed(b"", 0.8)
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    return raw
+
+
+def main():
+    raw = run()
+    text = raw.decode("utf-8", errors="replace")
+
+    check("shell produced output", len(raw) > 2000, "got %d bytes" % len(raw))
+
+    bad = ORPHAN_SGR.findall(text)
+    check("no escape sequence was cut by a short write",
+          not bad, "orphaned SGR bodies on screen: %s" % bad[:5])
+
+    check("no UTF-8 character was cut by a short write",
+          "�" not in text,
+          "replacement char at %s" % text.find("�"))
+
+    # A frame cut mid-escape also tends to leave a bare ESC[ with nothing
+    # after it before ordinary text.
+    check("no truncated CSI introducer",
+          not re.search(r'\x1b\[(?![\d;?]*[ -~])', text))
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tools/capture-prompt-bug.sh
+++ b/tools/capture-prompt-bug.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Capture the raw terminal byte stream while you use hellish normally, so an
+# intermittent prompt corruption can be diagnosed from ground truth instead
+# of from a screenshot.
+#
+# On screen the corruption looks like one of these:
+#   ╰─❯ 8;2;90;96;106m╰─❯     an escape that lost its ESC[ introducer
+#   ╰─❯ <?>                   a UTF-8 character cut mid-sequence
+#
+# Usage:  tools/capture-prompt-bug.sh
+#         ... use the shell normally until you see the corruption ...
+#         exit
+# Then send the .analysis file it prints.
+set -u
+out="${TMPDIR:-/tmp}/hellish-prompt-capture.$$"
+bin="${HELLISH:-$(command -v hellish || echo ./build/bin/hellish)}"
+
+echo "recording to $out.raw   (shell: $bin)"
+echo "reproduce the corruption, then type 'exit'."
+# script(1) records everything the terminal received, escape bytes included.
+script -q -f -c "$bin" "$out.raw"
+
+{
+	echo "=== capture analysis ==="
+	echo "binary : $bin"
+	echo "TERM=${TERM:-unset} COLORTERM=${COLORTERM:-unset} LANG=${LANG:-unset}"
+	echo "size   : $(stat -c%s "$out.raw" 2>/dev/null) bytes"
+	echo
+	echo "--- SGR bodies that reached the screen without their ESC[ ---"
+	grep -aoP '(?<!\x1b\[)(?<![\x1b\[0-9;])\b\d{1,3}(?:;\d{1,3}){2,}m' \
+		"$out.raw" 2>/dev/null | sort | uniq -c | head -20
+	echo
+	echo "--- replacement characters (cut UTF-8), line count ---"
+	grep -ac $'\xef\xbf\xbd' "$out.raw" 2>/dev/null
+	echo
+	echo "--- context around the first orphan ---"
+	perl -0777 -ne 'if (/((?<!\x1b\[)\b\d{1,3}(?:;\d{1,3}){2,}m)/) {
+		my $p = $-[0]; my $s = $p > 150 ? $p-150 : 0;
+		my $c = substr($_, $s, 300); $c =~ s/\x1b/<ESC>/g;
+		print "byte offset $p\n$c\n"; }' "$out.raw" 2>/dev/null
+} > "$out.analysis" 2>&1
+
+echo
+echo "analysis : $out.analysis"
+echo "raw      : $out.raw"


### PR DESCRIPTION
Release-readiness for **v2.6.0**: a new CLI flag, four fixes, and the test suites that previously only ran when somebody remembered.

## New — `hellish --version`

It used to answer `invalid option`. It now prints the version, the asset the updater will fetch, and the repo it will fetch it from — a build pointing somewhere unexpected is worth seeing *before* it downloads anything.

```
$ hellish --version
hellish, version 2.6.0 (hellish-linux-x86_64)
Release channel: https://github.com/Univers42/hellish
An almost-POSIX shell, diffed byte-for-byte against bash --posix.
```

Exits 0 without sourcing a startup file or reading stdin, so package managers and CI can probe it safely. Four new checks in `cli_opts_compare.sh`, including that the version printed **is the one in `version.h`** — a release shipping a binary that misreports itself is worse than having no flag.

## CI now runs what it never ran

`make test` and the script corpus were the only things CI checked. Fifteen-odd other Makefile targets ran only by hand. Five new parallel jobs:

| job | covers |
|---|---|
| `gates` | cli-opts, login, help, cd-posix, update-config |
| `interactive` | 8 pty gates: readline, hist, prompt-atomic, anim, git-prompt, widechar, bg-tty, prompt-integrity |
| `update` | the update path against a local fake release server, plus `/dev/tcp` |
| `corpus` | `tests/hard/` (own runner, never in `make test`) + allocator parity on both heaps |
| `bench` | measured, uploaded as an artifact, **never a gate** |

Benchmarks are `continue-on-error` on purpose: shared runners are noisy neighbours, and timing thresholds there produce flaky red builds, which teaches people to ignore CI.

The pinned-bash-5.3.9 setup is now a composite action instead of thirty duplicated lines in six jobs.

## Two defects found while wiring CI up

- **`tests/hard/run.sh` always exited 0.** It printed `14 PASS / 3 FAIL` and returned success — it fell off the end of the loop. Harmless while only humans read it; not harmless the moment CI does. Now exits non-zero, and retries `rc 126` (ETXTBSY — the binary being relinked mid-run, which is what produced those three phantom FAILs).
- **Two compare scripts graded against whatever bash the host shipped.** `tests/tester` has always preferred the pinned 5.3.9; these did not. `make cd-posix-test` failed here with four "failures" that were pure version drift (`cd aaa bbb` is exit 1 through bash 5.2, exit 2 from 5.3 — hellish already matched 5.3.9 exactly). Both now pin the oracle and warn loudly otherwise: 3 pass/4 fail → **7 pass/0 fail**, no shell source touched.

## Fixes carried in this branch

- **Prompt frames are written whole.** Both prompt writers used a single unchecked `write()`; `write(2)` may transfer fewer bytes than asked and report success, silently dropping the tail. Demonstrated: a 1048576-byte tty write returning 12032.
- **The animation ships off.** It was the only thing writing to the terminal while the user was not typing — **6428 bytes per 2.5s** at an idle prompt, versus **0** now. `HELLISH_ANIM` also now governs the built-in prompt, which previously animated regardless of the setting.

## Scope note, stated plainly

The animation change does **not** explain the corruption in #34. The reporter's `PS1` is commented out, so they get the built-in prompt, which never armed the live repaint — verified: their exact rc writes **0 idle bytes**. And the short-write fix cannot explain it either: a short write drops the *tail*, while the reported symptom is a missing *head* (`ESC[3` gone, body printed). Both changes are genuine, independently justified improvements; neither is the fix for #34, which stays open with the ruled-out list recorded.

## Verification

3688 golden cases · 11 pty/auxiliary gates · hard corpus · `verify_alloc` both heaps · `make re` and `make re OPT=1` · norminette clean.
