### PR TITLE
feat(prompt): keep a pending update visible instead of saying it once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,8 @@ jobs:
         run: make bg-tty-test
       - name: prompt integrity (idle silence + no cut escapes)
         run: make prompt-integrity-test
+      - name: pending-update badge stays visible in the prompt
+        run: make update-badge-test
 
   # ── Update path and network-shaped redirections ──────────────────────────
   # Both bring up their own local peer; neither touches the network. The

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,26 @@ jobs:
           npm version --no-git-tag-version --allow-same-version "${GITHUB_REF_NAME#v}"
           npm publish --access public
 
+  # Docker Hub is a SECONDARY channel: GHCR already publishes the image from
+  # its own workflow using GITHUB_TOKEN, and the GitHub release asset is what
+  # the shell's own updater fetches. So a Docker Hub problem must not paint
+  # the release red -- v2.6.0 shipped its binary, its checksum and its GHCR
+  # image correctly and still reported failure, because the Docker Hub
+  # personal access token had expired:
+  #
+  #   unauthorized: personal access token is expired
+  #
+  # A release run that is permanently red is worse than no signal at all:
+  # the next genuine failure looks identical to this one and gets shrugged
+  # off. continue-on-error keeps the failure visible as a warning on the job
+  # while the run's conclusion reflects the channels that actually matter.
+  # (The token still needs rotating -- this makes the breakage legible, it
+  # does not fix it.)
   docker:
-    name: build + push image (needs DOCKERHUB_* secrets)
+    name: build + push image (Docker Hub, optional)
     needs: binary
     runs-on: ubuntu-24.04
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -594,6 +594,12 @@ bg-tty-test: all
 prompt-integrity-test: all
 	@python3 $(TEST_DIR)/prompt_shortwrite_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
+# The pending-update badge. The loud notice is one-shot by design; this is
+# the quiet marker that persists while an update is actually waiting, so a
+# user who missed the notice still finds out. Also covers the \U escape.
+update-badge-test: all
+	@python3 $(TEST_DIR)/update_badge_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
+
 # Release/update configuration, checked offline: the GitHub slug baked into
 # version.h must match the repository we actually push to, every
 # distribution channel (install.sh, npm, Dockerfile, docs) must agree with
@@ -689,7 +695,7 @@ geoman: all
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
 	docker-arch docker-clean cd-zsh-test cd-posix-test agnostic-bench \
 	hist-test readline-test anim-test git-prompt-test prompt-atomic-test \
-	bg-tty-test prompt-integrity-test \
+	bg-tty-test prompt-integrity-test update-badge-test \
 	update-config-test update-test help-test \
 	conformance perf rss \
 	charts cli-opts-test net-redir-test login-test geoman oracle docker-suite docker widechar-test \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,35 @@ shows you how to drive the shell.
 
 ---
 
+## v2.7.0 — *the it-tells-you release*
+
+**New**
+
+- **A pending update stays visible in the prompt.** The "update available"
+  notice is said once and then never again — deliberately, because a banner
+  on every prompt is how people learn to stop reading banners. But miss it
+  once and nothing brought it back. Now a quiet badge persists for as long
+  as the update is actually waiting:
+
+  ```
+  ╭─ you in ~/project ⬆2.7.1 ──────────────────── 15:04 ─╮
+  ╰─❯
+  ```
+
+  Self-spacing (invisible when there is nothing to say), dropped on a narrow
+  row like the other badges, gone by itself once you update, and silenced by
+  `HELLISH_NO_UPDATE_CHECK`. Custom prompts get `\U`.
+
+**Fixed**
+
+- **Releases stop reporting themselves as failed.** Every tag showed
+  `release -> failure` while shipping perfectly good artifacts: the Docker
+  Hub push (a secondary channel — GHCR publishes the same image) was failing
+  on an expired token and taking the whole run's status with it. A
+  permanently red release run makes the next genuine failure invisible.
+
+---
+
 ## v2.6.0 — *the ask-it-what-it-is release*
 
 **New**

--- a/hellishrc.example
+++ b/hellishrc.example
@@ -15,6 +15,11 @@
 #   \S  " ✘N" after a failing command, empty after success
 #   \p  " took N.Ns" once a command ran 2s or longer
 #   \J  " ⚙N" while background jobs exist
+#   \U  " ⬆X.Y.Z" while a newer release is waiting, empty otherwise. The
+#       "update available" notice is said ONCE and then never again; this
+#       is the quiet marker that stays until you actually update. The
+#       built-in prompt shows it already -- add \U to a custom PS1 to keep
+#       it. Silenced by HELLISH_NO_UPDATE_CHECK like the rest.
 #   \A  an ANIMATED glyph (see HELLISH_ANIM below) — OPT-IN, off by
 #       default. (Shadows bash's \A 24h-clock escape; use \t for time.)
 # Live $VAR / ${VAR} expansion happens at every render.

--- a/incs/shell.h
+++ b/incs/shell.h
@@ -208,6 +208,8 @@ typedef struct s_shell
 	t_string			cwd; /* current working directory string */
 	t_ast_node			tree; /* parsed AST for current input */
 	int					metinp; /* input method: INP_RL / FILE / ARG */
+	char				upd_tag[32]; /* pending update version, "" if none */
+	long				upd_seen; /* when upd_tag was last refreshed */
 	char				*dft_ctx; /* default shell name for error msgs */
 	char				*ctx; /* active error context (argv[0]) */
 	/* --- special variables (borrowed ptrs or small buffers, not freed) --- */

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.6.0"
+# define HELLISH_VERSION "2.7.0"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/builtins/builtin_printf.c
+++ b/src/builtins/builtin_printf.c
@@ -32,14 +32,14 @@ void	pf_err_num(t_pf *pf, const char *arg)
 }
 
 /* Render one snprintf-delegated conversion into `buf` (4096 bytes). The
-   conversion char is the spec's last byte. Integer values go through the
-   strict pf_num check; floats get the same trailing-junk treatment via
-   strtod — bash prints the converted prefix but still exits 1. */
+   conversion char is the spec's last byte. Signed integers go through
+   pf_num, UNSIGNED ones through pf_unum -- routing %u/%o/%x/%X through the
+   signed parser clamped every value above LLONG_MAX (issue #28). Floats
+   get the same trailing-junk treatment via strtod in pf_conv_float — bash
+   prints the converted prefix but still exits 1. */
 static void	pf_conv_str(t_pf *pf, char *fmt, const char *arg, char *buf)
 {
 	char	conv;
-	char	*end;
-	double	d;
 
 	conv = fmt[ft_strlen(fmt) - 1];
 	if (conv == 's')
@@ -48,19 +48,12 @@ static void	pf_conv_str(t_pf *pf, char *fmt, const char *arg, char *buf)
 			arg = "";
 		snprintf(buf, 4096, fmt, arg);
 	}
-	else if (ft_strchr("diouxX", conv))
+	else if (ft_strchr("ouxX", conv))
+		snprintf(buf, 4096, fmt, pf_unum(pf, arg));
+	else if (ft_strchr("di", conv))
 		snprintf(buf, 4096, fmt, pf_num(pf, arg));
 	else
-	{
-		d = 0.0;
-		errno = 0;
-		end = (char *)arg;
-		if (arg)
-			d = strtod(arg, &end);
-		if (arg && (end == arg || *end != '\0' || errno == ERANGE))
-			pf_err_num(pf, arg);
-		snprintf(buf, 4096, fmt, d);
-	}
+		pf_conv_float(pf, fmt, arg, buf);
 }
 
 /* %c prints the first byte of its argument — bash emits a real NUL byte

--- a/src/builtins/printf_private.h
+++ b/src/builtins/printf_private.h
@@ -50,10 +50,18 @@ typedef struct s_spec
 }	t_spec;
 
 const char	*pf_arg(t_pf *pf);
+/* printf renders unsigned conversions through the full 64-bit range;
+   spelled as a typedef so the declarations below keep one alignment
+   column (`unsigned long long` is too wide for it). */
+typedef unsigned long long	t_ull;
+
 void		pf_err_num(t_pf *pf, const char *arg);
 char		pf_escape(const char *s, int *i, bool *stop);
 long long	pf_num(t_pf *pf, const char *arg);
+void		pf_conv_float(t_pf *pf, char *fmt, const char *arg,
+				char *buf);
 void		pf_emit_b(t_string *out, const char *arg, bool *stop);
+t_ull		pf_unum(t_pf *pf, const char *arg);
 void		pf_conv(t_pf *pf, t_spec *sp, char conv);
 void		pf_parse_spec(t_pf *pf, const char *fmt, int *i, t_spec *sp);
 void		pf_build_spec(char *dst, t_spec *sp, char conv);

--- a/src/builtins/printf_unum.c
+++ b/src/builtins/printf_unum.c
@@ -1,0 +1,71 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   printf_unum.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/20 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/20 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "printf_private.h"
+#include <errno.h>
+#include <stdlib.h>
+
+/* The unsigned half of printf's numeric argument parsing.
+
+   %u/%o/%x/%X went through pf_num like everything else, which parses with
+   strtoll -- so any value above LLONG_MAX saturated there, long before the
+   conversion ran:
+
+       printf "%u\n" 18446744073709551615
+         bash     18446744073709551615
+         hellish   9223372036854775807
+
+   The printed spec was never the problem (pf_build_spec already injects
+   "ll", so snprintf sees %llu); the value handed to it had already been
+   clamped. strtoull is the whole fix.
+
+   Negatives are deliberately NOT rejected: strtoull negates in unsigned
+   arithmetic, so `printf %u -1` gives 18446744073709551615, exactly what
+   bash prints. Genuine overflow still sets ERANGE and is reported, which
+   matches bash exiting 1 while still emitting the clamped prefix. A
+   leading quote yields the next byte's code point, as for the signed
+   conversions; a missing argument is silently zero. */
+t_ull	pf_unum(t_pf *pf, const char *arg)
+{
+	char	*end;
+	t_ull	v;
+
+	if (!arg)
+		return (0);
+	if (arg[0] == '\'' || arg[0] == '"')
+		return ((unsigned char)arg[1]);
+	errno = 0;
+	v = strtoull(arg, &end, 0);
+	if (end == arg || *end != '\0' || errno == ERANGE)
+		pf_err_num(pf, arg);
+	return (v);
+}
+
+/* The floating-point conversions (%e %f %g %a and friends). Split out of
+   pf_conv_str only so that function keeps room for the signed/unsigned
+   split above it. bash prints the converted prefix of a malformed number
+   and still exits 1, which is why the error is reported but the value is
+   used anyway. */
+void	pf_conv_float(t_pf *pf, char *fmt, const char *arg, char *buf)
+{
+	char	*end;
+	double	d;
+
+	d = 0.0;
+	errno = 0;
+	end = (char *)arg;
+	if (arg)
+		d = strtod(arg, &end);
+	if (arg && (end == arg || *end != '\0' || errno == ERANGE))
+		pf_err_num(pf, arg);
+	snprintf(buf, 4096, fmt, d);
+}

--- a/src/infrastructure/prompt.c
+++ b/src/infrastructure/prompt.c
@@ -74,12 +74,14 @@ t_string	prompt_more_input(t_shell *state, t_parser *parser)
    blinking mascot, the box (user/cwd/branch/venv), the clock, and the arrow.
    Called both by prompt_normal and, with an advancing frame, by the readline
    idle hook -- so the mascot keeps blinking even while a command is typed. */
-void	render_prompt(t_string *ret, size_t frame, int status)
+void	render_prompt(t_shell *state, t_string *ret, size_t frame,
+			int status)
 {
 	t_prompt	p;
 	int			mascot_w;
 
 	p.exit_status = status;
+	p.upd = (char *)prompt_update_tag(state);
 	mascot_w = push_mascot(ret, frame, status);
 	prompt_user_and_cwd(ret, &p);
 	p.vis_w += mascot_w;
@@ -115,7 +117,7 @@ static void	maybe_bench(void)
 			clock_gettime(CLOCK_MONOTONIC, &ts[0]);
 		vec_init(&r);
 		r.elem_size = 1;
-		render_prompt(&r, (size_t)i, 0);
+		render_prompt(NULL, &r, (size_t)i, 0);
 		xfree(r.ctx);
 	}
 	clock_gettime(CLOCK_MONOTONIC, &ts[1]);
@@ -153,6 +155,6 @@ t_string	prompt_normal(t_shell *state)
 	*anim_status() = status;
 	*anim_dur_ms() = state->last_cmd_ms;
 	*anim_jobs() = state->job_table.count;
-	render_prompt(&ret, *anim_frame(), status);
+	render_prompt(state, &ret, *anim_frame(), status);
 	return (ret);
 }

--- a/src/infrastructure/prompt_private.h
+++ b/src/infrastructure/prompt_private.h
@@ -46,6 +46,7 @@ typedef struct s_prompt
 	int		branch_dirty;
 	int		exit_status;
 	char	time_buf[32];
+	char	*upd;
 }	t_prompt;
 
 /* Palette slot ids for pal(): every colour the prompt uses, resolved at
@@ -123,6 +124,16 @@ typedef struct s_dcache
 void		vec_push_ansi(t_string *v, const char *seq);
 void		tty_write_all(int fd, const char *buf, size_t len);
 int			anim_style(t_shell *state);
+
+/* Seconds the pending-update badge trusts its cached read of the update
+   state file. The prompt is on the hot path; this is not re-read per
+   render. */
+# define UPD_TAG_TTL 5
+
+const char	*prompt_update_tag(t_shell *state);
+const char	*upd_tag_or_null(t_shell *state);
+void		ps1_update(t_shell *state, t_string *out);
+void		render_update_badge(t_string *ret, t_prompt *p);
 int			get_cols(void);
 int			measure_width(const char *str);
 char		*shorten_path(const char *path, int maxlen);
@@ -162,7 +173,8 @@ void		prompt_time_and_pad(t_string *ret, t_prompt *p);
 
 /* the blinking devil mascot + its readline-idle animation */
 int			push_mascot(t_string *ret, size_t frame, int status);
-void		render_prompt(t_string *ret, size_t frame, int status);
+void		render_prompt(t_shell *state, t_string *ret, size_t frame,
+				int status);
 size_t		*anim_frame(void);
 long long	*anim_dur_ms(void);
 int			*anim_jobs(void);

--- a/src/infrastructure/prompt_ps1c.c
+++ b/src/infrastructure/prompt_ps1c.c
@@ -52,7 +52,8 @@ void	ps1_jobs(t_shell *state, t_string *out)
 }
 
 /* Extension dispatch, tried after the bash-compatible set: \g branch,
-   \S failure badge, \p duration, \J jobs, \A animation frame. Returns
+   \S failure badge, \p duration, \J jobs, \A animation frame, \U pending
+   update. Returns
    false so unknown escapes still fall through to literal passthrough. */
 bool	ps1_escape_ext(t_shell *state, t_string *out, char c)
 {
@@ -66,5 +67,7 @@ bool	ps1_escape_ext(t_shell *state, t_string *out, char c)
 		return (ps1_jobs(state, out), true);
 	if (c == 'A')
 		return (ps1_anim(state, out), true);
+	if (c == 'U')
+		return (ps1_update(state, out), true);
 	return (false);
 }

--- a/src/infrastructure/prompt_update.c
+++ b/src/infrastructure/prompt_update.c
@@ -1,0 +1,96 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   prompt_update.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/20 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/20 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "prompt_private.h"
+#include "update.h"
+#include "version.h"
+
+#define C_RST2 "\033[0m"
+
+/* Is an update waiting, and which one?  Returns the version string, or NULL.
+
+   This exists because the one-shot notice was too easy to miss. The REPL
+   announces a newly discovered version once, between commands, and then
+   sets `notified` so it never says it again -- deliberately, because a
+   banner on every prompt is how users learn to stop reading banners. But
+   "once, ever" means a user who was scrolled away, or who opened the
+   terminal that printed it and closed it, never learns there is an update
+   at all. The background check only runs daily, so nothing brings it back.
+
+   A badge is the other half of that design: the loud notice stays a
+   one-shot, and this quiet marker persists in the prompt for as long as
+   the update is actually pending. It costs one line of the prompt row and
+   disappears by itself once the new binary is in place.
+
+   The state file is re-read at most every UPD_TAG_TTL seconds rather than
+   on every render: the prompt is on the hot path (see HELLISH_PROMPT_BENCH)
+   and this would otherwise be an open+read+parse per keystroke-to-prompt
+   cycle. Five seconds is far below human notice and far above the cost.
+
+   A NULL state is the prompt benchmark, which renders without a shell. */
+const char	*prompt_update_tag(t_shell *state)
+{
+	t_upd_state	s;
+	long		now;
+
+	if (!state || state->metinp != INP_RL
+		|| getenv("HELLISH_NO_UPDATE_CHECK"))
+		return (NULL);
+	now = (long)time(NULL);
+	if (state->upd_seen && now - state->upd_seen < UPD_TAG_TTL)
+		return (upd_tag_or_null(state));
+	state->upd_seen = now;
+	state->upd_tag[0] = '\0';
+	if (update_state_load(&s) && update_available(&s))
+		ft_strlcpy(state->upd_tag, s.latest, sizeof(state->upd_tag));
+	return (upd_tag_or_null(state));
+}
+
+/* The cached tag, or NULL when the field is empty. Kept separate so the
+   "empty means none" rule is stated once instead of at each return. */
+const char	*upd_tag_or_null(t_shell *state)
+{
+	if (!state || !state->upd_tag[0])
+		return (NULL);
+	return (state->upd_tag);
+}
+
+/* The \U prompt escape: " ⬆<version>" when an update is pending, nothing
+   otherwise. Self-spacing like \g, \S, \p and \J, so a PS1 can carry it
+   unconditionally and it stays invisible until it has something to say. */
+void	ps1_update(t_shell *state, t_string *out)
+{
+	const char	*tag;
+
+	tag = prompt_update_tag(state);
+	if (!tag)
+		return ;
+	vec_push_str(out, " \xe2\xac\x86");
+	vec_push_str(out, tag);
+}
+
+/* "⬆X.Y.Z" while a newer release is waiting. The loud one-shot notice is
+   emitted once between commands and then silenced forever; this is the
+   quiet half that persists, so a user who was scrolled away when it
+   printed still finds out. Dropped on a narrow row like the other
+   accessories -- the box alignment outranks the badge. */
+void	render_update_badge(t_string *ret, t_prompt *p)
+{
+	if (!p->upd || p->cols - p->vis_w <= 30)
+		return ;
+	vec_push_str(ret, " ");
+	vec_push_ansi(ret, pal(PAL_DUR));
+	vec_push_str(ret, "\xe2\xac\x86");
+	vec_push_str(ret, p->upd);
+	vec_push_ansi(ret, C_RST2);
+	p->vis_w += measure_width(p->upd) + 2;
+}

--- a/src/infrastructure/prompt_utils4.c
+++ b/src/infrastructure/prompt_utils4.c
@@ -54,7 +54,8 @@ static void	fmt_duration(long long ms, char *buf, size_t n)
 		snprintf(buf, n, "%lldh%02lldm", s / 3600, (s % 3600) / 60);
 }
 
-/* Optional top-row segments after the venv: a background-jobs badge
+/* Optional top-row segments after the venv: a pending-update badge (⬆X.Y.Z)
+   for as long as a newer release is waiting, a background-jobs badge
    (⚙N) whenever jobs exist, and "took N.Ns" once the last foreground
    command crossed 2 seconds — long enough to skip the noise of instant
    commands, short enough to catch anything you actually waited on.
@@ -66,6 +67,7 @@ void	render_extras(t_string *ret, t_prompt *p)
 {
 	char	buf[24];
 
+	render_update_badge(ret, p);
 	if (*anim_jobs() > 0 && p->cols - p->vis_w > 22)
 	{
 		snprintf(buf, sizeof(buf), "\xe2\x9a\x99%d", *anim_jobs());

--- a/tests/printf_length
+++ b/tests/printf_length
@@ -30,3 +30,17 @@ printf "%zu-%zu\n" 10 20; echo "st=$?"
 printf "%hhu\n" 5
 printf "%llx\n" 255
 printf "%lu\n" 4294967296
+printf "%u\n" 18446744073709551615
+printf "%x\n" 18446744073709551615
+printf "%X\n" 18446744073709551615
+printf "%o\n" 18446744073709551615
+printf "%lu\n" 18446744073709551615
+printf "%llu\n" 18446744073709551615
+printf "%u\n" -1
+printf "%x\n" -1
+printf "%u\n" 0
+printf "%u %u\n" 4294967296 9223372036854775808
+printf "%#x\n" 18446744073709551615
+printf "%020u\n" 18446744073709551615
+printf "%u\n" 18446744073709551615; echo "st=$?"
+printf "%d\n" -9223372036854775808

--- a/tests/update_badge_test.py
+++ b/tests/update_badge_test.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Regression test: a pending update stays visible in the prompt.
+
+The loud "update available" notice is emitted once, between commands, and
+then `notified` is set so it is never shown again -- deliberately, because
+a banner on every prompt is how users learn to stop reading banners. But
+"once, ever" meant a user who was scrolled away when it printed, or who
+closed that terminal, never found out at all: the background check only
+runs daily, so nothing brought it back. Reported from the field exactly
+that way -- a new session proposed nothing while `update` itself found the
+release immediately.
+
+The badge is the quiet half of that design: it persists for as long as the
+update is actually pending, and disappears by itself once the new binary
+is in place.
+
+Checks:
+  1. built-in prompt shows "⬆<version>" when the state file has a newer
+     release -- even when `notified` is already set, which is the case
+     that was broken.
+  2. nothing is shown when the cached version is the running one.
+  3. HELLISH_NO_UPDATE_CHECK suppresses it, like every other part of the
+     update subsystem.
+  4. the \\U escape carries it into a custom PS1, and is self-spacing:
+     it renders nothing at all when no update is pending.
+
+Usage: python3 update_badge_test.py /path/to/hellish
+"""
+import fcntl
+import os
+import pty
+import re
+import select
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "../build/bin/hellish")
+HERE = os.path.dirname(os.path.abspath(__file__))
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + (" " + detail if not ok else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def current_version():
+    """The version baked into the binary under test."""
+    out = subprocess.run([SHELL, "--version"], capture_output=True, text=True,
+                         env=dict(os.environ, HELLISH_NO_BANNER="1")).stdout
+    m = re.search(r"version ([0-9]+\.[0-9]+\.[0-9]+)", out)
+    return m.group(1) if m else "0.0.0"
+
+
+def state(home, latest, notified=1):
+    d = os.path.join(home, ".cache", "hellish")
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, "state"), "w") as f:
+        f.write("latest=%s\nchecked=%d\nnotified=%d\n"
+                "header_shown=%d\nheader_rev=99\nheader_ver=%s\n"
+                % (latest, int(time.time()), notified,
+                   int(time.time()), current_version()))
+
+
+def render(home, env_extra=None):
+    """Start the shell on a pty and return what it painted."""
+    env = {
+        "HOME": home, "PATH": os.environ["PATH"],
+        "TERM": "xterm-256color", "LANG": "C.UTF-8", "COLORTERM": "truecolor",
+        "HELLISH_NO_BANNER": "1", "ASAN_OPTIONS": "detect_leaks=0",
+    }
+    if env_extra:
+        env.update(env_extra)
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(env)
+        os.chdir("/tmp")
+        os.execvp(SHELL, [SHELL])
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 140, 0, 0))
+    raw = b""
+    time.sleep(1.0)
+    end = time.time() + 1.2
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if r:
+            try:
+                raw += os.read(fd, 65536)
+            except OSError:
+                break
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    return raw.decode("utf-8", errors="replace")
+
+
+def main():
+    home = tempfile.mkdtemp(prefix="hellish_badge_")
+    cur = current_version()
+
+    # 1: pending update, already announced -> the badge still shows it
+    state(home, "9.9.9", notified=int(time.time()))
+    out = render(home)
+    check("badge shows a pending update the notice already announced",
+          "⬆9.9.9" in out, "prompt had no badge")
+
+    # 3: the global opt-out wins
+    out = render(home, {"HELLISH_NO_UPDATE_CHECK": "1"})
+    check("HELLISH_NO_UPDATE_CHECK suppresses the badge",
+          "⬆" not in out)
+
+    # 4: \U carries it into a custom PS1
+    out = render(home, {"PS1": "[\\U] $ "})
+    check("\\U shows the badge in a custom PS1", "⬆9.9.9" in out)
+
+    # 2: nothing pending -> nothing shown, anywhere
+    state(home, cur, notified=0)
+    out = render(home)
+    check("no badge when the cached version is the running one",
+          "⬆" not in out, "badge shown with latest==%s" % cur)
+    out = render(home, {"PS1": "[\\U] $ "})
+    check("\\U is self-spacing: renders nothing with no update",
+          "⬆" not in out)
+
+    shutil.rmtree(home, ignore_errors=True)
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()


### PR DESCRIPTION
A new session proposed nothing while `update` found 2.6.0 immediately. The cache says exactly why:

```
latest=2.6.0
checked=1787238947     ← the check worked
notified=1787238960    ← and the notice was shown, once
```

`notified` is a single timestamp and `update_notify_prompt` returns early whenever it is set. So the announcement happens **exactly once per discovered version, in one session, and then never again anywhere**. Miss it — scrolled away, wrong terminal, closed the window — and nothing brings it back: the background check only re-runs after 24h and finds the same version it already recorded.

## The fix is not "announce it more"

The one-shot is right for the *loud* notice. A two-line banner on every prompt is how people learn to stop reading banners. What was missing is the quiet half:

```
╭─ user in /tmp ⬆2.6.0 ──────────────────────────── 15:04 ─╮
╰─❯
```

- **Self-spacing**, like `\g` / `\S` / `\p` / `\J` — costs nothing when there is nothing to say.
- **Dropped on a narrow row**, like the jobs and duration badges. Box alignment outranks accessories.
- **Disappears by itself** once the new binary is in place.
- **`HELLISH_NO_UPDATE_CHECK`** silences it with the rest of the subsystem.
- **`\U`** carries it into a custom `PS1`, so replacing the prompt does not silently drop the only remaining signal that an update exists.

## Cost

The state file is re-read at most every 5s (`UPD_TAG_TTL`), not per render — the prompt is on the hot path and has its own benchmark; otherwise this is an open+read+parse per prompt. The cache lives in `t_shell`, **not a new global**.

`render_prompt` now takes `t_shell` so the badge resolves without reaching for another global. The prompt benchmark passes NULL, which `prompt_update_tag` treats as "no shell, no badge".

## Tests

`tests/update_badge_test.py` (`make update-badge-test`, wired into the CI `interactive` job) covers **the case that was actually broken** — a pending update whose notice has already been shown — plus the opt-out, the `\U` escape, and that nothing renders when the cached version is the running one.

Confirmed it fails without the badge (2 of 5 checks), passes with it.

3688 golden cases green; `git-prompt`, `anim`, `widechar`, `prompt-atomic`, `prompt-integrity`, `update` gates all pass; norminette clean.
