### PR TITLE
release: v2.6.0 — --version, animation off, CI covers every suite

### DIFF
--- a/.github/actions/oracle/action.yml
+++ b/.github/actions/oracle/action.yml
@@ -1,0 +1,38 @@
+name: Pinned bash oracle
+description: >
+  Build (or restore from cache) the bash 5.3.9 the golden suite is defined
+  against, and put it first on PATH. The suite diffs byte-for-byte against
+  `bash --posix`, and bash changes POSIX-visible behaviour between minor
+  releases -- cd's status on too many operands is exit 1 through 5.2 and
+  exit 2 from 5.3, printf's status on numeric overflow moved too. Grading
+  against whatever bash the runner image ships reports that drift as shell
+  bugs, so the oracle is pinned rather than inherited.
+runs:
+  using: composite
+  steps:
+    - name: Restore pinned bash 5.3.9
+      id: bashcache
+      uses: actions/cache@v4
+      with:
+        path: ~/bash-5.3.9
+        key: bash-5.3.9-${{ runner.os }}-${{ runner.arch }}
+    - name: Build pinned bash 5.3.9
+      if: steps.bashcache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -e
+        curl -sLO https://ftp.gnu.org/gnu/bash/bash-5.3.tar.gz
+        tar xzf bash-5.3.tar.gz
+        cd bash-5.3
+        for i in $(seq 1 9); do
+          p=$(printf 'bash53-%03d' "$i")
+          curl -sL "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/$p" | patch -p0
+        done
+        ./configure --prefix="$HOME/bash-5.3.9" > configure.log 2>&1
+        make -j"$(nproc)" > make.log 2>&1
+        make install > install.log 2>&1
+    - name: Use pinned bash as the golden oracle
+      shell: bash
+      run: |
+        echo "$HOME/bash-5.3.9/bin" >> "$GITHUB_PATH"
+        "$HOME/bash-5.3.9/bin/bash" --version | head -1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,29 +174,7 @@ jobs:
           submodules: recursive
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install -y build-essential libreadline-dev
-      - name: Restore pinned bash 5.3.9
-        id: bashcache
-        uses: actions/cache@v4
-        with:
-          path: ~/bash-5.3.9
-          key: bash-5.3.9-${{ runner.os }}-${{ runner.arch }}
-      - name: Build pinned bash 5.3.9
-        if: steps.bashcache.outputs.cache-hit != 'true'
-        run: |
-          curl -sLO https://ftp.gnu.org/gnu/bash/bash-5.3.tar.gz
-          tar xzf bash-5.3.tar.gz
-          cd bash-5.3
-          for i in $(seq 1 9); do
-            p=$(printf 'bash53-%03d' "$i")
-            curl -sL "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/$p" | patch -p0
-          done
-          ./configure --prefix="$HOME/bash-5.3.9" > configure.log 2>&1
-          make -j"$(nproc)" > make.log 2>&1
-          make install > install.log 2>&1
-      - name: Use pinned bash as the golden oracle
-        run: |
-          echo "$HOME/bash-5.3.9/bin" >> "$GITHUB_PATH"
-          "$HOME/bash-5.3.9/bin/bash" --version | head -1
+      - uses: ./.github/actions/oracle
       - name: Build debug (SAFE=1, ASan)
         run: |
           if ! make re > build.log 2>&1; then
@@ -218,3 +196,140 @@ jobs:
           if-no-files-found: ignore
       - name: Script corpus vs bash --posix + leak check
         run: tests/run_scripts.sh
+
+  # ── Everything the golden suite cannot express ───────────────────────────
+  # The golden suite diffs stdout+status of one-line cases. A lot of this
+  # shell's behaviour is not shaped like that: startup argv parsing, the
+  # login-shell file order, the help table, the release/update config. These
+  # ran only on developer machines before, which is exactly how they rot.
+  gates:
+    name: Gates · cli + login + help + cd + update-config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y build-essential libreadline-dev
+      - uses: ./.github/actions/oracle
+      - name: Build
+        run: make re > build.log 2>&1 || { sed 's/\x1b\[[0-9;]*[A-Za-z]//g' build.log | tail -80; exit 1; }
+      - name: Startup argv parsing (-e, -o name, +c, --, $-, --version)
+        run: make cli-opts-test
+      - name: Login shell startup file order
+        run: make login-test
+      - name: help builtin covers every dispatched builtin
+        run: make help-test
+      - name: cd POSIX-mode operand handling
+        run: make cd-posix-test
+      - name: Release/update configuration agrees across channels
+        run: make update-config-test
+
+  # ── pty-driven behaviour ─────────────────────────────────────────────────
+  # Interactive behaviour only exists in front of a terminal: readline, the
+  # prompt, history joining, job control's use of the tty. Each of these
+  # drives a real pty. They are the gates most likely to catch a regression
+  # a user would actually notice, and the least likely to be run by hand.
+  interactive:
+    name: Interactive · pty gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y build-essential libreadline-dev python3
+      - uses: ./.github/actions/oracle
+      - name: Build
+        run: make re > build.log 2>&1 || { sed 's/\x1b\[[0-9;]*[A-Za-z]//g' build.log | tail -80; exit 1; }
+      - name: readline entry points (completion, history, vi/emacs)
+        run: make readline-test
+      - name: cmdhist multiline history joining
+        run: make hist-test
+      - name: prompt reaches the tty in one write
+        run: make prompt-atomic-test
+      - name: prompt animation never clobbers pasted input
+        run: make anim-test
+      - name: git dirty check never blocks a render, and leaves no zombie
+        run: make git-prompt-test
+      - name: non-ASCII prompt and wrapping input
+        run: make widechar-test
+      - name: background jobs and the controlling terminal
+        run: make bg-tty-test
+      - name: prompt integrity (idle silence + no cut escapes)
+        run: make prompt-integrity-test
+
+  # ── Update path and network-shaped redirections ──────────────────────────
+  # Both bring up their own local peer; neither touches the network. The
+  # update suite is the one that matters most to users -- it is the code
+  # that replaces the binary on their machine.
+  update:
+    name: Update path + /dev/tcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y build-essential libreadline-dev python3
+      - uses: ./.github/actions/oracle
+      - name: Build
+        run: make re > build.log 2>&1 || { sed 's/\x1b\[[0-9;]*[A-Za-z]//g' build.log | tail -80; exit 1; }
+      - name: Update path against a local fake release server
+        run: make update-test
+      - name: /dev/tcp and /dev/udp redirections
+        run: make net-redir-test
+
+  # ── Whole-program corpus and allocator parity ────────────────────────────
+  # tests/hard/ holds programs too large for a one-line golden case, and has
+  # its own runner that `make test` does not invoke. verify_alloc proves the
+  # two compile-time heaps produce identical output and leak nothing --
+  # ft_malloc is invisible to ASan, so this is the only oracle it has.
+  corpus:
+    name: Hard corpus + allocator parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y build-essential libreadline-dev python3
+      - uses: ./.github/actions/oracle
+      - name: Build
+        run: make re > build.log 2>&1 || { sed 's/\x1b\[[0-9;]*[A-Za-z]//g' build.log | tail -80; exit 1; }
+      - name: Whole-program corpus vs bash --posix
+        run: bash tests/hard/run.sh
+      - name: Both heaps agree, and neither leaks
+        run: cd tests && ./verify_alloc.sh
+
+  # ── Benchmarks: measured, reported, never a gate ─────────────────────────
+  # Shared CI runners are noisy neighbours; timings there cannot decide
+  # pass/fail without producing flaky red builds. So this job measures and
+  # publishes the numbers as an artifact for tracking, and is allowed to
+  # fail without blocking the merge. Trend, not threshold.
+  bench:
+    name: Benchmarks (informational)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y build-essential libreadline-dev python3 hyperfine || true
+      - uses: ./.github/actions/oracle
+      - name: Speed vs bash --posix
+        run: make bench ROUNDS=3 2>&1 | tee bench-out.txt | tail -40
+      - name: Upload benchmark output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results
+          path: |
+            bench-out.txt
+            bench/results.md
+            bench/conformance.md
+          if-no-files-found: ignore
+          retention-days: 30

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,58 @@ shows you how to drive the shell.
 
 ---
 
+## v2.6.0 — *the ask-it-what-it-is release*
+
+**New**
+
+- **`hellish --version`.** It used to answer "invalid option". Now it prints
+  the version, the asset the updater will fetch, and the repo it will fetch
+  it from — because a build pointing somewhere unexpected is worth seeing
+  *before* it downloads anything. Exits 0 without sourcing a startup file or
+  reading stdin, so package managers and CI can probe it safely.
+
+**Fixed**
+
+- **`printf` accepts length modifiers.** `printf "%ld\n" 9999999999` failed
+  with `` `%l': invalid format character ``. Every C-habit format string hit
+  this: `%ld %lld %zu %hd %jd %td %Lf`. bash accepts and ignores them; so do
+  we now, measured against it rather than guessed.
+- **No more `git <defunct>`.** The prompt's async git check was reaped only
+  during a prompt render, so any scan finishing while a foreground command
+  ran left a zombie for that command's whole life — one per nested shell.
+  It is double-forked onto init now; there is no child to reap.
+- **`top &` works, and `^Z` no longer wedges the terminal.** Background jobs
+  keep the tty in an interactive shell (POSIX only redirects stdin to
+  `/dev/null` when job control is *off*), and the foreground wait passes
+  `WUNTRACED` — without it a stopped child never satisfied the wait, so the
+  shell blocked in `waitpid` forever while the kernel echoed keystrokes that
+  nothing ran.
+- **Whole prompt frames.** The prompt writers used a single unchecked
+  `write()`. `write(2)` may transfer fewer bytes than asked and report that
+  as success, so the tail was silently dropped.
+
+**Changed**
+
+- **The prompt animation ships off.** It was the only thing that wrote to
+  your terminal while you were not typing — 6.4KB of escape traffic every
+  2.5 seconds at an idle prompt. Set `HELLISH_ANIM=spinner|pulse|ember` to
+  opt back in. Nothing else about prompt customisation changes.
+- `HELLISH_ANIM` now means what it says. It only ever governed `\A` in a
+  custom `PS1`; the built-in prompt animated regardless, with no way to stop
+  it short of writing a whole custom prompt.
+
+**Under the hood**
+
+- CI runs the suites that previously only ran when somebody remembered:
+  the pty gates, startup argv parsing, login file order, the help table,
+  the update path, the whole-program corpus, allocator parity across both
+  heaps, and benchmarks (published, never a gate).
+- `vendor/libft` gained `%ld`-family support and the 64-bit correctness
+  fixes that exposed, and its own CI is green across ubuntu 22.04/24.04 ×
+  gcc/clang for the first time.
+
+---
+
 ## v2.5.0 — *the help release*
 
 **New**

--- a/hellishrc.example
+++ b/hellishrc.example
@@ -15,15 +15,25 @@
 #   \S  " ✘N" after a failing command, empty after success
 #   \p  " took N.Ns" once a command ran 2s or longer
 #   \J  " ⚙N" while background jobs exist
-#   \A  an ANIMATED glyph (see HELLISH_ANIM below) — live while the
-#       shell waits at the prompt, repainted in place ~10x/second.
-#       (Shadows bash's \A 24h-clock escape; use \t for time instead.)
+#   \A  an ANIMATED glyph (see HELLISH_ANIM below) — OPT-IN, off by
+#       default. (Shadows bash's \A 24h-clock escape; use \t for time.)
 # Live $VAR / ${VAR} expansion happens at every render.
 
-# Prompt animation style for \A:
+# ── ANIMATION: OFF BY DEFAULT, AND THAT IS DELIBERATE ──────────────────
+# A live style makes \A repaint the prompt rows in place ~10x/second
+# while the shell sits idle. That repaint is the one part of the prompt
+# that writes to your terminal when you are NOT typing, and it has been
+# reported to corrupt the prompt on some terminals — an escape sequence
+# arriving without its introducer prints its body as text
+# (`8;2;90;96;106m`), or a multibyte glyph gets cut and shows as U+FFFD.
+# It is not reproducible on demand, so it is shipped OFF rather than
+# shipped broken. Everything else in this file works exactly the same
+# with animation off; \A simply renders nothing.
+#
+# Styles, if you want to opt in anyway:
 #   spinner  braille spinner in blue        pulse  a ✦ breathing magenta
-#   ember    a ▲ flickering through fire    off    freeze/hide \A
-HELLISH_ANIM=pulse
+#   ember    a ▲ flickering through fire    off    hide \A (default)
+HELLISH_ANIM=off
 
 # Theme: "pure" (default) — a blank line for breathing room, then one
 # calm info line (bold blue path, grey branch, red failure badge, amber

--- a/incs/shell.h
+++ b/incs/shell.h
@@ -49,6 +49,7 @@ enum e_opt_flag
 	OPT_FLAG_VERBOSE = 1u << 1,
 	OPT_FLAG_POSIX = 1u << 2,
 	OPT_FLAG_LOGIN = 1u << 3,
+	OPT_FLAG_VERSION = 1u << 4,
 	OPT_FLAG_DEBUG_LEXER = 1u << 8,
 	OPT_FLAG_DEBUG_PARSER = 1u << 9,
 	OPT_FLAG_DEBUG_AST = 1u << 10

--- a/incs/update.h
+++ b/incs/update.h
@@ -107,6 +107,7 @@ int			update_selfupdate(t_origin o, const char *tag);
 /* Compare two dotted versions ("2.1.0", optionally "v"-prefixed).
    Returns >0 if a is newer than b, 0 if equal, <0 if older. */
 int			hellish_version_cmp(const char *a, const char *b);
+void		print_version(void);
 
 /* Read the latest release tag cached by the last background check into `out`
    (NUL-terminated, no leading 'v'). Returns 1 on success, 0 if no cache. */

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.5.0"
+# define HELLISH_VERSION "2.6.0"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/core/on.c
+++ b/src/core/on.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "core.h"
+#include "update.h"
 #include "shell.h"
 #include "helpers.h"
 #include "env.h"
@@ -32,6 +33,12 @@ static char	*shell_basename(char *arg0);
    tolerates. */
 static void	cli_early_exit(t_shell *state, char **argv, t_cli *cli)
 {
+	if (state->option_flags & OPT_FLAG_VERSION)
+	{
+		print_version();
+		free_all_state(state);
+		exit(0);
+	}
 	if (!(state->option_flags & OPT_FLAG_HELP))
 	{
 		if (!cli->err)
@@ -42,6 +49,7 @@ static void	cli_early_exit(t_shell *state, char **argv, t_cli *cli)
 	}
 	ft_printf("Usage: %s [options] [file]\n", argv[0]);
 	ft_printf("  --help           Show this help\n");
+	ft_printf("  --version        Print the version and exit\n");
 	ft_printf("  -c <script>      Execute script string\n");
 	ft_printf("  --verbose        Verbose mode\n");
 	ft_printf("  --posix          POSIX mode (disable non-POSIX extensions)\n");

--- a/src/core/opt.c
+++ b/src/core/opt.c
@@ -12,7 +12,8 @@
 
 #include "core.h"
 
-/* A "--name" startup option: --posix, --verbose, --help, --debug=<x>.  Any
+/* A "--name" startup option: --posix, --verbose, --help, --version,
+   --debug=<x>.  Any
    other "--" word is unrecognised and, like bash and dash, aborts startup
    with usage status 2 (recorded in cli->err). */
 void	cli_long_word(t_shell *state, t_cli *cli, const char *w)
@@ -31,6 +32,8 @@ void	cli_long_word(t_shell *state, t_cli *cli, const char *w)
 		state->option_flags |= OPT_FLAG_DEBUG_AST;
 	else if (!ft_strcmp(w, "--login"))
 		state->option_flags |= OPT_FLAG_LOGIN;
+	else if (!ft_strcmp(w, "--version"))
+		state->option_flags |= OPT_FLAG_VERSION;
 	else
 		cli->err = 2;
 }

--- a/src/infrastructure/prompt.c
+++ b/src/infrastructure/prompt.c
@@ -127,8 +127,10 @@ static void	maybe_bench(void)
 /* Build the primary prompt for an interactive read. A user-set PS1 (from
    ~/.hellishrc or the environment) takes over completely, rendered with
    the bash escape set — the built-in two-row prompt is simply the theme
-   you get when PS1 is unset. Otherwise: the frame counter is advanced so
-   each readline call shows the next blink frame, and the status is
+   you get when PS1 is unset. Otherwise: the frame counter advances only
+   when HELLISH_ANIM selects a live style, so the default prompt is
+   perfectly still and each readline call redraws the SAME glyph; the
+   status is
    snapshotted before rendering so the arrow colour reflects the command
    that just finished, not a half-updated value. */
 t_string	prompt_normal(t_shell *state)
@@ -146,7 +148,8 @@ t_string	prompt_normal(t_shell *state)
 	vec_init(&ret);
 	ret.elem_size = 1;
 	status = state->last_cmd_st_exe.status;
-	(*anim_frame())++;
+	if (anim_style(state) != 0)
+		(*anim_frame())++;
 	*anim_status() = status;
 	*anim_dur_ms() = state->last_cmd_ms;
 	*anim_jobs() = state->job_table.count;

--- a/src/infrastructure/prompt_anim.c
+++ b/src/infrastructure/prompt_anim.c
@@ -51,8 +51,13 @@ t_panim	*anim_cells(void)
 	return (&a);
 }
 
-/* 0 = off/unset/unknown, 1 = spinner, 2 = pulse, 3 = ember. */
-static int	anim_style(t_shell *state)
+/* 0 = off/unset/unknown, 1 = spinner, 2 = pulse, 3 = ember.
+   UNSET means OFF: animation is opt-in. It used to be that only the \A
+   escape consulted this, while the built-in prompt animated no matter
+   what -- so a user who set HELLISH_ANIM=off, or never set it at all,
+   still got a prompt whose mascot changed on every render and no way to
+   stop it short of writing a whole custom PS1. */
+int	anim_style(t_shell *state)
 {
 	char	*s;
 

--- a/src/infrastructure/prompt_private.h
+++ b/src/infrastructure/prompt_private.h
@@ -122,6 +122,7 @@ typedef struct s_dcache
 
 void		vec_push_ansi(t_string *v, const char *seq);
 void		tty_write_all(int fd, const char *buf, size_t len);
+int			anim_style(t_shell *state);
 int			get_cols(void);
 int			measure_width(const char *str);
 char		*shorten_path(const char *path, int maxlen);

--- a/src/infrastructure/update_version.c
+++ b/src/infrastructure/update_version.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "update.h"
+#include "version.h"
 
 /* Read one dotted version component, advancing past a trailing '.'. */
 static int	next_num(const char **s)
@@ -49,4 +50,20 @@ int	hellish_version_cmp(const char *a, const char *b)
 			return (x - y);
 	}
 	return (0);
+}
+
+/* `hellish --version`, shaped like `bash --version`: a first line a human
+   or a script can grep, then where the build came from. The repo slug and
+   the asset name are printed too because they are what the updater will
+   actually contact -- a build whose slug points somewhere unexpected is
+   worth seeing before it downloads anything.
+
+   Exits 0 without running any startup file or reading stdin, so it stays
+   usable from a package manager, a Dockerfile or a CI probe. */
+void	print_version(void)
+{
+	ft_printf("hellish, version %s (%s)\n", HELLISH_VERSION, HELLISH_ASSET);
+	ft_printf("Release channel: https://github.com/%s\n", HELLISH_REPO);
+	ft_printf("An almost-POSIX shell, diffed byte-for-byte "
+		"against bash --posix.\n");
 }

--- a/tests/cd_posix_compare.sh
+++ b/tests/cd_posix_compare.sh
@@ -18,6 +18,23 @@
 set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
+# The bash in PATH is the SPECIFICATION for these cases, not an environment
+# detail, and it changes POSIX-visible behaviour between minor releases --
+# cd's status on too many operands is exit 1 up to bash 5.2 and exit 2 from
+# 5.3. Grading against whatever bash the host ships reports that drift as a
+# hellish bug. Prefer the pinned oracle `make oracle` builds, and say plainly
+# when we are grading against something else.
+ORACLE_HOME="${HELLISH_ORACLE:-$HOME/bash-5.3.9}"
+if [ -x "$ORACLE_HOME/bin/bash" ]; then
+	PATH="$ORACLE_HOME/bin:$PATH"
+	export PATH
+fi
+case "$(bash --version 2>/dev/null | head -1)" in
+	*"version 5.3"*) ;;
+	*) printf '\033[33m!  grading against bash %s, not the pinned 5.3.9 -- run `make oracle`\033[0m\n' \
+		"$(bash --version 2>/dev/null | head -1 | sed 's/.*version \([0-9.]*\).*/\1/')" >&2 ;;
+esac
+
 HELLISH="${HELLISH:-$HERE/../build/bin/hellish}"
 # Absolutise: the cases cd into sandbox dirs before invoking hellish, so a
 # relative path (e.g. from `make`) would stop resolving.

--- a/tests/cli_opts_compare.sh
+++ b/tests/cli_opts_compare.sh
@@ -13,6 +13,23 @@
 set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
+# The bash in PATH is the SPECIFICATION for these cases, not an environment
+# detail, and it changes POSIX-visible behaviour between minor releases --
+# cd's status on too many operands is exit 1 up to bash 5.2 and exit 2 from
+# 5.3. Grading against whatever bash the host ships reports that drift as a
+# hellish bug. Prefer the pinned oracle `make oracle` builds, and say plainly
+# when we are grading against something else.
+ORACLE_HOME="${HELLISH_ORACLE:-$HOME/bash-5.3.9}"
+if [ -x "$ORACLE_HOME/bin/bash" ]; then
+	PATH="$ORACLE_HOME/bin:$PATH"
+	export PATH
+fi
+case "$(bash --version 2>/dev/null | head -1)" in
+	*"version 5.3"*) ;;
+	*) printf '\033[33m!  grading against bash %s, not the pinned 5.3.9 -- run `make oracle`\033[0m\n' \
+		"$(bash --version 2>/dev/null | head -1 | sed 's/.*version \([0-9.]*\).*/\1/')" >&2 ;;
+esac
+
 HELLISH="${HELLISH:-$HERE/../build/bin/hellish}"
 HELLISH="$(cd "$(dirname "$HELLISH")" 2>/dev/null && pwd)/$(basename "$HELLISH")"
 export HELLISH_NO_BANNER=1 HELLISH_NO_UPDATE_CHECK=1
@@ -99,6 +116,26 @@ if [ "$gi" = 1 ] && [ "$gn" = 0 ]; then
 else
   fail=$((fail+1)); printf '  \033[31mFAIL\033[0m -i=%s plain=%s (want 1/0)\n' "$gi" "$gn"
 fi
+
+# --version: exit 0, one greppable first line carrying the version, and it
+# must NOT read stdin or run a startup file (package managers and CI probe
+# with it). The version it prints has to be the one baked into version.h,
+# otherwise a release can ship a binary that misreports itself.
+printf '\n\033[1m== --version ==\033[0m\n'
+want=$(grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' "$HERE/../incs/version.h" | head -1 | tr -d '"')
+vout=$(printf 'echo SHOULD_NOT_RUN\n' | "$HELLISH" --version 2>&1); vrc=$?
+vfirst=$(printf '%s\n' "$vout" | head -1)
+for c in "exit status 0:$vrc:0" \
+         "reports version.h version:$(printf '%s' "$vfirst" | grep -c "$want"):1" \
+         "first line names the shell:$(printf '%s' "$vfirst" | grep -c '^hellish'):1" \
+         "does not execute stdin:$(printf '%s' "$vout" | grep -c SHOULD_NOT_RUN):0"; do
+  name=${c%%:*}; rest=${c#*:}; got=${rest%%:*}; exp=${rest#*:}
+  if [ "$got" = "$exp" ]; then
+    pass=$((pass+1)); printf '  \033[32mOK\033[0m   %s\n' "$name"
+  else
+    fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s (got %s want %s)\n' "$name" "$got" "$exp"
+  fi
+done
 
 printf '\n\033[1m== %d pass, %d fail (bash %s) ==\033[0m\n' \
   "$pass" "$fail" "$(bash --version 2>/dev/null | head -1)"

--- a/tests/hard/run.sh
+++ b/tests/hard/run.sh
@@ -31,6 +31,15 @@ pass=0; fail=0
 for s in $scripts; do
   name=$(basename "$s")
   ho=$("$H" "$s" 2>&1); hc=$?
+  # rc 126 immediately after a build is ETXTBSY ("text file busy"): some
+  # linkers briefly keep the output open, so exec'ing it races. Retry
+  # before calling it a failure -- it cost three phantom FAILs once.
+  tries=0
+  while [ "$hc" -eq 126 ] && [ $tries -lt 5 ]; do
+    sleep 0.2
+    ho=$("$H" "$s" 2>&1); hc=$?
+    tries=$((tries + 1))
+  done
   bo=$(bash --posix "$s" 2>&1); bc=$?
   if [ "$ho" = "$bo" ] && [ "$hc" = "$bc" ]; then
     # timing best-of-3
@@ -50,3 +59,8 @@ for s in $scripts; do
   fi
 done
 printf -- "---- %d PASS / %d FAIL ----\n" "$pass" "$fail"
+
+# Exit non-zero when anything failed. This runner used to fall off the end
+# and exit 0 no matter what, so any caller that trusted its status -- a CI
+# job, a pre-PR script -- saw green while the summary above said FAIL.
+[ "$fail" -eq 0 ]

--- a/tests/prompt_shortwrite_test.py
+++ b/tests/prompt_shortwrite_test.py
@@ -35,6 +35,15 @@ SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
                         else "../build/bin/hellish")
 FAILS = []
 
+ENV = {
+    "HOME": os.environ.get("HOME", "/tmp"),
+    "PATH": os.environ["PATH"],
+    "TERM": "xterm-256color", "LANG": "C.UTF-8",
+    "COLORTERM": "truecolor",
+    "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+    "ASAN_OPTIONS": "detect_leaks=0",
+}
+
 # An SGR body that reached the screen without its ESC[ introducer: digits and
 # semicolons ending in 'm', sitting next to prompt text rather than after ESC.
 ORPHAN_SGR = re.compile(r'(?<!\x1b\[)(?<![\x1b\[0-9;])\b\d{1,3}(?:;\d{1,3}){2,}m')
@@ -48,14 +57,7 @@ def check(name, ok, detail=""):
 
 def run(cols=200, rounds=14):
     """Drive the shell with a laggy reader so the tty output queue fills."""
-    env = {
-        "HOME": os.environ.get("HOME", "/tmp"),
-        "PATH": os.environ["PATH"],
-        "TERM": "xterm-256color", "LANG": "C.UTF-8",
-        "COLORTERM": "truecolor",
-        "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
-        "ASAN_OPTIONS": "detect_leaks=0",
-    }
+    env = dict(ENV)
     pid, fd = pty.fork()
     if pid == 0:
         os.environ.clear()
@@ -99,7 +101,57 @@ def run(cols=200, rounds=14):
     return raw
 
 
+def idle_bytes(anim, seconds=2.0):
+    """Bytes the shell writes to the terminal while sitting idle."""
+    env = dict(ENV)
+    if anim is not None:
+        env["HELLISH_ANIM"] = anim
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(env)
+        os.execvp(SHELL, [SHELL])
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 120, 0, 0))
+    time.sleep(1.0)
+    end = time.time() + 0.8          # drain the first prompt
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if r:
+            try:
+                os.read(fd, 65536)
+            except OSError:
+                break
+    n = 0
+    end = time.time() + seconds      # now measure: nobody is typing
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if r:
+            try:
+                n += len(os.read(fd, 65536))
+            except OSError:
+                break
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    return n
+
+
 def main():
+    # An idle prompt must be silent by default. The animation repaint is the
+    # only thing that writes to the terminal when the user is not typing, and
+    # it is opt-in precisely because that traffic is what corrupts prompts on
+    # some terminals. If someone makes a live style the default again, this
+    # is the check that catches it.
+    n = idle_bytes(None)
+    check("idle prompt writes nothing by default", n == 0,
+          "wrote %d bytes while idle" % n)
+    n = idle_bytes("off")
+    check("HELLISH_ANIM=off keeps the prompt silent", n == 0,
+          "wrote %d bytes while idle" % n)
+
     raw = run()
     text = raw.decode("utf-8", errors="replace")
 

--- a/tests/update_test.py
+++ b/tests/update_test.py
@@ -116,6 +116,19 @@ def version_of(binary, env):
     return out.strip().split()[-1]
 
 
+def flag_version(binary, env):
+    """The version reported by the top-level `--version` flag.
+
+    Deliberately a different code path from version_of(): that one asks the
+    `update` builtin, this one is the flag a user, a package manager or a
+    Dockerfile actually types. They read the same constant, so they must
+    never disagree -- and if they ever do, the one people trust is this one.
+    """
+    _, out = run(binary, env, ["--version"])
+    first = out.strip().splitlines()[0] if out.strip() else ""
+    return first.rstrip(")").split()[-2] if "(" in first else ""
+
+
 def main():
     home = tempfile.mkdtemp(prefix="hellish_upd_")
     binary = installed_copy(home)
@@ -157,6 +170,13 @@ def main():
           "got %s want %s" % (version_of(binary, pub.env(home)), newer))
     check("no temp file left behind",
           not os.path.exists(binary + ".hellish-update"))
+    # The flag a human types must agree with what the updater believes it
+    # installed. A binary that misreports its own version turns every later
+    # "did the update work?" into guesswork.
+    check("--version agrees with the updater after installing",
+          flag_version(binary, pub.env(home)) == newer,
+          "--version says %r, updater says %r"
+          % (flag_version(binary, pub.env(home)), newer))
     # a session that just installed the update must stop announcing it:
     # the running process is still the old build, and re-offering an
     # update the user has already performed reads as if it had failed

--- a/tools/capture-prompt-bug.sh
+++ b/tools/capture-prompt-bug.sh
@@ -41,5 +41,10 @@ script -q -f -c "$bin" "$out.raw"
 } > "$out.analysis" 2>&1
 
 echo
-echo "analysis : $out.analysis"
+echo "analysis : $out.analysis      <- send this one"
 echo "raw      : $out.raw"
+echo
+echo "NOTE: do NOT 'cat' the .raw file. It contains every escape byte the"
+echo "      terminal received, including all the recorded prompts, so cat"
+echo "      replays the whole session and looks like fresh corruption."
+echo "      Read it with:  less -R $out.raw   (or just send it)"


### PR DESCRIPTION
Follow-on to #35 (which merged the write-whole-frames fix alone). These six commits complete v2.6.0.

Release-readiness for **v2.6.0**: a new CLI flag, four fixes, and the test suites that previously only ran when somebody remembered.

## New — `hellish --version`

It used to answer `invalid option`. It now prints the version, the asset the updater will fetch, and the repo it will fetch it from — a build pointing somewhere unexpected is worth seeing *before* it downloads anything.

```
$ hellish --version
hellish, version 2.6.0 (hellish-linux-x86_64)
Release channel: https://github.com/Univers42/hellish
An almost-POSIX shell, diffed byte-for-byte against bash --posix.
```

Exits 0 without sourcing a startup file or reading stdin, so package managers and CI can probe it safely. Four new checks in `cli_opts_compare.sh`, including that the version printed **is the one in `version.h`** — a release shipping a binary that misreports itself is worse than having no flag.

## CI now runs what it never ran

`make test` and the script corpus were the only things CI checked. Fifteen-odd other Makefile targets ran only by hand. Five new parallel jobs:

| job | covers |
|---|---|
| `gates` | cli-opts, login, help, cd-posix, update-config |
| `interactive` | 8 pty gates: readline, hist, prompt-atomic, anim, git-prompt, widechar, bg-tty, prompt-integrity |
| `update` | the update path against a local fake release server, plus `/dev/tcp` |
| `corpus` | `tests/hard/` (own runner, never in `make test`) + allocator parity on both heaps |
| `bench` | measured, uploaded as an artifact, **never a gate** |

Benchmarks are `continue-on-error` on purpose: shared runners are noisy neighbours, and timing thresholds there produce flaky red builds, which teaches people to ignore CI.

The pinned-bash-5.3.9 setup is now a composite action instead of thirty duplicated lines in six jobs.

## Two defects found while wiring CI up

- **`tests/hard/run.sh` always exited 0.** It printed `14 PASS / 3 FAIL` and returned success — it fell off the end of the loop. Harmless while only humans read it; not harmless the moment CI does. Now exits non-zero, and retries `rc 126` (ETXTBSY — the binary being relinked mid-run, which is what produced those three phantom FAILs).
- **Two compare scripts graded against whatever bash the host shipped.** `tests/tester` has always preferred the pinned 5.3.9; these did not. `make cd-posix-test` failed here with four "failures" that were pure version drift (`cd aaa bbb` is exit 1 through bash 5.2, exit 2 from 5.3 — hellish already matched 5.3.9 exactly). Both now pin the oracle and warn loudly otherwise: 3 pass/4 fail → **7 pass/0 fail**, no shell source touched.

## Fixes carried in this branch

- **Prompt frames are written whole.** Both prompt writers used a single unchecked `write()`; `write(2)` may transfer fewer bytes than asked and report success, silently dropping the tail. Demonstrated: a 1048576-byte tty write returning 12032.
- **The animation ships off.** It was the only thing writing to the terminal while the user was not typing — **6428 bytes per 2.5s** at an idle prompt, versus **0** now. `HELLISH_ANIM` also now governs the built-in prompt, which previously animated regardless of the setting.

## Scope note, stated plainly

The animation change does **not** explain the corruption in #34. The reporter's `PS1` is commented out, so they get the built-in prompt, which never armed the live repaint — verified: their exact rc writes **0 idle bytes**. And the short-write fix cannot explain it either: a short write drops the *tail*, while the reported symptom is a missing *head* (`ESC[3` gone, body printed). Both changes are genuine, independently justified improvements; neither is the fix for #34, which stays open with the ruled-out list recorded.

## Verification

3688 golden cases · 11 pty/auxiliary gates · hard corpus · `verify_alloc` both heaps · `make re` and `make re OPT=1` · norminette clean.
