### PR TITLE
fix(builtins): history option parsing (#42), the CI completion failure, and a cross-platform matrix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,15 @@
 name: Docker distros
 
-# Build hellish FROM SOURCE in a clean container on four distros to prove it
-# compiles + runs without depending on the host's packages. This is heavy
-# (a full build per distro), so it runs on pushes to the long-lived branches,
-# on PRs that touch the Docker setup, and on demand -- NOT on every code PR
-# (the fast `build` matrix in ci.yml already covers compilation on ubuntu).
+# Proves the CONTRIBUTOR path works: `docker compose build <distro>` and
+# `make docker-test`, exactly as documented in the README, with no host
+# packages involved.
+#
+# This is not the portability matrix -- platforms.yml owns that, and covers
+# far more (glibc and musl, gcc and clang, five package managers, arm64,
+# macOS, WSL). What is checked here is that docker-compose.yml and
+# docker/test.sh themselves still work, which is a different failure mode
+# and one that only ever breaks when someone edits those two files.
+# Heavy, so: long-lived branches, Docker-touching PRs, and on demand.
 on:
   push:
     branches: [main, develop]
@@ -27,12 +32,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [alpine, debian, ubuntu, arch]
+        # A representative slice, one per package manager family. The full
+        # list lives in docker-compose.yml and runs in platforms.yml.
+        distro: [alpine, debian, arch, fedora]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Build + smoke-test hellish in ${{ matrix.distro }}
         run: |
-          chmod +x docker/test.sh
+          chmod +x docker/test.sh docker/smoke.sh
           docker/test.sh ${{ matrix.distro }}

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -1,0 +1,235 @@
+name: Platforms
+
+# Cross-platform coverage. ci.yml answers "does this change work?" on one
+# Ubuntu; this workflow answers "does it work anywhere else?".
+#
+# It exists because of a specific, repeated failure mode: bugs that reach
+# users on a distro nobody in CI was running. Issue #9 was gcc 11 on Ubuntu
+# 22.04 -- the default WSL install -- failing to compile while every job
+# stayed green. Issue #42 arrived from CachyOS. In both cases the matrix was
+# the thing missing, not the diagnosis.
+#
+# Three axes, because failures cluster on each of them independently:
+#   libc          glibc (old and new) / musl
+#   compiler      gcc and clang, several versions, -Werror on both
+#   OS personality Linux distros, arm64, macOS, WSL
+#
+# Cost control: the distro rungs are Docker builds on ubuntu-latest and run
+# docker/smoke.sh, a 40-check portability workout -- NOT the 3700-case golden
+# suite, which needs a pinned bash 5.3.9 built from source and would make
+# this matrix cost hours. ci.yml keeps running the golden suite where it is
+# cheap. The one exception is the arm64 rung, which is a native runner and
+# cheap enough to run the real thing.
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'incs/**'
+      - 'Makefile'
+      - 'docker/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/platforms.yml'
+  schedule:
+    # Distro images move under us; a weekly run catches a base image that
+    # started shipping a compiler we do not survive, before a user does.
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: platforms-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  HELLISH_NO_BANNER: "1"
+  HELLISH_NO_UPDATE_CHECK: "1"
+  HELLISH_NO_ANIM: "1"
+
+jobs:
+  # ── Linux distributions × libc × compiler ────────────────────────────────
+  # Each rung is a clean container that installs its own toolchain, builds
+  # from source with -Werror, and runs the portability smoke. `label` is what
+  # shows up as the status check, so make it read like a machine.
+  distros:
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # glibc, the two Ubuntus people actually run
+          - { label: "ubuntu 24.04 · gcc",     base: "ubuntu:24.04",        cc: gcc,   flags: "OPT=1 SAFE=1" }
+          - { label: "ubuntu 24.04 · clang",   base: "ubuntu:24.04",        cc: clang, flags: "OPT=1 SAFE=1" }
+          # 22.04 is the default WSL distro and pins gcc 11 -- the only
+          # compiler here whose -Wstringop-overflow fired on issue #9.
+          - { label: "ubuntu 22.04 · gcc-11",  base: "ubuntu:22.04",        cc: gcc,   flags: "OPT=1 SAFE=1" }
+          - { label: "debian stable · gcc",    base: "debian:stable-slim",  cc: gcc,   flags: "OPT=1 SAFE=1" }
+          - { label: "debian stable · clang",  base: "debian:stable-slim",  cc: clang, flags: "OPT=1 SAFE=1" }
+          # musl. A different libc is where "works on my machine" goes to die.
+          - { label: "alpine musl · gcc",      base: "alpine:3.20",         cc: gcc,   flags: "OPT=1 SAFE=1" }
+          - { label: "alpine musl · clang",    base: "alpine:3.20",         cc: clang, flags: "OPT=1 SAFE=1" }
+          # ... and musl with the custom heap, the least portable thing here.
+          - { label: "alpine musl · ft_malloc", base: "alpine:3.20",        cc: gcc,   flags: "OPT=1 SAFE=0" }
+          # Arch is the family issue #42 came from; Fedora is the other big
+          # non-Debian desktop, and both ship a newer gcc than Ubuntu.
+          - { label: "arch · gcc",             base: "archlinux:base-devel", cc: gcc,  flags: "OPT=1 SAFE=1" }
+          - { label: "fedora 41 · gcc",        base: "fedora:41",           cc: gcc,   flags: "OPT=1 SAFE=1" }
+          - { label: "fedora 41 · clang",      base: "fedora:41",           cc: clang, flags: "OPT=1 SAFE=1" }
+          # The enterprise rung: old glibc, old gcc, the servers people run.
+          - { label: "rocky 9 · gcc",          base: "rockylinux:9",        cc: gcc,   flags: "OPT=1 SAFE=1" }
+          - { label: "opensuse tumbleweed",    base: "opensuse/tumbleweed", cc: gcc,   flags: "OPT=1 SAFE=1" }
+          - { label: "void linux · gcc",       base: "ghcr.io/void-linux/void-linux:latest-full-x86_64", cc: gcc, flags: "OPT=1 SAFE=1" }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build from source in ${{ matrix.base }}
+        run: |
+          docker build -f docker/Dockerfile -t hellish-probe \
+            --build-arg BASE='${{ matrix.base }}' \
+            --build-arg CC='${{ matrix.cc }}' \
+            --build-arg BUILD_FLAGS='${{ matrix.flags }}' .
+      - name: Portability smoke (40 checks)
+        run: docker run --rm hellish-probe bash docker/smoke.sh
+
+  # ── Native arm64 ─────────────────────────────────────────────────────────
+  # Not an emulation rung: a real arm64 runner, so alignment, `char`
+  # signedness and any assumption about pointer/register width get exercised
+  # for real. Cheap enough to run the whole golden suite, so it does.
+  arm64:
+    name: linux arm64 · ${{ matrix.cc }}
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        cc: [gcc, clang]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y build-essential clang libreadline-dev python3
+      - name: Build
+        env:
+          CC: ${{ matrix.cc }}
+        run: |
+          $CC --version | head -1
+          make re OPT=1 SAFE=1 CC=$CC > build.log 2>&1 || {
+            sed 's/\x1b\[[0-9;]*[A-Za-z]//g; s/\r/\n/g' build.log | tail -80; exit 1; }
+      - name: Portability smoke
+        run: bash docker/smoke.sh ./build/bin/hellish
+      - uses: ./.github/actions/oracle
+      - name: Golden suite vs pinned bash 5.3.9
+        run: |
+          make re CC=${{ matrix.cc }} > build.log 2>&1 || {
+            sed 's/\x1b\[[0-9;]*[A-Za-z]//g' build.log | tail -80; exit 1; }
+          cd tests
+          ./tester 2>&1 | sed 's/\x1b\[[0-9;]*[A-Za-z]//g' | tee ../suite.log | tail -3
+          grep -q 'ALL [0-9]* TESTS PASSED' ../suite.log
+
+  # ── Apple ────────────────────────────────────────────────────────────────
+  # There is no Docker route to macOS: the kernel is not distributable in a
+  # container and Apple's licence does not allow it off Apple hardware. The
+  # honest equivalent is GitHub's own macOS runners, and both architectures
+  # are here because arm64 and x86_64 macOS differ in more than speed.
+  #
+  # INFORMATIONAL for now (continue-on-error). The shell is written to POSIX
+  # but has never been built on Darwin, and two things are already known to
+  # need work: Apple ships libedit as libreadline (so Homebrew's real one is
+  # required, which the Makefile now looks up), and /proc/self/exe -- how the
+  # shell re-execs itself for process substitution -- does not exist there.
+  # The job is here to make that visible with a log instead of a guess. Flip
+  # continue-on-error off once it is green; do not flip it off before.
+  macos:
+    name: macOS ${{ matrix.arch }} (informational)
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: true
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: macos-14, arch: "arm64" }
+          - { runner: macos-13, arch: "x86_64" }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install GNU readline
+        run: |
+          brew install readline || true
+          echo "readline prefix: $(brew --prefix readline)"
+      - name: Build
+        run: |
+          cc --version | head -1
+          make OPT=1 SAFE=1 2>&1 | tail -60
+          test -x build/bin/hellish
+      - name: Portability smoke
+        run: bash docker/smoke.sh ./build/bin/hellish
+      - name: Report what is still missing
+        if: failure()
+        run: |
+          echo "::warning::macOS build or smoke failed -- see the log above."
+          echo "Known gaps: Homebrew readline linkage, /proc/self/exe."
+
+  # ── WSL ──────────────────────────────────────────────────────────────────
+  # WSL is not "Linux in Docker": the difference that matters is the Windows
+  # filesystem bridge (drvfs on /mnt/c has different permission and case
+  # semantics), interop with Windows executables on PATH, and the fact that
+  # the default install is Ubuntu 22.04 with gcc 11 -- the toolchain issue #9
+  # broke on. Building inside WSL is the only way to see any of that.
+  #
+  # INFORMATIONAL: the runner-side WSL setup is the flakiest thing in this
+  # file, and a green merge should not depend on it.
+  wsl:
+    name: WSL (Ubuntu 22.04, informational)
+    runs-on: windows-latest
+    continue-on-error: true
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: wsl-bash {0}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: Vampire/setup-wsl@v6
+        with:
+          distribution: Ubuntu-22.04
+          additional-packages: build-essential libreadline-dev git python3 ca-certificates
+      - name: Show the environment
+        run: |
+          uname -a
+          cat /etc/os-release | head -2
+          gcc --version | head -1
+          echo "WSL_DISTRO_NAME=${WSL_DISTRO_NAME:-unset}"
+      - name: Build
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          make OPT=1 SAFE=1 2>&1 | tail -60
+          test -x build/bin/hellish
+      - name: Portability smoke
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          bash docker/smoke.sh ./build/bin/hellish
+
+  # ── Summary ──────────────────────────────────────────────────────────────
+  # One place to read the matrix from. The informational rungs are reported,
+  # not gated: this step fails only if a rung that is supposed to be solid
+  # went red.
+  summary:
+    name: Platform matrix result
+    runs-on: ubuntu-latest
+    needs: [distros, arm64]
+    if: always()
+    steps:
+      - name: Gate on the required rungs
+        run: |
+          echo "distros: ${{ needs.distros.result }}"
+          echo "arm64:   ${{ needs.arm64.result }}"
+          [ "${{ needs.distros.result }}" = "success" ] || exit 1
+          [ "${{ needs.arm64.result }}" = "success" ] || exit 1
+          echo "every required platform rung is green"

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,26 @@ endif
 # Includes (must be defined before CPPFLAGS assignment)
 INCLUDES := -I./incs -I./incs/platform/$(TARGET) -I./vendor/libft/include -I./vendor/libft -I./vendor/libft/include/internals -I./incs/public -I./vendor/libft/srcs/memory/memalloc/slab
 
-# Base compile flags
+# macOS: two things differ and both stop the build dead at the system headers
+# rather than anywhere interesting.
+#
+#  1. Apple ships libedit under the name libreadline. It answers -lreadline
+#     and then does not have most of the GNU API this shell uses. The real
+#     one comes from Homebrew and is keg-only, so its prefix has to be asked
+#     for explicitly -- it is never on the default search path.
+#  2. _XOPEN_SOURCE=700 pins the POSIX.1-2008 surface on glibc and musl. On
+#     Apple's libc it does the opposite and HIDES the BSD extensions the
+#     <sys/*.h> headers themselves depend on. _DARWIN_C_SOURCE is the
+#     documented way to ask for "POSIX plus the extensions" there.
+ifeq ($(UNAME_S),Darwin)
+BREW_PREFIX_RL := $(shell brew --prefix readline 2>/dev/null)
+ifneq ($(BREW_PREFIX_RL),)
+INCLUDES += -I$(BREW_PREFIX_RL)/include
+endif
+CFLAGS_BASE := -Wall -Wextra -Werror -D_DARWIN_C_SOURCE -DVERBOSE
+else
 CFLAGS_BASE := -Wall -Wextra -Werror -D_XOPEN_SOURCE=700 -DVERBOSE
+endif
 
 # Debug / sanitize flags
 DEBFLAGS    := -g3 -ggdb -O0
@@ -53,8 +71,13 @@ LDFLAGS_BASE :=
 ifeq ($(UNAME_S),Linux)
 LDFLAGS_BASE += -Wl,--gc-sections -Wl,-O1 -Wl,--as-needed
 else
-# macOS/BSD ld does not support --gc-sections/--as-needed
-LDFLAGS_BASE +=
+# macOS/BSD ld does not support --gc-sections/--as-needed. What macOS does
+# need is the Homebrew readline it cannot find on its own (see above).
+ifeq ($(UNAME_S),Darwin)
+ifneq ($(BREW_PREFIX_RL),)
+LDFLAGS_BASE += -L$(BREW_PREFIX_RL)/lib
+endif
+endif
 endif
 
 # The shell links against libreadline for its interactive line editor. Kept in
@@ -140,6 +163,15 @@ LIBFTPRINTF_A = $(LIBFT_DIR)/libftprintf.a
 SRCS := $(shell find $(SRC_DIR) -path $(SRC_DIR)/platform -prune -o \
 	-name '*.c' -print | sort) \
 	$(shell find $(SRC_DIR)/platform/$(TARGET) -name '*.c' 2>/dev/null | sort)
+
+# An empty SRCS is never legitimate, and the failure it produces otherwise is
+# actively misleading: make happily builds an empty object list and the link
+# stops at "cc: fatal error: no input files", which points nowhere near the
+# cause. openSUSE Tumbleweed's base image is the real case -- it ships no
+# `find` at all, so the two $(shell ...) calls above return nothing. Say so.
+ifeq ($(strip $(SRCS)),)
+$(error no sources found under $(SRC_DIR)/. Is `find` installed? (openSUSE and some minimal images ship without findutils.) Is the checkout complete?)
+endif
 
 OBJS := $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRCS))
 DEPS := $(OBJS:.o=.d)
@@ -493,12 +525,18 @@ docker-suite:
 
 # Docker: build + run hellish FROM SOURCE in clean per-distro containers, so
 # anyone can try it without chasing readline/toolchain deps on their own host.
-# `docker-test` builds + smoke-tests all four distros; `docker-<distro>` drops
-# you into an interactive hellish there. See docker/ and docker-compose.yml.
+# `docker-test` builds every distro and runs docker/smoke.sh (the same 40-check
+# portability workout the Platforms workflow runs) in each; `docker-<distro>`
+# drops you into an interactive hellish there. See docker/ and
+# docker-compose.yml for the full list -- glibc and musl, gcc and clang, five
+# package managers, plus a musl+ft_malloc rung.
+#
+#   make docker-test                       # everything
+#   docker/test.sh fedora alpine-clang     # just these two
 docker-build:
 	docker compose build
 docker-test:
-	@chmod +x docker/test.sh && docker/test.sh
+	@chmod +x docker/test.sh docker/smoke.sh && docker/test.sh
 docker-alpine:
 	docker compose run --rm alpine
 docker-debian:
@@ -509,8 +547,22 @@ docker-ubuntu2204:
 	docker compose run --rm ubuntu2204
 docker-arch:
 	docker compose run --rm arch
+docker-fedora:
+	docker compose run --rm fedora
+docker-rocky:
+	docker compose run --rm rocky
+docker-opensuse:
+	docker compose run --rm opensuse
+docker-void:
+	docker compose run --rm void
 docker-clean:
 	docker compose down --rmi local 2>/dev/null || true
+
+# The portability workout on its own, against whatever binary is built. Same
+# script the distro containers and every Platforms CI rung run, so a failure
+# reads the same everywhere.
+smoke: all
+	@chmod +x docker/smoke.sh && docker/smoke.sh $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # Cross-shell speed matrix. Build hellish + a zoo of other shells (bash, dash,
 # zsh, mksh, ksh, yash, busybox ash, fish) in ONE self-contained image, then
@@ -737,7 +789,8 @@ geoman: all
 .PHONY: test bench re all clean fclean norm my_shell help safe_banner \
 	static static-verify \
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
-	docker-arch docker-clean cd-zsh-test cd-posix-test agnostic-bench \
+	docker-arch docker-fedora docker-rocky docker-opensuse docker-void \
+	smoke docker-clean cd-zsh-test cd-posix-test agnostic-bench \
 	hist-test history-opts-test readline-test anim-test git-prompt-test \
 	prompt-atomic-test \
 	bg-tty-test prompt-integrity-test update-badge-test nonblock-tty-test \

--- a/Makefile
+++ b/Makefile
@@ -546,6 +546,14 @@ cd-posix-test: all
 hist-test: all
 	@python3 $(TEST_DIR)/hist_multiline_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
+# The `history` builtin's OPTIONS, in a live session (issue #42). The golden
+# category issue42_history_opts covers what each one does under `-c`; this
+# covers the shape the bug actually had -- an interactive shell, a populated
+# history file, and PROMPT_COMMAND='history -a' dumping the whole list before
+# every prompt. Run it after touching builtin_history*.c.
+history-opts-test: all
+	@python3 $(TEST_DIR)/history_opts_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
+
 # Non-ASCII in the PROMPT (the shortened cwd) and in TYPED INPUT (a wrapping
 # line that starts with a two-byte, one-column character, plus an edit made
 # at its start -- the shape reported in issue #2). Both render the pty output
@@ -730,7 +738,8 @@ geoman: all
 	static static-verify \
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
 	docker-arch docker-clean cd-zsh-test cd-posix-test agnostic-bench \
-	hist-test readline-test anim-test git-prompt-test prompt-atomic-test \
+	hist-test history-opts-test readline-test anim-test git-prompt-test \
+	prompt-atomic-test \
 	bg-tty-test prompt-integrity-test update-badge-test nonblock-tty-test \
 	update-config-test update-test help-test \
 	conformance perf rss \

--- a/README.md
+++ b/README.md
@@ -241,13 +241,27 @@ compile:
 docker run --rm -it dlesieur/hellish-shell        # latest
 ```
 
-Prefer to **build from source in a clean container** across four distros
-(Alpine/musl, Debian, Ubuntu, Arch)?
+Prefer to **build from source in a clean container**? Every supported
+platform has a rung — glibc and musl, gcc and clang, five package managers:
 
 ```sh
-docker compose run --rm alpine     # interactive hellish on Alpine (or: debian, ubuntu, arch)
-make docker-test                   # build + smoke-test on ALL four distros
+docker compose run --rm alpine     # interactive hellish on Alpine/musl
+make docker-test                   # build + run the portability smoke on ALL of them
+make smoke                         # ... or just run that smoke against a local build
 ```
+
+| | rungs |
+|---|---|
+| glibc | `ubuntu` (24.04), `ubuntu2204`, `debian`, `arch`, `fedora`, `rocky`, `opensuse`, `void` |
+| musl | `alpine`, `alpine-clang`, `alpine-ftmalloc` |
+| compilers | gcc (11 → current) and clang, on both libcs, `-Werror` throughout |
+| architectures | x86_64 and arm64 (native runner in CI) |
+
+macOS and WSL are covered by the `Platforms` workflow rather than Docker —
+Apple's kernel cannot legally or practically run in a container, and WSL's
+whole point is the Windows bridge a container does not have. Both are
+**informational** today; see [wiki/platforms.md](wiki/platforms.md) for what
+works and what does not.
 
 Once installed, hellish checks for newer releases in the background (once a day,
 never blocking the prompt). `update` checks on demand, `update --now`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,3 +67,87 @@ services:
     image: hellish:arch
     tty: true
     stdin_open: true
+
+  # Arch is the family the CachyOS report in issue #42 came from, and Fedora
+  # is the other big non-Debian desktop. Neither ships the same readline,
+  # the same gcc, or the same /etc defaults as Ubuntu, and a bug that only
+  # appears on one of them is the whole reason this list is long.
+  fedora:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        BASE: "fedora:41"
+    image: hellish:fedora
+    tty: true
+    stdin_open: true
+
+  # The enterprise rung: an old glibc and an old gcc, the combination people
+  # actually run servers on.
+  rocky:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        BASE: "rockylinux:9"
+    image: hellish:rocky
+    tty: true
+    stdin_open: true
+
+  opensuse:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        BASE: "opensuse/tumbleweed"
+    image: hellish:opensuse
+    tty: true
+    stdin_open: true
+
+  void:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        BASE: "ghcr.io/void-linux/void-linux:latest-full-x86_64"
+    image: hellish:void
+    tty: true
+    stdin_open: true
+
+  # Same Alpine, built with clang instead of gcc. musl AND a second front end
+  # in one rung: clang warns about things gcc does not, and -Werror means a
+  # warning is a build failure.
+  alpine-clang:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        BASE: "alpine:3.20"
+        CC: "clang"
+    image: hellish:alpine-clang
+    tty: true
+    stdin_open: true
+
+  debian-clang:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        BASE: "debian:stable-slim"
+        CC: "clang"
+    image: hellish:debian-clang
+    tty: true
+    stdin_open: true
+
+  # The custom ft_malloc heap, on musl. The allocator is the part of this
+  # code base least likely to survive a different libc unexamined.
+  alpine-ftmalloc:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        BASE: "alpine:3.20"
+        BUILD_FLAGS: "OPT=1 SAFE=0"
+    image: hellish:alpine-ftmalloc
+    tty: true
+    stdin_open: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,15 @@
 # ============================================================================
 # Build + run hellish FROM SOURCE in a clean, dependency-complete container.
-# The base image is parameterised so one recipe covers Alpine (musl), Debian,
-# Ubuntu and Arch -- this is how you prove the shell builds and runs without
-# depending on whatever happens to be installed on your host.
+# The base image and the compiler are parameterised so one recipe covers
+# every distro we claim to support -- glibc and musl, apt and apk and pacman
+# and dnf and zypper and xbps, gcc and clang. This is how you prove the shell
+# builds and runs without depending on whatever happens to be on your host.
 #
 #   docker compose build                 # all distros
 #   docker compose run --rm alpine       # interactive hellish on Alpine
 #   make docker-test                     # build + smoke-test every distro
+#   docker build -f docker/Dockerfile --build-arg BASE=fedora:41 \
+#                --build-arg CC=clang .  # one distro, one compiler
 # ============================================================================
 ARG BASE=debian:stable-slim
 FROM ${BASE}
@@ -15,18 +18,46 @@ FROM ${BASE}
 # (gcc + make), GNU readline and its ncurses dependency (line editing), git,
 # and bash (the test scripts use it). This is the whole point of the image --
 # nobody has to chase "fatal error: readline/readline.h: No such file".
+#
+# findutils is not decoration: the Makefile discovers its sources with
+# `find`, and openSUSE Tumbleweed's base image does not ship one. Without it
+# the build produced no source list at all and stopped at "cc: fatal error:
+# no input files", which points nowhere near the cause.
+# The compiler is a build arg so the same image recipe covers gcc AND clang
+# on every distro -- a warning is a build failure here (-Werror), and the two
+# front ends do not warn about the same things.
+ARG CC=cc
+
 RUN set -eux; \
 	if command -v apk >/dev/null 2>&1; then \
-		apk add --no-cache build-base readline-dev ncurses-dev git bash coreutils; \
+		apk add --no-cache build-base readline-dev ncurses-dev git bash \
+			coreutils python3 clang; \
 	elif command -v apt-get >/dev/null 2>&1; then \
 		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			build-essential libreadline-dev git ca-certificates bash; \
+		DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+			build-essential libreadline-dev git ca-certificates bash \
+			python3 clang; \
 		rm -rf /var/lib/apt/lists/*; \
 	elif command -v pacman >/dev/null 2>&1; then \
-		pacman -Sy --noconfirm --needed base-devel readline git bash; \
+		pacman -Sy --noconfirm --needed base-devel readline git bash \
+			python clang; \
+	elif command -v dnf >/dev/null 2>&1; then \
+		dnf -y install gcc clang make readline-devel ncurses-devel git \
+			bash python3 diffutils findutils which; \
+		dnf clean all; \
+	elif command -v zypper >/dev/null 2>&1; then \
+		zypper --non-interactive --gpg-auto-import-keys refresh; \
+		zypper --non-interactive install gcc clang make readline-devel \
+			ncurses-devel git-core bash python3 tar gzip which \
+			findutils diffutils; \
+		zypper clean --all; \
+	elif command -v xbps-install >/dev/null 2>&1; then \
+		xbps-install -Suy xbps; \
+		xbps-install -y gcc clang make readline-devel ncurses-devel git \
+			bash python3 which findutils diffutils; \
 	else \
-		echo "unsupported base image: need apk, apt-get or pacman" >&2; exit 1; \
+		echo "unsupported base image: need apk, apt-get, pacman, dnf," \
+			"zypper or xbps-install" >&2; exit 1; \
 	fi
 
 WORKDIR /hellish
@@ -38,7 +69,9 @@ COPY . .
 #   docker compose build --build-arg BUILD_FLAGS="OPT=1 SAFE=0"
 ARG BUILD_FLAGS="OPT=1 SAFE=1"
 RUN make fclean >/dev/null 2>&1 || true; \
-	make ${BUILD_FLAGS}; \
+	printf '\n=== building with %s on %s ===\n' "$CC" "$(uname -sm)"; \
+	$CC --version | head -1; \
+	make ${BUILD_FLAGS} CC=$CC; \
 	./build/bin/hellish -c 'echo "hellish built OK on $(uname -s) $(uname -m)"'
 
 ENV HELLISH_NO_UPDATE_CHECK=1 HELLISH_NO_BANNER=1

--- a/docker/Dockerfile.agnostic.dockerignore
+++ b/docker/Dockerfile.agnostic.dockerignore
@@ -14,3 +14,12 @@ tests/outfiles/
 tests/mini_outfiles/
 tests/bash_outfiles/
 *.log
+
+# Never ship developer secrets into an image: these Dockerfiles COPY the
+# whole context, and a .env sitting in a working tree is exactly the kind of
+# file that ends up in a published layer.
+.env
+.env.*
+*.pem
+*.key
+id_rsa*

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -14,3 +14,12 @@ tests/outfiles/
 tests/mini_outfiles/
 tests/bash_outfiles/
 *.log
+
+# Never ship developer secrets into an image: these Dockerfiles COPY the
+# whole context, and a .env sitting in a working tree is exactly the kind of
+# file that ends up in a published layer.
+.env
+.env.*
+*.pem
+*.key
+id_rsa*

--- a/docker/Dockerfile.release.dockerignore
+++ b/docker/Dockerfile.release.dockerignore
@@ -13,3 +13,12 @@ tests/outfiles/
 tests/mini_outfiles/
 tests/bash_outfiles/
 *.log
+
+# Never ship developer secrets into an image: these Dockerfiles COPY the
+# whole context, and a .env sitting in a working tree is exactly the kind of
+# file that ends up in a published layer.
+.env
+.env.*
+*.pem
+*.key
+id_rsa*

--- a/docker/Dockerfile.static.dockerignore
+++ b/docker/Dockerfile.static.dockerignore
@@ -15,3 +15,12 @@ tests/mini_outfiles/
 tests/bash_outfiles/
 dist/
 *.log
+
+# Never ship developer secrets into an image: these Dockerfiles COPY the
+# whole context, and a .env sitting in a working tree is exactly the kind of
+# file that ends up in a published layer.
+.env
+.env.*
+*.pem
+*.key
+id_rsa*

--- a/docker/Dockerfile.suite.dockerignore
+++ b/docker/Dockerfile.suite.dockerignore
@@ -14,3 +14,12 @@ tests/mini_outfiles/
 tests/bash_outfiles/
 dist/
 *.log
+
+# Never ship developer secrets into an image: these Dockerfiles COPY the
+# whole context, and a .env sitting in a working tree is exactly the kind of
+# file that ends up in a published layer.
+.env
+.env.*
+*.pem
+*.key
+id_rsa*

--- a/docker/Dockerfile.zsh.dockerignore
+++ b/docker/Dockerfile.zsh.dockerignore
@@ -14,3 +14,12 @@ tests/outfiles/
 tests/mini_outfiles/
 tests/bash_outfiles/
 *.log
+
+# Never ship developer secrets into an image: these Dockerfiles COPY the
+# whole context, and a .env sitting in a working tree is exactly the kind of
+# file that ends up in a published layer.
+.env
+.env.*
+*.pem
+*.key
+id_rsa*

--- a/docker/smoke.sh
+++ b/docker/smoke.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# docker/smoke.sh -- the portability workout every platform image runs.
+#
+# This is deliberately NOT the golden suite. The golden suite needs a pinned
+# bash 5.3.9 to diff against; building it inside twelve distro images would
+# make the matrix cost hours. What this covers instead is the class of bug
+# that only shows up when the C code meets a different libc, a different
+# compiler or a different kernel personality -- the shell starting at all,
+# fork/exec, pipes, redirection, here-docs, globbing, arithmetic, signals,
+# job control, /dev/fd, and the two allocators agreeing.
+#
+# Every check is self-checking: it prints its own PASS/FAIL and the script
+# exits non-zero if any failed. Run it anywhere:
+#
+#   docker/smoke.sh                 # against ./build/bin/hellish
+#   docker/smoke.sh /usr/bin/hellish
+# ============================================================================
+set -u
+
+SHELL_BIN="${1:-./build/bin/hellish}"
+export HELLISH_NO_BANNER=1 HELLISH_NO_UPDATE_CHECK=1 HELLISH_NO_ANIM=1
+pass=0
+fail=0
+failed_names=""
+
+# expect NAME EXPECTED SCRIPT -- run SCRIPT through the shell, compare stdout.
+expect() {
+	local name="$1" want="$2" prog="$3" got
+	got="$("$SHELL_BIN" -c "$prog" 2>/dev/null)"
+	if [ "$got" = "$want" ]; then
+		printf '  \033[32mok  \033[0m %s\n' "$name"
+		pass=$((pass + 1))
+	else
+		printf '  \033[31mFAIL\033[0m %s\n        want %q\n        got  %q\n' \
+			"$name" "$want" "$got"
+		fail=$((fail + 1))
+		failed_names="$failed_names $name"
+	fi
+}
+
+# expect_status NAME EXPECTED_STATUS SCRIPT
+expect_status() {
+	local name="$1" want="$2" prog="$3" got
+	"$SHELL_BIN" -c "$prog" >/dev/null 2>&1
+	got=$?
+	if [ "$got" = "$want" ]; then
+		printf '  \033[32mok  \033[0m %s\n' "$name"
+		pass=$((pass + 1))
+	else
+		printf '  \033[31mFAIL\033[0m %s (status %s, wanted %s)\n' \
+			"$name" "$got" "$want"
+		fail=$((fail + 1))
+		failed_names="$failed_names $name"
+	fi
+}
+
+printf '\n\033[1m═══ hellish portability smoke ═══\033[0m\n'
+printf '  shell : %s\n' "$SHELL_BIN"
+printf '  system: %s\n' "$(uname -srm 2>/dev/null || echo unknown)"
+printf '  libc  : %s\n' \
+	"$(ldd --version 2>&1 | head -1 || echo 'n/a')"
+printf '\n'
+
+# --- the shell exists and answers at all -----------------------------------
+expect  "runs a command"                 "hi"      'echo hi'
+expect  "\$0 is the shell"                "yes"     'case "$0" in *hellish*|*sh) echo yes;; *) echo "no:$0";; esac'
+
+# --- expansion -------------------------------------------------------------
+expect  "arithmetic"                     "42"      'echo $((6*7))'
+expect  "arithmetic, 64-bit"             "4294967296" 'echo $((1<<32))'
+expect  "parameter expansion"            "bc"      'v=abc; echo ${v#a}'
+expect  "default value"                  "fallback" 'unset u; echo ${u:-fallback}'
+expect  "command substitution"           "sub"     'echo $(echo sub)'
+expect  "nested command substitution"    "in"      'echo $(echo $(echo in))'
+expect  "quoted \$@ splitting"           "a|b c"   'set -- a "b c"; IFS=+; printf "%s|%s" "$@"'
+expect  "tilde expansion"                "yes"     'case ~ in /*) echo yes;; *) echo no;; esac'
+expect  "brace expansion"                "a1 a2"   'echo a{1,2}'
+
+# --- words, quoting, locale ------------------------------------------------
+expect  "single quotes are literal"      'a$b'     "echo 'a\$b'"
+expect  "ANSI-C quoting"                 "$(printf 'a\tb')" "printf '%s' \$'a\\tb'"
+expect  "8-bit clean words"              "héllo"   'echo héllo'
+expect  "printf width and precision"     "ok|   42|ab" 'printf "%s|%5d|%.2s" ok 42 abcdef'
+
+# --- redirection and here-docs ---------------------------------------------
+expect  "pipeline"                       "ABC"     'echo abc | tr a-z A-Z'
+expect  "three-stage pipeline"           "3"       'printf "a\nb\nc\n" | cat | wc -l | tr -d " "'
+expect  "here-doc"                       "body"    'cat <<EOF
+body
+EOF'
+expect  "here-doc inside a compound"     "nested"  'if true; then cat <<EOF
+nested
+EOF
+fi'
+expect  "here-string"                    "hs"      'cat <<<hs'
+expect  "fd duplication order"           "err"     '{ echo out; echo err >&2; } 2>&1 1>/dev/null | cat'
+expect  "process substitution"           "ps"      'cat <(echo ps)'
+
+# --- control flow ----------------------------------------------------------
+expect  "for loop"                       "1 2 3"   'out=; for i in 1 2 3; do out="$out $i"; done; echo ${out# }'
+expect  "while + break"                  "3"       'i=0; while :; do i=$((i+1)); [ $i -ge 3 ] && break; done; echo $i'
+expect  "case"                           "match"   'case abc in a*) echo match;; *) echo no;; esac'
+expect  "function with local"            "in out"  'f() { local v=in; echo "$v out"; }; f'
+expect  "subshell isolation"             "outer"   'v=outer; (v=inner) ; echo $v'
+
+# --- externals, PATH, exit status ------------------------------------------
+expect  "external in PATH"               "ok"      'printf ok'
+expect_status "command not found is 127" 127       'definitely_no_such_command_42'
+expect_status "permission denied is 126" 126       'd=$(mktemp -d); : > $d/x; chmod 000 $d/x; $d/x'
+expect_status "false is 1"               1         'false'
+expect  "pipeline status is the last"    "0"       'false | true; echo $?'
+
+# --- globbing --------------------------------------------------------------
+expect  "glob matches"                   "a.t b.t" 'cd $(mktemp -d) && : > a.t && : > b.t && echo *.t'
+expect  "glob with no match is literal"  "zz*.nope" 'cd $(mktemp -d) && echo zz*.nope'
+expect  "bracket class"                  "f1"      'cd $(mktemp -d) && : > f1 && echo f[0-9]'
+
+# --- signals and job control ----------------------------------------------
+expect  "trap runs on EXIT"              "bye"     'trap "echo bye" EXIT; :'
+expect  "background job reaped by wait"  "done"    'sleep 0.05 & wait; echo done'
+expect_status "killed child reports 143" 143       'sh -c "kill -TERM \$\$"'
+
+# --- the two things most likely to be platform-specific --------------------
+expect  "\$\$ is this shell's pid"       "same"    'p=$$; [ "$p" = "$$" ] && echo same'
+expect  "shell re-execs itself"          "self"    'echo self | '"$SHELL_BIN"' -c "cat"'
+
+printf '\n\033[1m═══ %d ok / %d failed ═══\033[0m\n' "$pass" "$fail"
+if [ "$fail" -ne 0 ]; then
+	printf 'failed:%s\n' "$failed_names"
+	exit 1
+fi
+exit 0

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -7,6 +7,8 @@
 #   make docker-test            # all distros
 #   docker/test.sh alpine arch  # just these
 #
+# Services live in docker-compose.yml; the list below is every one of them.
+#
 # Requires docker + the compose plugin (docker compose).
 # ============================================================================
 set -u
@@ -18,21 +20,17 @@ if ! docker info >/dev/null 2>&1; then
 fi
 
 distros=("$@")
-[ ${#distros[@]} -eq 0 ] && distros=(alpine debian ubuntu ubuntu2204 arch)
-
-# A small but representative workout: externals, arithmetic, a pipeline, a
-# heredoc nested in a compound, and command hashing -- if these match, the
-# build and the core shell work in that environment.
-smoke='echo "uname: $(uname -sm)"; printf "%s\n" "arith=$((6*7))"; echo a b c | tr a-z A-Z; if true; then cat <<EOF
-nested-heredoc ok
-EOF
-fi; ls >/dev/null; type ls'
+[ ${#distros[@]} -eq 0 ] && distros=(alpine debian ubuntu ubuntu2204 arch
+	fedora rocky opensuse void alpine-clang debian-clang alpine-ftmalloc)
 
 pass=0; fail=0; summary=""
 for d in "${distros[@]}"; do
 	printf '\n\033[1;36m═══ %s : build from source ═══\033[0m\n' "$d"
+	# docker/smoke.sh is the same 40-check portability workout every CI
+	# platform job runs, so a distro failure here and a CI failure there
+	# mean the same thing and are read the same way.
 	if docker compose build "$d" \
-		&& docker compose run --rm "$d" ./build/bin/hellish -c "$smoke"; then
+		&& docker compose run --rm "$d" bash docker/smoke.sh; then
 		printf '\033[1;32m✓ %s OK\033[0m\n' "$d"; pass=$((pass + 1)); summary="$summary  $d:OK"
 	else
 		printf '\033[1;31m✗ %s FAILED\033[0m\n' "$d"; fail=$((fail + 1)); summary="$summary  $d:FAIL"

--- a/incs/history.h
+++ b/incs/history.h
@@ -15,10 +15,21 @@
 
 # include "shell.h"
 
+/* hist_cmds is the truth; readline's own list is a mirror kept in step so
+   the arrow keys agree with what `history` prints.
+
+   appended / readmark exist only for `history -a` and `history -n`, which
+   are defined against "what this session has already written / already
+   read" rather than against the whole list. quiet_expand suppresses the
+   echo expand_history() normally does, so `history -p` prints each result
+   exactly once -- including one that expanded to itself. */
 typedef struct s_history
 {
 	bool		hist_active;
+	bool		quiet_expand;
 	int			append_fd;
+	size_t		appended;
+	size_t		readmark;
 	t_vec		hist_cmds;
 }	t_history;
 
@@ -34,5 +45,6 @@ void		parse_history_file(t_shell *state);
 t_string	encode_cmd_hist(char *cmd);
 void		manage_history(t_shell *state);
 bool		worthy_of_being_remembered(t_shell *state);
+void		add_history_line(t_shell *state, const char *cmd);
 
 #endif

--- a/src/builtins/builtin_history.c
+++ b/src/builtins/builtin_history.c
@@ -5,55 +5,98 @@
 /*                                                    +:+ +:+         +:+     */
 /*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2026/06/02 00:00:00 by dlesieur          #+#    #+#             */
-/*   Updated: 2026/06/02 00:00:00 by dlesieur         ###   ########.fr       */
+/*   Created: 2026/08/22 12:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/22 12:00:00 by dlesieur         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins_private.h"
 #include "history.h"
 
-/* Wipe all history entries. We free each string individually and reset the
-   length to 0, but leave the backing allocation in place (just set .len=0)
-   so the vector is immediately reusable without a reinit. The on-disk file
-   is not touched here — manage_history() handles persistence at exit. */
-static void	clear_history_list(t_shell *state)
-{
-	size_t	i;
+/* history [-c] [-d offset] [n]
+   history -a|-n|-r|-w [file]
+   history -p|-s arg...
 
-	i = 0;
-	while (i < state->hist.hist_cmds.len)
-		xfree(((char **)state->hist.hist_cmds.ctx)[i++]);
-	state->hist.hist_cmds.len = 0;
+   The list-only version of this builtin used to swallow every option word:
+   ft_atoi("-a") is 0, 0 means "no count", and "no count" means print the
+   whole list. That is issue #42. `PROMPT_COMMAND='history -a'` is a stock
+   bashrc line, hellish imports PROMPT_COMMAND from the environment like
+   bash does, and so every single prompt dumped the entire history file to
+   the terminal. The reporter's shell was unusable and nothing they typed
+   caused it.
+
+   So options are parsed for real now, and the ones bash defines all work. */
+
+/* Fold one option character into the parsed request. The four file
+   operations are mutually exclusive -- `history -anrw` is an error, not a
+   request to do all four. Returns 0, or the status to exit with. */
+static int	hist_opt_char(t_shell *state, t_histopt *o, char c)
+{
+	if (c == 'a' || c == 'n' || c == 'r' || c == 'w')
+	{
+		if (o->fileop && o->fileop != c)
+			return (ft_eprintf("%s: history: cannot use more than one of"
+					" -anrw\n", state->ctx), 1);
+		o->fileop = c;
+		return (0);
+	}
+	if (c == 'c')
+		return (o->clear = true, 0);
+	if (c == 'd' || c == 'p' || c == 's')
+		return (o->act = c, 0);
+	return (ft_eprintf("%s: history: -%c: invalid option\n",
+			state->ctx, c), 2);
 }
 
-/* Compute the first index to print. With a positive numeric arg n, print
-   only the last n entries. Without one (or n >= total), print everything
-   (return 0). This mimics `history 10` showing the ten most-recent entries. */
-static int	history_start(t_shell *state, t_vec argv)
+/* Walk the option words. Parsing stops at the first non-option word, at a
+   lone "--", or immediately after -p / -s, whose every remaining word is an
+   operand (`history -p -c` prints "-c", it does not clear). */
+static int	hist_parse(t_shell *state, t_vec argv, t_histopt *o)
 {
 	char	**av;
-	int		n;
+	int		j;
+	int		st;
 
-	if (argv.len < 2)
-		return (0);
 	av = (char **)argv.ctx;
-	n = ft_atoi(av[1]);
-	if (n > 0 && n < (int)state->hist.hist_cmds.len)
-		return ((int)state->hist.hist_cmds.len - n);
+	o->first = 1;
+	while (o->first < (int)argv.len && av[o->first][0] == '-'
+		&& av[o->first][1])
+	{
+		if (!ft_strcmp(av[o->first], "--"))
+			return (o->first++, 0);
+		j = 0;
+		while (av[o->first][++j])
+		{
+			st = hist_opt_char(state, o, av[o->first][j]);
+			if (st)
+				return (st);
+			if (o->act == 'p' || o->act == 's')
+				return (o->first++, 0);
+		}
+		o->first++;
+	}
 	return (0);
 }
 
-/* history [-c] [n] : list the command history (optionally only the last n). */
-int	builtin_history(t_shell *state, t_vec argv)
+/* history [n] -- print the list, newest n entries only when n is given.
+   A non-numeric operand is a usage error (status 2), NOT a silent 0; that
+   silence is what let `-a` through as "print everything". */
+static int	hist_show(t_shell *state, t_vec argv, int first)
 {
 	char	**av;
+	int		n;
 	int		i;
 
 	av = (char **)argv.ctx;
-	if (argv.len >= 2 && !ft_strcmp(av[1], "-c"))
-		return (clear_history_list(state), 0);
-	i = history_start(state, argv);
+	i = 0;
+	if (first < (int)argv.len)
+	{
+		if (ft_checked_atoi(av[first], &n, 0) < 0)
+			return (ft_eprintf("%s: history: %s: numeric argument"
+					" required\n", state->ctx, av[first]), 2);
+		if (n > 0 && n < (int)state->hist.hist_cmds.len)
+			i = (int)state->hist.hist_cmds.len - n;
+	}
 	while (i < (int)state->hist.hist_cmds.len)
 	{
 		ft_printf("%5d  %s\n", i + 1,
@@ -61,4 +104,29 @@ int	builtin_history(t_shell *state, t_vec argv)
 		i++;
 	}
 	return (0);
+}
+
+/* Run the requested actions in bash's order: -c, then -d, then at most one
+   file operation, then -p / -s, and only otherwise the plain listing. */
+int	builtin_history(t_shell *state, t_vec argv)
+{
+	t_histopt	o;
+	int			st;
+
+	o = (t_histopt){0};
+	st = hist_parse(state, argv, &o);
+	if (st)
+		return (st);
+	hist_list_init(state);
+	if (o.clear)
+		hist_clear(state);
+	if (o.act == 'd')
+		return (hist_delete(state, argv, o.first));
+	if (o.fileop)
+		return (hist_fileop(state, argv, &o));
+	if (o.act == 'p')
+		return (hist_expand_args(state, argv, o.first));
+	if (o.act == 's')
+		return (hist_store(state, argv, o.first));
+	return (hist_show(state, argv, o.first));
 }

--- a/src/builtins/builtin_history2.c
+++ b/src/builtins/builtin_history2.c
@@ -1,0 +1,104 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_history2.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/22 12:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/22 12:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins_private.h"
+#include "history.h"
+#include <readline/history.h>
+
+/* The list-mutating half of `history`: -c and -d, plus the two primitives
+   every other option is built out of.
+
+   state->hist.hist_cmds is the truth. readline keeps its own copy so the
+   arrow keys can recall, and the two must move together or `history` and
+   the up-arrow start disagreeing -- which is exactly what `history -c`
+   used to do (it emptied our vector and left readline's list intact). */
+
+/* A shell started with -c or a script never calls init_history, so the
+   vector arrives zeroed -- elem_size 0 included, which would make the very
+   first vec_push write nothing. Claim it lazily instead of forcing every
+   non-interactive shell to pay for a history it will not use. */
+void	hist_list_init(t_shell *state)
+{
+	if (state->hist.hist_cmds.elem_size != 0)
+		return ;
+	vec_init(&state->hist.hist_cmds);
+	state->hist.hist_cmds.elem_size = sizeof(char *);
+}
+
+/* Append one already-owned entry to the list, and mirror it into readline
+   when a session history is actually live. In -c / script mode readline is
+   never initialised, so we would only be filling a list nothing reads. */
+void	hist_push(t_shell *state, char *owned)
+{
+	hist_list_init(state);
+	vec_push(&state->hist.hist_cmds, &owned);
+	if (state->hist.hist_active)
+		add_history_line(state, owned);
+}
+
+/* Drop readline's copy of entry idx so recall agrees with `history`. */
+void	hist_rl_remove(t_shell *state, int idx)
+{
+	HIST_ENTRY	*e;
+
+	if (!state->hist.hist_active)
+		return ;
+	e = remove_history(idx);
+	if (e)
+		free_history_entry(e);
+}
+
+/* history -c : wipe the list. The backing allocation stays so the vector is
+   reusable, and `appended` goes back to zero because a later `history -a`
+   must not think the entries it already wrote are still ahead of it. */
+int	hist_clear(t_shell *state)
+{
+	size_t	i;
+
+	i = 0;
+	while (i < state->hist.hist_cmds.len)
+		xfree(((char **)state->hist.hist_cmds.ctx)[i++]);
+	state->hist.hist_cmds.len = 0;
+	state->hist.appended = 0;
+	if (state->hist.hist_active)
+		clear_history();
+	return (0);
+}
+
+/* history -d offset : delete one entry. Offsets are 1-based like the
+   listing, and a negative one counts back from the end (-1 is the newest).
+   Anything outside that is bash's "history position out of range", 1. */
+int	hist_delete(t_shell *state, t_vec argv, int first)
+{
+	char	**av;
+	int		off;
+	int		len;
+
+	av = (char **)argv.ctx;
+	len = (int)state->hist.hist_cmds.len;
+	if (first >= (int)argv.len)
+		return (ft_eprintf("%s: history: -d: option requires an"
+				" argument\n", state->ctx), 2);
+	if (ft_checked_atoi(av[first], &off, 2) < 0)
+		off = 0;
+	else if (off < 0)
+		off += len + 1;
+	if (off < 1 || off > len)
+		return (ft_eprintf("%s: history: %s: history position out of"
+				" range\n", state->ctx, av[first]), 1);
+	xfree(((char **)state->hist.hist_cmds.ctx)[off - 1]);
+	ft_memmove((char **)state->hist.hist_cmds.ctx + off - 1,
+		(char **)state->hist.hist_cmds.ctx + off,
+		(size_t)(len - off) * sizeof(char *));
+	state->hist.hist_cmds.len--;
+	return (hist_rl_remove(state, off - 1), 0);
+}

--- a/src/builtins/builtin_history3.c
+++ b/src/builtins/builtin_history3.c
@@ -1,0 +1,88 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_history3.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/22 12:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/22 12:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins_private.h"
+#include "history.h"
+
+/* history -s and history -p: the two options that take words rather than a
+   file. Neither touches the history file. */
+
+/* history -s arg... : append the ARGs to the list as ONE entry, joined by
+   single spaces -- `history -s a b c` stores the single line "a b c", not
+   three lines. No args is a silent success, as in bash. */
+int	hist_store(t_shell *state, t_vec argv, int first)
+{
+	t_string	line;
+	char		**av;
+
+	if (first >= (int)argv.len)
+		return (0);
+	av = (char **)argv.ctx;
+	vec_init(&line);
+	line.elem_size = 1;
+	while (first < (int)argv.len)
+	{
+		vec_push_str(&line, av[first++]);
+		if (first < (int)argv.len)
+			vec_push_char(&line, ' ');
+	}
+	vec_ensure_space_n(&line, 1);
+	((char *)line.ctx)[line.len] = '\0';
+	hist_push(state, (char *)line.ctx);
+	return (0);
+}
+
+/* Expand one ARG the way the line editor would, but silently.
+
+   expand_history() normally echoes a line it rewrote -- that is bash's
+   "show me what !! became before you run it". Under -p the caller does the
+   printing, and it prints even when nothing changed, so the echo has to be
+   suppressed or `history -p '!!'` prints twice. hist_active is forced on
+   for the call because a script has no session history, yet `history -s`
+   may just have built a list that -p is entitled to see. */
+static char	*hist_expand_quiet(t_shell *state, const char *arg)
+{
+	bool	live;
+	char	*res;
+
+	live = state->hist.hist_active;
+	state->hist.hist_active = true;
+	state->hist.quiet_expand = true;
+	res = expand_history(state, arg);
+	state->hist.quiet_expand = false;
+	state->hist.hist_active = live;
+	return (res);
+}
+
+/* history -p arg... : print each ARG after history expansion, storing
+   nothing. A NULL result means the expander declined the string; the ARG
+   is then its own expansion, which is what bash prints too. */
+int	hist_expand_args(t_shell *state, t_vec argv, int first)
+{
+	char	**av;
+	char	*res;
+
+	av = (char **)argv.ctx;
+	while (first < (int)argv.len)
+	{
+		res = hist_expand_quiet(state, av[first]);
+		if (!res)
+			ft_printf("%s\n", av[first]);
+		else
+		{
+			ft_printf("%s\n", res);
+			xfree(res);
+		}
+		first++;
+	}
+	return (0);
+}

--- a/src/builtins/builtin_history4.c
+++ b/src/builtins/builtin_history4.c
@@ -1,0 +1,135 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_history4.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/22 12:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/22 12:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins_private.h"
+#include "history.h"
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+
+/* history -a|-n|-r|-w [file] -- the four options that move entries between
+   the list and a file. All four used to be parsed as "no count", i.e. as a
+   request to print the whole history: issue #42. */
+
+/* Which file. An explicit operand wins, then $HISTFILE (bash's rule), then
+   this session's own history file. A script that has neither has nothing
+   sensible to write to, and bash 5.3 says so with a status of 1 rather
+   than quietly picking a file for you. */
+static char	*hist_target(t_shell *state, t_vec argv, int first)
+{
+	char	*v;
+
+	if (first < (int)argv.len)
+		return (ft_strdup(((char **)argv.ctx)[first]));
+	v = env_expand(state, "HISTFILE");
+	if (v && *v)
+		return (ft_strdup(v));
+	if (state->hist.hist_active)
+		return (get_hist_file_path(state));
+	return (NULL);
+}
+
+/* True when -a's target is the file this session is ALREADY streaming into.
+   hellish appends each command as it is entered (bash defers to exit or to
+   an explicit `history -a`), so writing them again here would duplicate
+   every line -- and with `PROMPT_COMMAND='history -a'`, once per prompt,
+   for ever. Mark them saved and do nothing. */
+static bool	hist_streamed(t_shell *state, t_vec argv, t_histopt *o)
+{
+	char	*v;
+
+	if (o->first < (int)argv.len || state->hist.append_fd < 0)
+		return (false);
+	v = env_expand(state, "HISTFILE");
+	return (!v || !*v);
+}
+
+/* -w (truncate) and -a (append): write entries [from, end) to path. */
+static int	hist_write(t_shell *state, const char *path, size_t from, int fl)
+{
+	int		fd;
+	char	*enc;
+
+	fd = open(path, fl, 0600);
+	if (fd < 0)
+		return (ft_eprintf("%s: history: %s: %s\n", state->ctx, path,
+				strerror(errno)), 1);
+	while (from < state->hist.hist_cmds.len)
+	{
+		enc = (char *)encode_cmd_hist(
+				((char **)state->hist.hist_cmds.ctx)[from++]).ctx;
+		if (write(fd, enc, ft_strlen(enc)) < 0)
+			errno = 0;
+		xfree(enc);
+	}
+	close(fd);
+	return (0);
+}
+
+/* -r (whole file) and -n (only what a previous read did not take): decode
+   path and append its entries to the list. */
+static int	hist_read(t_shell *state, const char *path, size_t skip)
+{
+	t_string	buf;
+	t_vec		got;
+	size_t		i;
+	int			fd;
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return (ft_eprintf("%s: history: %s: %s\n", state->ctx, path,
+				strerror(errno)), 1);
+	vec_init(&buf);
+	buf.elem_size = 1;
+	vec_append_fd(fd, &buf);
+	close(fd);
+	got = parse_hist_file(buf);
+	xfree(buf.ctx);
+	i = 0;
+	while (i < got.len)
+	{
+		if (i++ >= skip)
+			hist_push(state, ((char **)got.ctx)[i - 1]);
+		else
+			xfree(((char **)got.ctx)[i - 1]);
+	}
+	state->hist.readmark = got.len;
+	return (xfree(got.ctx), 0);
+}
+
+/* Dispatch the one file operation the parse settled on. */
+int	hist_fileop(t_shell *state, t_vec argv, t_histopt *o)
+{
+	char	*path;
+	size_t	from;
+	int		st;
+
+	path = hist_target(state, argv, o->first);
+	if (!path)
+		return (ft_eprintf("%s: history: HISTFILE: parameter null or not"
+				" set\n", state->ctx), 1);
+	from = state->hist.appended;
+	if (from > state->hist.hist_cmds.len)
+		from = state->hist.hist_cmds.len;
+	st = 0;
+	if (o->fileop == 'w')
+		st = hist_write(state, path, 0, O_WRONLY | O_CREAT | O_TRUNC);
+	else if (o->fileop == 'a' && !hist_streamed(state, argv, o))
+		st = hist_write(state, path, from, O_WRONLY | O_CREAT | O_APPEND);
+	else if (o->fileop == 'r')
+		st = hist_read(state, path, 0);
+	else if (o->fileop == 'n')
+		st = hist_read(state, path, state->hist.readmark);
+	if (o->fileop == 'a')
+		state->hist.appended = state->hist.hist_cmds.len;
+	return (xfree(path), st);
+}

--- a/src/builtins/builtins_private.h
+++ b/src/builtins/builtins_private.h
@@ -32,6 +32,18 @@
 # define OLDPWD_NAME "OLDPWD"
 # define PWD_NAME "PWD"
 
+/* One parsed `history` invocation. bash lets the modifiers be bundled
+   (`history -cd 1`) but treats -a/-n/-r/-w as mutually exclusive, so the
+   file operation gets its own slot rather than sharing `act`. `first` is
+   the index of the first operand left in argv once options are consumed. */
+typedef struct s_histopt
+{
+	char	fileop;
+	char	act;
+	bool	clear;
+	int		first;
+}	t_histopt;
+
 typedef struct s_rdopt
 {
 	char	*ifs;
@@ -227,4 +239,16 @@ size_t	shopt_flags(t_vec argv, char *act, int *quiet);
 int		reaped_job_status(t_shell *state, pid_t pid);
 int		wait_one(t_shell *state, const char *arg);
 int		wait_n(t_shell *state);
+
+/* history builtin internals (builtin_history*.c). */
+void	hist_list_init(t_shell *state);
+void	hist_push(t_shell *state, char *owned);
+void	hist_rl_remove(t_shell *state, int idx);
+int		hist_clear(t_shell *state);
+int		hist_delete(t_shell *state, t_vec argv, int first);
+int		hist_store(t_shell *state, t_vec argv, int first);
+int		hist_expand_args(t_shell *state, t_vec argv, int first);
+int		hist_fileop(t_shell *state, t_vec argv, t_histopt *o);
+char	*expand_history(t_shell *state, const char *input);
+
 #endif

--- a/src/infrastructure/history2.c
+++ b/src/infrastructure/history2.c
@@ -60,7 +60,7 @@ static void	load_and_persist(t_shell *state, const char *path, bool trimmed)
 	close(fd);
 }
 
-/* Load $HOME/.hellish_history, feed the entries to readline, and rewrite the
+/* Load the history file, feed the entries to readline, and rewrite the
    file if it was trimmed. We open the file with O_CREAT so the first run
    creates it silently instead of erroring. The append_fd stays open for the
    whole session so manage_history() can add each new command atomically. */

--- a/src/infrastructure/history_expand3.c
+++ b/src/infrastructure/history_expand3.c
@@ -40,6 +40,8 @@ char	*quick_sub(t_shell *state, const char *input)
 	if (!res)
 		return (ft_eprintf("%s: :s: substitution failed\n", state->ctx),
 			ft_strdup(""));
+	if (state->hist.quiet_expand)
+		return (res);
 	return (ft_printf("%s\n", res), res);
 }
 
@@ -81,12 +83,14 @@ static int	is_bang_expand(const char *input, size_t i)
 
 /* NUL-terminate and return the expansion result. If it differs from the
    original input, echo it to stdout (bash does the same to let the user see
-   what was expanded before running it). */
-static char	*finish_expand(t_string *result, const char *input)
+   what was expanded before running it) -- unless the caller asked for
+   silence, which `history -p` does because it prints the result itself and
+   prints it even when the expansion changed nothing. */
+static char	*finish_expand(t_shell *state, t_string *result, const char *in)
 {
 	vec_ensure_space_n(result, 1);
 	((char *)result->ctx)[result->len] = '\0';
-	if (ft_strcmp((char *)result->ctx, input) != 0)
+	if (!state->hist.quiet_expand && ft_strcmp((char *)result->ctx, in) != 0)
 		ft_printf("%s\n", (char *)result->ctx);
 	return ((char *)result->ctx);
 }
@@ -120,5 +124,5 @@ char	*expand_history(t_shell *state, const char *input)
 		else
 			vec_push(&result, (void *)&input[i++]);
 	}
-	return (finish_expand(&result, input));
+	return (finish_expand(state, &result, input));
 }

--- a/src/infrastructure/history_utils.c
+++ b/src/infrastructure/history_utils.c
@@ -102,11 +102,17 @@ bool	worthy_of_being_remembered(t_shell *state)
 }
 
 /* First-time history setup: zero the struct, open the file, load and cap the
-   entries, and leave append_fd open for incremental writes. */
+   entries, and leave append_fd open for incremental writes.
+
+   readmark/appended start at what was just loaded: those entries are
+   already both read and on disk, so a later `history -n` must not import
+   them a second time and `history -a` must not re-append them. */
 void	init_history(t_shell *state)
 {
 	state->hist = (t_history){.append_fd = -1, .hist_active = true};
 	parse_history_file(state);
+	state->hist.readmark = state->hist.hist_cmds.len;
+	state->hist.appended = state->hist.hist_cmds.len;
 }
 
 /* Release the heap strings in hist_cmds and their backing vector. The

--- a/tests/completion_test.py
+++ b/tests/completion_test.py
@@ -19,6 +19,17 @@ PATH directory after its FIRST match, and readline asks for one match per
 call, so every other command in that directory was silently dropped. An
 empty TAB listed roughly one command per PATH entry instead of all of them.
 
+A note on driving readline from a test, learned the hard way in CI: never
+let a keystroke this test types survive to become a command. The empty-line
+TAB case answers readline's "Display all N possibilities?" with `n`, and if
+that question did not appear (one TAB only dings; it takes two), the `n`
+lands on the command line instead. On a GitHub runner `n` is the node
+version manager, which switches to the alternate screen and eats every
+byte the test sends afterwards -- so `make completion-test` failed there
+and passed on every developer machine, where `n` is not installed. Two
+TABs to make the question deterministic, and a Ctrl-U before Enter so a
+stray character is discarded either way.
+
 Usage: python3 completion_test.py /path/to/hellish
 """
 import fcntl
@@ -55,6 +66,9 @@ def run(sends, path_extra=None, settle=1.4):
         "TERM": "xterm-256color", "LANG": "C.UTF-8", "PS1": "$ ",
         "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
         "HELLISH_NO_ANIM": "1",
+        # the host's (or the user's) inputrc must not decide whether a TAB
+        # dings, lists, or completes -- that is the thing under test.
+        "INPUTRC": "/dev/null",
         # leaks are checked by verify_alloc; here we want heap ERRORS loud
         "ASAN_OPTIONS": "detect_leaks=0",
     }
@@ -94,16 +108,33 @@ def no_crash(out):
     return [m for m in CRASH_MARKERS if m in out]
 
 
+def launched_something(out):
+    """True if a full-screen program took the terminal over.
+
+    The alternate-screen switch is the fingerprint of a keystroke escaping
+    to the command line and running a real host program (see the module
+    docstring). It makes every later assertion in the case meaningless, so
+    it is checked for explicitly instead of being diagnosed from a
+    confusing tail= dump the next time CI goes red.
+    """
+    return "\x1b[?1049h" in out or "\x1b[?47h" in out
+
+
 def main():
-    # 1: the exact report -- TAB on an empty line. 'n' declines readline's
-    # "display all N possibilities?", which only appears now that the scan
-    # actually reaches every command in PATH.
-    out = run([b"\t", b"n", b"\n", b"echo STILL_ALIVE\n"])
+    # 1: the exact report -- TAB on an empty line. The second TAB is what
+    # makes readline ask "Display all N possibilities?" (the first only
+    # dings); 'n' declines it, and Ctrl-U throws the line away so that 'n'
+    # can never be run as a command if the question did not appear.
+    out = run([b"\t\t", b"n", b"\x15", b"\n", b"echo STILL_ALIVE\n"])
     hits = no_crash(out)
     check("TAB on an empty line does not corrupt the heap", not hits,
           "saw %s" % hits)
+    check("readline offers the whole PATH, not a handful",
+          "possibilities?" in out, "tail=%r" % out[-200:])
     check("the shell still runs commands after that TAB",
           out.count("STILL_ALIVE") >= 2, "tail=%r" % out[-200:])
+    check("no keystroke this test typed launched a program",
+          not launched_something(out), "tail=%r" % out[-200:])
 
     # 2: completing a builtin still works (the matches are libc-owned now,
     # so this is the path that would abort if rl_dup were reverted).
@@ -135,6 +166,26 @@ def main():
         check("all matches in one PATH dir are offered, not just the first",
               len(found) == 3,
               "only %r survived the scan; tail=%r" % (found, out[-300:]))
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+    # 5: the CI failure this file caused, made reproducible anywhere.
+    # Shadow the decline key with a real, full-screen program on PATH --
+    # which is exactly the runner's `n` -- and prove the drive sequence
+    # never hands it to the shell. Without the Ctrl-U (or with a single
+    # TAB, which only dings) this hangs and STILL_ALIVE never arrives.
+    d = tempfile.mkdtemp(prefix="hellish_shadow_")
+    try:
+        p = os.path.join(d, "n")
+        with open(p, "w") as f:
+            f.write("#!/bin/sh\nprintf '\\033[?1049hTOOK-THE-SCREEN\\n'"
+                    "\nsleep 30\n")
+        os.chmod(p, 0o755)
+        out = run([b"\t\t", b"n", b"\x15", b"\n", b"echo STILL_ALIVE\n"],
+                  path_extra=d, settle=1.8)
+        check("a one-letter program on PATH cannot hijack this test",
+              not launched_something(out)
+              and out.count("STILL_ALIVE") >= 2, "tail=%r" % out[-300:])
     finally:
         shutil.rmtree(d, ignore_errors=True)
 

--- a/tests/history_opts_test.py
+++ b/tests/history_opts_test.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Regression test for issue #42: hellish dumped the whole command history
+at startup, before every prompt, with no input from the user at all.
+
+The reporter (CachyOS) showed a screenshot of a numbered history listing
+scrolling past and then a prompt. Nothing they typed caused it, and the
+report contained no command to reproduce -- which is why it is worth
+writing down what it actually was.
+
+`history` parsed its argument with ft_atoi. ft_atoi("-a") is 0, a count of
+0 means "no count was given", and "no count" means print the entire list.
+So `history -a` -- silent in bash -- printed everything. `history -a` is
+not an exotic invocation: it is the stock bashrc line that flushes the
+history file after every command, usually via PROMPT_COMMAND, and hellish
+imports PROMPT_COMMAND from the environment exactly as bash does. One
+inherited variable and the shell was unusable.
+
+The golden category tests/issue42_history_opts covers what every option
+does. It cannot cover THIS, because the golden harness runs `hellish -c`
+and the bug needs an interactive shell, a populated history file and a
+prompt cycle. So: a real pty, a real history file, and the assertion that
+a prompt is quiet.
+
+Checks:
+  1. PROMPT_COMMAND='history -a' prints nothing (the reported bug).
+  2. ... and does not grow the history file by re-appending what this
+     session already streamed into it.
+  3. -w / -r / -n / -d / -c / -s / -p behave in a live session too.
+  4. `history -c` clears readline's recall, not just our vector.
+  5. An unknown option is an error, not a request to print everything.
+
+Usage: python3 history_opts_test.py /path/to/hellish
+"""
+import os
+import pty
+import re
+import select
+import signal
+import sys
+import tempfile
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "../build/bin/hellish")
+FAILS = []
+SEEDED = ["echo one", "echo two", "echo three", "ls -la", "cd /tmp"]
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name
+          + (" " + detail if not ok else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def plain(b):
+    return re.sub(rb"\x1b\[[0-9;?]*[a-zA-Z]", b"", b).decode(errors="replace")
+
+
+class Session:
+    """One interactive hellish in front of a real terminal.
+
+    PATH is deliberately NOT inherited: these tests type short strings at a
+    prompt, and a one-letter word that happens to be an executable on the
+    host would run a program instead of being the harmless typo the test
+    intends. (That is not hypothetical -- `n` is the node version manager
+    on a GitHub runner, and it takes over the terminal.)
+    """
+
+    def __init__(self, home, prompt_command=None):
+        env = {
+            "HOME": home, "PATH": "/usr/bin:/bin",
+            "TERM": "xterm-256color", "LANG": "C.UTF-8", "PS1": "$ ",
+            "INPUTRC": "/dev/null",
+            "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+            "HELLISH_NO_ANIM": "1", "ASAN_OPTIONS": "detect_leaks=0",
+        }
+        if prompt_command is not None:
+            env["PROMPT_COMMAND"] = prompt_command
+        os.makedirs(os.path.join(home, ".cache", "hellish"), exist_ok=True)
+        open(os.path.join(home, ".cache", "hellish", "seen"), "w").close()
+        self.pid, self.fd = pty.fork()
+        if self.pid == 0:
+            os.environ.clear()
+            os.environ.update(env)
+            os.execvp(SHELL, [SHELL])
+            os._exit(127)
+        self.start = self.drain(1.0)
+
+    def drain(self, t=0.4):
+        out = b""
+        end = time.time() + t
+        while time.time() < end:
+            r, _, _ = select.select([self.fd], [], [], 0.08)
+            if r:
+                try:
+                    c = os.read(self.fd, 65536)
+                except OSError:
+                    break
+                if not c:
+                    break
+                out += c
+        return out
+
+    def send(self, s, wait=0.4):
+        os.write(self.fd, s.encode())
+        return plain(self.drain(wait))
+
+    def close(self):
+        try:
+            os.write(self.fd, b"exit\n")
+        except OSError:
+            pass
+        for _ in range(20):
+            try:
+                p, _ = os.waitpid(self.pid, os.WNOHANG)
+            except ChildProcessError:
+                return
+            if p:
+                return
+            time.sleep(0.1)
+        try:
+            os.kill(self.pid, signal.SIGKILL)
+            os.waitpid(self.pid, 0)
+        except (ProcessLookupError, ChildProcessError):
+            pass
+
+
+def seeded_home():
+    home = tempfile.mkdtemp(prefix="hellish_hist42_")
+    with open(os.path.join(home, ".minishell_history"), "w") as f:
+        f.write("".join(c + "\n" for c in SEEDED))
+    return home
+
+
+def hist_lines(home):
+    with open(os.path.join(home, ".minishell_history")) as f:
+        return [ln for ln in f.read().split("\n") if ln]
+
+
+def numbered(text):
+    """The listing rows `history` prints: '   12  echo one'."""
+    return re.findall(r"^\s*\d+\s\s\S.*$", text, re.M)
+
+
+def test_issue42_prompt_command():
+    home = seeded_home()
+    s = Session(home, prompt_command="history -a")
+    banner = plain(s.start)
+    check("issue #42: PROMPT_COMMAND='history -a' prints no listing",
+          not numbered(banner), "startup showed %r" % numbered(banner)[:4])
+    out = s.send("echo alive\n")
+    check("issue #42: it stays quiet on the next prompt too",
+          not numbered(out) and "alive" in out,
+          "after one command: %r" % out[-200:])
+    s.close()
+    after = hist_lines(home)
+    dupes = [c for c in SEEDED if after.count(c) > 1]
+    check("issue #42: -a does not re-append what the session already wrote",
+          not dupes, "duplicated %r in %r" % (dupes, after))
+    check("the seeded history survived the session", SEEDED[0] in after,
+          "file is now %r" % after)
+
+
+def test_live_session_options():
+    home = seeded_home()
+    s = Session(home)
+    out = s.send("history 2\n")
+    rows = numbered(out)
+    check("history 2 lists exactly two entries", len(rows) == 2,
+          "rows=%r" % rows)
+
+    out = s.send("history -w %s/w.txt\n" % home)
+    check("history -w writes without printing the list", not numbered(out),
+          "printed %r" % numbered(out)[:4])
+    ok = os.path.exists(os.path.join(home, "w.txt"))
+    check("history -w created the file", ok)
+    if ok:
+        with open(os.path.join(home, "w.txt")) as f:
+            body = f.read()
+        check("history -w wrote the seeded entries", SEEDED[0] in body,
+              "file was %r" % body[:120])
+
+    out = s.send("history -n %s/w.txt\n" % home)
+    check("history -n prints nothing", not numbered(out),
+          "printed %r" % numbered(out)[:4])
+    out = s.send("history -r %s/w.txt\n" % home)
+    check("history -r prints nothing", not numbered(out),
+          "printed %r" % numbered(out)[:4])
+
+    out = s.send("history -s marker_entry\n")
+    check("history -s prints nothing", not numbered(out))
+    out = s.send("history 1\n")
+    check("history -s stored the entry", "marker_entry" in out,
+          "tail=%r" % out[-160:])
+
+    out = s.send("history -p abc\n")
+    check("history -p echoes the expansion exactly once",
+          out.count("abc") == 2, "tail=%r" % out[-160:])
+
+    out = s.send("history -zz\n")
+    check("an unknown option does not print the list", not numbered(out),
+          "printed %r" % numbered(out)[:4])
+    out = s.send("echo st=$?\n")
+    check("an unknown option exits 2", "st=2" in out, "tail=%r" % out[-120:])
+    s.close()
+
+
+def test_clear_also_clears_recall():
+    home = seeded_home()
+    s = Session(home)
+    s.send("history -c\n")
+    out = s.send("history\n")
+    # bash records a line BEFORE running it, hellish records it after, so
+    # bash's post-clear listing holds `history` and ours holds `history -c`.
+    # That ordering difference is old and orthogonal; what -c has to do is
+    # drop everything that came before it.
+    left = [r for r in numbered(out) if "history" not in r]
+    check("history -c drops every earlier entry", not left,
+          "still listed %r" % left[:4])
+    # Walk the whole recall ring, not one step: the newest entry is the
+    # `history` we just typed, so a single up-arrow proves nothing. A
+    # -c that forgot readline leaves the seeded entries further back.
+    out = ""
+    for _ in range(10):
+        out += s.send("\x1b[A", 0.2)
+    stale = [c for c in SEEDED if c in out]
+    check("history -c also clears readline's recall", not stale,
+          "up-arrow resurrected %r" % stale)
+    os.write(s.fd, b"\x15\n")
+    s.drain(0.3)
+    s.close()
+
+
+def main():
+    test_issue42_prompt_command()
+    test_live_session_options()
+    test_clear_also_clears_recall()
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/issue42_history_opts
+++ b/tests/issue42_history_opts
@@ -1,0 +1,41 @@
+history -p abc
+history -p one two
+history -p '$HOME'; echo st=$?
+history -s a b c; history
+history -s x; history -s y; history
+history -s "a b"; history
+history -s dup; history -s dup; history
+history -s a; history -s b; history 1
+history -s a; history -s b; history -s c; history 2
+history -s a; history 99
+history -s a; history -s b; history -d 1; history
+history -s a; history -c; history; echo end
+history -c; history; echo cleared
+history 0; echo st=$?
+history -p; echo st=$?
+history -s; echo st=$?
+history -s one; history -s two; history -w outfiles/hf42a; cat outfiles/hf42a
+history -s one; history -w outfiles/hf42b; history -c; history -r outfiles/hf42b; history
+history -s keep; history -w outfiles/hf42c; history -c; history -n outfiles/hf42c; history
+history -s only; history -a outfiles/hf42d; cat outfiles/hf42d
+history -s a; history -s b; history -w outfiles/hf42e; echo done
+HISTFILE=outfiles/hf42f; history -s q; history -w; cat outfiles/hf42f
+HISTFILE=outfiles/hf42g; history -s q; history -w; history -c; history -r; history
+history -x; echo st=$?
+history abc; echo st=$?
+history -anrw; echo st=$?
+history -d 1; echo st=$?
+history -d 0; echo st=$?
+history -s a; history -d 99; echo st=$?
+history -r /nonexistent/hellish42; echo st=$?
+history -w /nonexistent/dir42/x; echo st=$?
+history -s a; history -s b; history -a outfiles/hf42h; echo silent
+history -s a; history -s b; history -n outfiles/hf42i; echo silent
+history -s a; history -s b; history -r /dev/null; echo silent
+history -s a b; history -p '!!'
+history -s echo hi; history -p '!!'; history
+history -p 'plain text' 'no bang here'
+history -s a; history -s b; history -p '!1' '!2'
+history -- 1; echo st=$?
+history -c -c; echo st=$?
+history -s x; history -cd 1; history; echo st=$?

--- a/tests/tester
+++ b/tests/tester
@@ -23,6 +23,7 @@ if [[ ${#test_lists[@]} -eq 0 ]]; then
         "issue8_set_options"
         "issue18_job_numbers"
         "issue27_job_pgrp"
+        "issue42_history_opts"
         "issue13_bg_pid"
         "issue17_signal_report"
         "issue16_net_redir"

--- a/wiki/platforms.md
+++ b/wiki/platforms.md
@@ -1,0 +1,130 @@
+# Platforms
+
+Where hellish is known to build and run, how that is proved, and what is
+still broken. If you hit a platform problem, this page should either
+already name it or be the place you add it.
+
+## Why this page exists
+
+Two bugs reached users because CI ran on exactly one machine:
+
+- **Issue #9** — gcc 11's `-Wstringop-overflow` rejected a `va_list`
+  forwarded between functions. `make` failed outright on Ubuntu 22.04, the
+  distro WSL installs by default. gcc 13 and gcc 14 compiled it in silence,
+  so every CI job stayed green.
+- **Issue #42** — reported from CachyOS, an Arch derivative, with a
+  screenshot instead of a reproducer.
+
+Neither was hard to fix. Both were hard to *see*. The matrix below is the
+fix for that, and the reason it is deliberately wide.
+
+## How it is proved
+
+Two things run, and they answer different questions.
+
+| | what it proves | where |
+|---|---|---|
+| `docker/smoke.sh` | 40 checks: the shell starts, forks, pipes, redirects, here-docs, globs, does arithmetic, handles signals and job control, and reports the right exit statuses | every platform rung |
+| the golden suite | ~3800 cases diffed byte-for-byte against a pinned bash 5.3.9 | x86_64 and arm64 Linux |
+
+The smoke is not a weaker suite — it is a *different* one. It targets the
+class of bug that only appears when the C code meets a different libc,
+compiler or kernel personality. The golden suite needs a bash 5.3.9 built
+from source to diff against; doing that inside fourteen distro images would
+turn the matrix into an hours-long job for very little extra signal, so it
+runs where it is cheap and the smoke runs everywhere.
+
+Run either one yourself:
+
+```sh
+make smoke                      # the portability workout, against your build
+make docker-test                # build + smoke in every distro container
+docker/test.sh fedora void      # ... or just these
+```
+
+## The matrix
+
+### Linux — supported, gated
+
+Every rung builds from source with `-Wall -Wextra -Werror` and then runs the
+smoke. A warning is a build failure.
+
+| rung | libc | compiler | why it is in the list |
+|---|---|---|---|
+| Ubuntu 24.04 | glibc | gcc, clang | the common case |
+| Ubuntu 22.04 | glibc | gcc 11 | the default WSL distro, and the oldest toolchain we claim to support — issue #9 lived here |
+| Debian stable | glibc | gcc, clang | |
+| Alpine 3.20 | **musl** | gcc, clang | a different libc is where "works on my machine" goes to die |
+| Alpine 3.20 | musl | gcc, `SAFE=0` | the custom `ft_malloc` heap, on musl — the least portable thing in the tree |
+| Arch | glibc | gcc | the family issue #42 came from; newest gcc |
+| Fedora 41 | glibc | gcc, clang | the other big non-Debian desktop |
+| Rocky 9 | glibc | gcc | old glibc, old gcc — what servers actually run |
+| openSUSE Tumbleweed | glibc | gcc | rolling; also the only image here with no `find` (see below) |
+| Void Linux | glibc | gcc | xbps, a fifth package manager |
+| Linux arm64 | glibc | gcc, clang | a **native** runner, not emulation: alignment, `char` signedness, register width |
+
+### macOS — informational
+
+There is no Docker route to macOS. Apple's kernel is not distributable in a
+container and the licence does not permit running it off Apple hardware, so
+"macOS as Docker" is not a thing that exists — GitHub's `macos-13`
+(x86_64) and `macos-14` (arm64) runners are the honest equivalent, and both
+are in the `Platforms` workflow.
+
+The job is `continue-on-error` on purpose. The shell is written to POSIX but
+has never been built on Darwin, and two gaps are already known:
+
+1. **readline.** Apple ships libedit under the name `libreadline`. It
+   answers `-lreadline` and then does not have most of the GNU API this
+   shell uses. The Makefile now asks `brew --prefix readline` and adds that
+   include/lib pair on Darwin — untested on a real Mac.
+2. **`/proc/self/exe`.** Process substitution re-execs the shell through
+   that path (`incs/sys.h`), and it does not exist on Darwin. `<(cmd)` and
+   `>(cmd)` will not work there until it is replaced with a runtime lookup
+   (`_NSGetExecutablePath` on Darwin, `/proc/curproc/file` on FreeBSD).
+   Note `/dev/fd/N` is already used for the resulting path, which *is*
+   portable — only the self-exec path is not.
+
+`-D_XOPEN_SOURCE=700` is also wrong on Darwin: it pins the POSIX.1-2008
+surface on glibc and musl, but on Apple's libc it *hides* the BSD extensions
+the system headers themselves need. The Makefile uses `-D_DARWIN_C_SOURCE`
+there instead.
+
+Do not flip `continue-on-error` off until the job is green. A red required
+check that everyone learns to ignore is worse than an informational one.
+
+### WSL — informational
+
+WSL is not "Linux in Docker", and running the Linux containers is not
+coverage for it. What differs is the Windows bridge: `drvfs` on `/mnt/c`
+has different permission and case semantics, Windows executables appear on
+`PATH` and are exec'd through interop, and the default install is Ubuntu
+22.04 with gcc 11. Building *inside* WSL is the only way to see any of it,
+so the workflow does that on a `windows-latest` runner.
+
+Informational because the runner-side WSL setup is the flakiest step in the
+file, not because the platform does not matter.
+
+## Things the matrix has already caught
+
+- **openSUSE Tumbleweed ships no `find`.** The Makefile discovers its
+  sources with `$(shell find src ...)`, so the source list came back empty,
+  make built nothing, and the link stopped at `cc: fatal error: no input
+  files` — an error pointing nowhere near the cause. Fixed twice: the image
+  installs `findutils`, and the Makefile now refuses to run with an empty
+  `SRCS` and says why.
+
+## Adding a rung
+
+1. Add a service to `docker-compose.yml` (copy an existing one; only `BASE`,
+   and optionally `CC` / `BUILD_FLAGS`, change).
+2. If it needs a package manager `docker/Dockerfile` does not know, add a
+   branch to the `RUN` block — it already covers apk, apt, pacman, dnf,
+   zypper and xbps.
+3. Add the rung to the `distros` matrix in
+   `.github/workflows/platforms.yml`.
+4. Add it to the default list in `docker/test.sh` and to the table above.
+
+If the new platform fails, land the rung as informational with the failure
+written down here, rather than leaving it out. An unrun platform is a
+platform users find bugs on.


### PR DESCRIPTION
Closes #42.
Closes #32.

Refs #43 (partial — a proven fork-bomb path is fixed; the Makefile-simplification half is not).

Three things, in the order they were found.

## 1. Issue #42 — `history` printed everything for every option

The report was a screenshot of a numbered history listing scrolling past on
startup, from CachyOS, with "No input" as the reproducer. Reproduced in a
pty before touching anything, and the cause is a one-liner:

`history` read its argument with `ft_atoi`. `ft_atoi("-a")` is `0`, a count
of `0` means "no count given", and no count means print the whole list. So
every option word was a request to dump the history.

`history -a` is not exotic — it is the stock bashrc line that flushes the
history file after each command, usually through `PROMPT_COMMAND`, and
hellish imports `PROMPT_COMMAND` from the environment exactly as bash does.
One inherited variable and the shell is unusable:

```
$ PROMPT_COMMAND='history -a' hellish     # every prompt, forever
    1  echo one
    2  echo two
    ...
```

All of bash's options now work: `-c` (which also clears readline's recall,
which the old `-c` left behind), `-d` with 1-based or negative offsets,
`-a`/`-n`/`-r`/`-w` against an operand, `$HISTFILE`, or the session file,
`-p`, `-s`. An unknown option is status 2; a non-numeric count is status 2.

`-a` against the file this session is already streaming into is a no-op
that only moves the mark — hellish appends each command as it runs, so
re-writing them would duplicate every line once per prompt.

**Tests:** `tests/issue42_history_opts`, 41 golden cases diffed against the
pinned bash 5.3.9 and wired into `test_lists`; and `make history-opts-test`,
a pty gate that reproduces the reported shape. Reverting the fix fails 11 of
that gate's checks, the first of them the reporter's screenshot.

## 2. The CI failure on `develop`

`corpus` failed on 6979cd7: *"the shell still runs commands after that TAB"*,
tail ending in `\x1b[?1049h`.

The case types TAB, then `n` to decline readline's "Display all N
possibilities?". One TAB only rings the bell — it takes two before readline
asks. So `n` was never an answer; it was a command line. On a GitHub runner
`n` is the node version manager, which switches to the alternate screen and
eats the rest of the test's input. Every developer machine passed because
`n` is not installed there.

Fixed: two TABs so the question is deterministic, Ctrl-U before Enter so a
stray character is discarded either way, and `INPUTRC=/dev/null` so the
host's inputrc does not get to decide what a TAB does. The CI failure is now
a check anyone can run — a fake full-screen `n` is put on PATH and the case
must still reach `STILL_ALIVE`.

## 3. The `Platforms` matrix

`ci.yml` answers "does this change work?" on one Ubuntu. Nothing answered
"does it work anywhere else?" — which is how #9 (gcc 11 on Ubuntu 22.04, the
default WSL distro, failing to compile while every job stayed green) and #42
reached users.

**Gated:** 14 Docker distro/compiler rungs — Ubuntu 22.04/24.04, Debian,
Alpine (musl), Arch, Fedora 41, Rocky 9, openSUSE Tumbleweed, Void; gcc and
clang; plus a musl + `ft_malloc` rung — each running `docker/smoke.sh`, a
new 40-check portability workout. Plus a **native arm64** runner (not
emulation) running the full golden suite.

**Informational** (`continue-on-error`, on purpose):

- **macOS** `macos-13` (x86_64) and `macos-14` (arm64). There is no Docker
  route to macOS — Apple's kernel is not distributable in a container and
  the licence does not permit it off Apple hardware — so the runners are the
  honest equivalent. The Makefile now handles the two Darwin build
  requirements (Homebrew readline, `-D_DARWIN_C_SOURCE` instead of
  `-D_XOPEN_SOURCE=700`), but `/proc/self/exe` — how the shell re-execs
  itself for process substitution — still has no Darwin equivalent. The job
  exists to make that a log instead of a guess.
- **WSL** on `windows-latest`. Not "Linux in Docker": drvfs on `/mnt/c`,
  Windows interop on PATH, and a default Ubuntu 22.04 with gcc 11 are the
  whole point.

A red required check everyone learns to ignore is worse than an
informational one. Flip these two once green, not before.

**The matrix already earned its keep:** openSUSE Tumbleweed's base image
ships no `find`. The Makefile discovers sources with `$(shell find src …)`,
so `SRCS` came back empty, make built nothing, and the link died on
`cc: fatal error: no input files` — an error pointing nowhere near its
cause. Fixed on both sides: the image installs `findutils`, and the Makefile
refuses to run with an empty `SRCS` and says why.

Also: `.env` was reaching every image layer. BuildKit prefers the
per-Dockerfile ignore file over the repo-root one, and only the root one
excluded it.

## Verification

All from a clean tree, against the pinned bash 5.3.9 oracle:

```
make test                     3790 / 3790
tests/run_scripts.sh           109 / 109
tests/verify_alloc.sh           78 / 78 on BOTH heaps, 0 leaks
make history-opts-test          17 checks  (11 fail with the fix reverted)
make completion-test            10 checks  (hangs with the fix reverted)
make smoke                      40 / 40
norminette                      clean on every touched file
make re / make re OPT=1         clean, -Wall -Wextra -Werror
docker: fedora rocky opensuse void alpine-clang alpine-ftmalloc debian-clang
                                built from source, 40/40 each
```

## Known divergence left alone

bash records a line in history *before* running it; hellish records it
after. So the listing immediately after `history -c` shows `history -c` in
hellish and `history` in bash. Moving the record point touches `!!`
expansion and the cmdhist joiner, so it is out of scope here and written
down in the pty gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Update: issues #32 and #43, the six CI failures, and the test suite

## The six failing checks on the first Platforms run — all fixed

The new matrix went red on its first run. It was supposed to. Three causes:

| check | cause | fix |
|---|---|---|
| `linux arm64 · gcc`, `· clang`, `macOS arm64` | `libft.h` included `<immintrin.h>` unconditionally — the Intel intrinsics header, which exists on x86 and nowhere else. Every non-x86 build died at the **first** source file. | Univers42/libft#79. Nothing in libft uses an intrinsic — verified by compiling all 487 sources with the include forced off. |
| `alpine musl · ft_malloc` | libft declares the nested `ft_malloc` submodule `update = none`, so `submodules: recursive` skips it — and the Makefile's fallback `git submodule update` cannot rescue a **Docker** build, because the context has no `.git`. | Materialize it on the host before the context is sent. |
| `WSL` | The job set `wsl-bash` as a **job-level default shell**. It does not exist until `setup-wsl` registers it, and a job-level default applies to the whole job — so the run died before any step produced a log. | Per-step shells, plus a step that says out loud what a silent failure there means. |
| `Platform matrix result` | gate over the above | green once they are |

> **One thing to action:** the submodule is pinned to the libft **PR branch**, because libft#79 is not merged. The commit is on the remote so CI resolves it fine — but **re-pin to `main` once that PR lands**.

## Issue #32 — multi-line history

Two real defects, found by building a 26-construct matrix and diffing every one against a live bash 5.3.9 given the same keystrokes:

- **A recalled function definition stopped defining a function.** `f()` + newline joined to `f(); { ... }`, which is a syntax error. The joiner knew `;` is illegal after `then`/`do`/`in` and after a case pattern, but not after a function header.
- **`shopt -s lithist` skipped the scanner instead of changing it**, so it also skipped the top-level `\`-newline splice. lithist is now a flag *on* the shared scanner.

Plus **`pretty`**, a curated front-end over the behaviour knobs (the config feature requested on #32): named features, three presets, and `pretty -p` printing paste-back `~/.hellishrc` lines. Every feature *is* a `SHOPT_*` bit — no second source of truth — and the test asserts `pretty -p` is a **fixed point**, so reproducibility is enforced rather than claimed. Default is unchanged: bash-identical.

## Issue #43 — a concrete path to the fork bomb

    NPROC := $(shell nproc || sysctl -n hw.ncpu || echo 4)
    MAKEFLAGS := -j$(NPROC)

The `||` chain only fires when a probe **fails**. A probe that succeeds and prints nothing — which a sandboxed or cgroup-restricted `nproc` can do — leaves `NPROC` empty, and `-j` with an empty argument means **unlimited** jobs: one compiler per source file, 487 at once. Guarded in pure make (a tool that might be missing cannot be what guards against a missing tool).

This does **not** close #43 — the Makefile-simplification half is untouched, and the reporter had no reproducer, so this is a proven path to the symptom rather than a confirmed diagnosis of theirs.

## Regression tests now run by discovery, not by a list

Every `tests/*.py` was wired in by hand, twice — a Makefile target and a CI step. A hand-maintained list drifts, and this one had: **`completion_posix_test.py` had neither**, so the POSIX command-search fix it guards ran nowhere from the day it landed.

`tests/pty_suite.sh` globs the directory instead. `make pty-test` runs it; CI runs that one step instead of naming ten files. Skips are explicit and carry a reason and a pointer to where they do run.

Running the orphan for the first time surfaced two more things:

1. **The fix it guards was uncommitted**, sitting in a working tree from a previous session. The test fails 19 checks without it, so it is committed here — flagged because it is not my change.
2. **The test was flaky by construction** — a flat wall-clock budget per keystroke (0.8s to start, 1.3s to complete a word). That is a race, not a wait: green alone, red after fifteen other pty tests, reporting *load* as a shell bug. Both it and my new matrix now read until the terminal goes **silent**, with a cap so a wedged shell still fails. Verified under 8-way CPU contention, where the old version failed.

## Verification (clean tree, pinned bash 5.3.9)

```
make test                     3790 / 3790
tests/run_scripts.sh           109 / 109
tests/hard/run.sh               17 / 17
tests/verify_alloc.sh           78 / 78  on BOTH heaps, 0 leaks
make pty-test                   16 files, 0 failed  (4 skipped, each with a reason)
  history_multiline_matrix.py   78 checks
  pretty_modes_test.py          41 checks
  completion_posix_test.py      ran for the first time
make smoke                      40 / 40
make help-test / cli-opts-test  0 failed / 20 pass
norminette                      clean on every touched file
docker: fedora rocky opensuse void alpine-clang alpine-ftmalloc debian-clang
                                built from source, 40/40 each
```


