### PR TITLE
fix(prompt): the git star must not outlive the tree it describes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -633,6 +633,15 @@ history-matrix-test: all
 	@python3 $(TEST_DIR)/history_multiline_matrix.py \
 		$(BIN_DIR)/$(BAPTIZE_SHELL)
 
+# The git dirty star must not outlive the state it describes: a `git status`
+# that took a second armed a 30-second TTL, and the prompt then asserted
+# "dirty" for half a minute after a `git checkout` in the same shell had made
+# the tree clean. Makes the slow scan deterministic with a `git` shim rather
+# than needing a big repo, so it reproduces on any machine.
+git-star-test: all
+	@python3 $(TEST_DIR)/git_star_freshness_test.py \
+		$(BIN_DIR)/$(BAPTIZE_SHELL)
+
 # ── Every pty/regression test in tests/*.py, by DISCOVERY ────────────────────
 # Not a list: a list drifts, and this one had. completion_posix_test.py lived
 # in tests/ with no target and no CI job, so the POSIX command-search fix it
@@ -839,7 +848,7 @@ geoman: all
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
 	docker-arch docker-fedora docker-rocky docker-opensuse docker-void \
 	smoke docker-clean cd-zsh-test cd-posix-test agnostic-bench \
-	hist-test history-opts-test history-matrix-test pty-test \
+	hist-test history-opts-test history-matrix-test pty-test git-star-test \
 	completion-test completion-posix-test \
 	readline-test anim-test git-prompt-test \
 	prompt-atomic-test \

--- a/src/infrastructure/input_utils2.c
+++ b/src/infrastructure/input_utils2.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "input_private.h"
+#include "prompt_private.h"
 #include "parena.h"
 
 /* Initialise the parser, token deque, and prompt string for one command cycle.
@@ -53,6 +54,7 @@ static void	finalize_parser_and_cleanup(t_shell *state,
 	if (parser->res == RES_OK && !state->cycle_streamed)
 	{
 		execute_top_level(state);
+		(*git_scan_gen())++;
 		if (parena()->attached)
 			free_ast(&state->tree);
 		else

--- a/src/infrastructure/prompt_git2.c
+++ b/src/infrastructure/prompt_git2.c
@@ -73,3 +73,26 @@ t_gitloc	*repo_locate(void)
 	walk_root(&loc);
 	return (&loc);
 }
+
+/* Bumped once per command the REPL actually executes.
+
+   The dirty cache below throttles how often `git status` is RE-RUN while
+   nothing is happening, which is right: a prompt redrawn on an idle
+   terminal has no reason to rescan. What it must never do is outlive an
+   actual change to the working tree -- and the only moment the tree can
+   change under this shell is a command running in it.
+
+   Without this, a scan that took a second armed a 30-second TTL and the
+   prompt then asserted "dirty" for half a minute after `git checkout`,
+   `git commit` or `git stash` had made it clean. The star said one thing
+   and `git status` on the line above said the other.
+
+   A counter rather than a flag: it makes "has anything happened since
+   this answer was computed?" a comparison, so a scan that completes late
+   is still attributed to the generation it was started for. */
+int	*git_scan_gen(void)
+{
+	static int	gen;
+
+	return (&gen);
+}

--- a/src/infrastructure/prompt_private.h
+++ b/src/infrastructure/prompt_private.h
@@ -109,17 +109,22 @@ typedef struct s_gitloc
    `ttl` seconds past `at`) plus the in-flight `git status` scan, if any
    (`busy`, `fd` its non-blocking read end, started at `spawned`).  The
    scanner is deliberately NOT our child -- see prompt_git3.c -- so there
-   is no pid here to wait for; `fd` closing is the only completion signal. */
+   is no pid here to wait for; `fd` closing is the only completion signal.
+   `gen` is the value of *git_scan_gen() when this answer was computed: the
+   TTL only throttles rescanning while NOTHING has happened, so a command
+   running in the tree retires the cached answer regardless of how much of
+   the TTL is left. */
 typedef struct s_dcache
 {
-	char	root[PATH_MAX];
-	time_t	at;
-	time_t	ttl;
-	time_t	spawned;
-	int		busy;
-	int		fd;
-	int		dirty;
-	int		init;
+	char			root[PATH_MAX];
+	int				gen;
+	time_t			at;
+	time_t			ttl;
+	time_t			spawned;
+	int				busy;
+	int				fd;
+	int				dirty;
+	int				init;
 }	t_dcache;
 
 void		vec_push_ansi(t_string *v, const char *seq);
@@ -170,6 +175,7 @@ void		ps1_anim(t_shell *state, t_string *out);
 t_string	ps1_animated(t_shell *state, char *ps1);
 int			visible_width_cstr(const char *s);
 void		get_git_info(char **branch, int *dirty);
+int			*git_scan_gen(void);
 void		prompt_user_and_cwd(t_string *ret, t_prompt *p);
 void		prompt_branch(t_string *ret, t_prompt *p);
 void		prompt_venv(t_string *ret, t_prompt *p);

--- a/src/platform/posix/prompt_git3.c
+++ b/src/platform/posix/prompt_git3.c
@@ -146,7 +146,12 @@ static int	poll_done(t_dcache *c, int wait_ms)
 /* Non-blocking dirty flag for the repo rooted at `root`. A change of root
    abandons any in-flight check (its answer is for a repo we left). Only a
    freshly entered root gets a bounded wait — TTL refreshes poll with a
-   zero budget, so a render never stalls once the shell is inside a repo. */
+   zero budget, so a render never stalls once the shell is inside a repo.
+
+   A generation change (a command ran, so the tree may differ) retires the
+   cached answer whatever the TTL says. Without that, the 30-second arm
+   taken by a slow scan kept asserting "dirty" long after a `git checkout`
+   in the same shell had made the tree clean. */
 int	git_dirty_cached(const char *root)
 {
 	static t_dcache	c;
@@ -157,6 +162,7 @@ int	git_dirty_cached(const char *root)
 	if (c.busy)
 		return (poll_done(&c, 0), c.dirty);
 	if (c.init && ft_strcmp(c.root, root) == 0
+		&& c.gen == *git_scan_gen()
 		&& time(NULL) - c.at < c.ttl)
 		return (c.dirty);
 	wait_ms = 0;
@@ -166,6 +172,7 @@ int	git_dirty_cached(const char *root)
 		c.dirty = 0;
 	}
 	c.init = 1;
+	c.gen = *git_scan_gen();
 	ft_strlcpy(c.root, root, sizeof(c.root));
 	spawn_check(&c);
 	if (c.busy)

--- a/tests/git_star_freshness_test.py
+++ b/tests/git_star_freshness_test.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""The git dirty star must not outlive the state it describes.
+
+The report: a prompt reading `on develop*` while `git status` in the same
+shell, one line above, said "nothing to commit, working tree clean". The
+star stayed for every prompt after that.
+
+    ╰─❯ git push
+        ... (success)
+    ╰─❯ git status
+        nothing to commit, working tree clean
+    ╰─❯                     <- still `on develop*`
+    ╰─❯                     <- still `on develop*`
+
+Not a rendering bug. `git_dirty_cached` (prompt_git3.c) throttles the
+async `git status -uno` with a TTL, and the TTL has two values:
+
+    c->ttl = 3;
+    if (c->at - c->spawned >= 1)
+        c->ttl = 30;        <- a scan that took a second
+
+The 30-second arm exists so a slow repo is not re-scanned continuously,
+and it is a reasonable thing to want. But while it holds, the shell
+answers "dirty?" from a cache **without checking whether anything
+happened** -- so for half a minute after the working tree is cleaned, the
+prompt keeps asserting modifications that are not there. On a big repo, or
+a loaded machine, a one-second `git status` is ordinary.
+
+The failure is therefore invisible on a small fast repo, which is why it
+survived: every existing test uses one. So this file makes the slow scan
+DETERMINISTIC instead of hoping for it -- a `git` shim earlier on PATH
+sleeps before `status` and then execs the real git. No timing luck, no
+big fixture repo, and the same reproduction on any machine.
+
+Checks:
+  1. a dirty tree shows the star (the test can detect a star at all)
+  2. after the tree is cleaned BY A COMMAND IN THE SHELL, the very next
+     prompt does not claim it is dirty      <- the report
+  3. the same, with the slow-scan TTL engaged
+  4. the reverse: a clean tree made dirty by a command grows a star
+  5. `cd` to another repo never shows the previous repo's answer
+
+Usage: python3 git_star_freshness_test.py /path/to/hellish
+"""
+import os
+import pty
+import re
+import select
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "../build/bin/hellish")
+FAILS = []
+GIT = shutil.which("git") or "/usr/bin/git"
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + (" " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def plain(b):
+    return re.sub(rb"\x1b\[[0-9;?]*[a-zA-Z]", b"", b).decode(errors="replace")
+
+
+def git(repo, *args):
+    subprocess.run([GIT, "-C", repo] + list(args), capture_output=True,
+                   check=False)
+
+
+def make_repo(root, branch="main"):
+    os.makedirs(root, exist_ok=True)
+    subprocess.run([GIT, "init", "-q", "-b", branch, root],
+                   capture_output=True, check=False)
+    git(root, "config", "user.email", "t@t")
+    git(root, "config", "user.name", "t")
+    with open(os.path.join(root, "f.txt"), "w") as f:
+        f.write("one\n")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "init")
+    return root
+
+
+def slow_git_dir(base, seconds="1.3"):
+    """A `git` earlier on PATH that makes `status` take over a second.
+
+    This is the whole reason the bug is reproducible here: the 30-second
+    TTL arm is only taken when a scan is slow, and no fixture repo small
+    enough to live in a test suite is ever slow. Shimming the clock is
+    honest -- the shell cannot tell this from a genuinely large repo.
+    """
+    d = os.path.join(base, "slowbin")
+    os.makedirs(d, exist_ok=True)
+    p = os.path.join(d, "git")
+    with open(p, "w") as f:
+        f.write("#!/bin/sh\ncase \" $* \" in *\" status \"*) sleep %s ;; "
+                "esac\nexec %s \"$@\"\n" % (seconds, GIT))
+    os.chmod(p, 0o755)
+    return d
+
+
+class Shell:
+    def __init__(self, cwd, path_prefix=None):
+        path = "/usr/bin:/bin"
+        if path_prefix:
+            path = path_prefix + ":" + path
+        env = {
+            "HOME": tempfile.mkdtemp(prefix="hellish_star_home_"),
+            "PATH": path, "TERM": "xterm-256color", "LANG": "C.UTF-8",
+            "INPUTRC": "/dev/null", "HELLISH_NO_BANNER": "1",
+            "HELLISH_NO_UPDATE_CHECK": "1", "HELLISH_NO_ANIM": "1",
+            "ASAN_OPTIONS": "detect_leaks=0",
+        }
+        self.pid, self.fd = pty.fork()
+        if self.pid == 0:
+            os.environ.clear()
+            os.environ.update(env)
+            try:
+                os.chdir(cwd)
+                os.execvp(SHELL, [SHELL])
+            except BaseException:
+                pass
+            os._exit(127)
+        self.read(1.6)
+
+    def read(self, quiet=0.4, cap=12.0):
+        out = b""
+        last = time.time()
+        end = last + cap
+        while time.time() < end:
+            r, _, _ = select.select([self.fd], [], [], 0.05)
+            if r:
+                try:
+                    c = os.read(self.fd, 65536)
+                except OSError:
+                    break
+                if not c:
+                    break
+                out += c
+                last = time.time()
+            elif time.time() - last >= quiet:
+                break
+        return plain(out)
+
+    def send(self, s, quiet=0.4, cap=12.0):
+        os.write(self.fd, s.encode())
+        return self.read(quiet, cap)
+
+    def settle(self, want, tries=10):
+        """Render until the star agrees with `want`; return how many it took.
+
+        The dirty scan is ASYNC by design -- the render never waits for
+        git, so on a slow repo the answer legitimately arrives a render or
+        two late (prompt_git3.c documents this trade). The contract is
+        therefore CONVERGENCE, not immediacy: the prompt must tell the
+        truth promptly, and `tries` is a bound comfortably under the 30s
+        TTL that used to make it never converge at all.
+
+        Returns the number of renders needed, or None if it never agreed.
+        """
+        for i in range(tries):
+            got, line = self.star()
+            if got == want:
+                return i + 1
+            self.last_line = line
+        return None
+
+    def star(self):
+        """(star_present, the prompt line) for a fresh, empty prompt."""
+        out = self.send("\n")
+        for line in reversed(out.replace("\r", "").split("\n")):
+            if " on " in line and "─" in line:
+                return ("*" in line, line.strip()[:100])
+        return (None, out[-140:])
+
+    def close(self):
+        try:
+            os.kill(self.pid, signal.SIGKILL)
+            os.waitpid(self.pid, 0)
+        except OSError:
+            pass
+
+
+def dirty(repo):
+    with open(os.path.join(repo, "f.txt"), "a") as f:
+        f.write("change\n")
+
+
+def run_case(label, base, slow):
+    repo = make_repo(os.path.join(base, "repo_" + label))
+    dirty(repo)
+    prefix = slow_git_dir(base) if slow else None
+    sh = Shell(repo, prefix)
+    sh.last_line = ""
+    try:
+        n = sh.settle(True)
+        check("%s: a modified tree shows the star" % label, n is not None,
+              "never appeared; last prompt %r" % sh.last_line)
+        # clean it the way the user did: a command run IN the shell
+        sh.send("%s checkout -- .\n" % GIT, cap=20.0)
+        n = sh.settle(False)
+        check("%s: the star clears once the tree is clean" % label,
+              n is not None,
+              "still starred after 10 prompts: %r" % sh.last_line)
+        # and stays cleared, rather than flickering back from the cache --
+        # this is the half that the 30s TTL broke
+        stuck = [sh.star()[0] for _ in range(4)]
+        check("%s: it stays cleared on later prompts" % label,
+              not any(stuck), "star came back: %r" % stuck)
+        # the reverse direction has to work too, or "never dirty" would pass
+        sh.send("printf 'x\\n' >> f.txt\n", cap=20.0)
+        n = sh.settle(True)
+        check("%s: a tree made dirty grows the star" % label,
+              n is not None,
+              "no star after modifying a tracked file: %r" % sh.last_line)
+    finally:
+        sh.close()
+
+
+def test_cd_between_repos(base):
+    a = make_repo(os.path.join(base, "clean_repo"))
+    b = make_repo(os.path.join(base, "dirty_repo"), branch="develop")
+    dirty(b)
+    sh = Shell(b, slow_git_dir(base))
+    sh.last_line = ""
+    try:
+        check("cd: the dirty repo starts starred",
+              sh.settle(True) is not None,
+              "never starred; last prompt %r" % sh.last_line)
+        sh.send("cd %s\n" % a, cap=20.0)
+        check("cd: a clean repo never inherits the previous repo's star",
+              sh.star()[0] is False,
+              "carried the star over: %r" % sh.last_line)
+    finally:
+        sh.close()
+
+
+def main():
+    base = tempfile.mkdtemp(prefix="hellish_gitstar_")
+    try:
+        # fast first: proves the harness detects a star at all, and that
+        # the small-repo path (which always worked) still does.
+        run_case("fast scan", base, slow=False)
+        # the reported shape: a scan slow enough to take the 30s TTL arm.
+        run_case("slow scan", base, slow=True)
+        test_cd_between_repos(base)
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()


### PR DESCRIPTION
Reported: a prompt reading `on develop*` with `git status` one line above saying *nothing to commit, working tree clean* — and the star staying for every prompt after.

```
╰─❯ git push          (success)
╰─❯ git status        nothing to commit, working tree clean
╰─❯                   <- still `on develop*`
╰─❯                   <- still `on develop*`
```

Not a rendering bug. `git_dirty_cached` throttles the async `git status` with a TTL that has two arms:

```c
c->ttl = 3;
if (c->at - c->spawned >= 1)
    c->ttl = 30;          // a scan that took a second
```

The 30-second arm is right in intent — do not rescan a big repo continuously. What was wrong: while it held, the shell answered *dirty?* from cache **without asking whether anything had happened**, so for half a minute after the tree was cleaned the prompt kept asserting modifications that were not there.

The TTL exists to stop git being **re-run** while nothing happens. It was also, accidentally, stopping the shell from **noticing** that something had. Those are separable: the only moment the working tree can change under this shell is a command running in it, so a command now retires the cached answer whatever the TTL says. Idle Enter still hits the cache, so the throttle keeps its whole purpose.

## Why it survived every existing test

The 30s arm is only taken when a scan is **slow**, and no fixture repo small enough to live in a test suite ever is. So `tests/git_star_freshness_test.py` does not hope for a slow scan — it puts a `git` shim earlier on PATH that sleeps before `status` and then execs the real one. Deterministic on any machine, no big repo required.

The gate asserts **convergence, not immediacy**: the scan is async by design, so on a slow repo the answer legitimately arrives a render or two late. The contract is that the prompt tells the truth promptly, bounded well under the 30s that used to mean never. Both directions are checked, or "never dirty" would pass.

**Verified non-vacuous:** reverting just the generation check fails 2 checks with the exact reported symptom — *still starred after 10 prompts*.

## Verification

```
make test              3790 / 3790
make git-star-test       10 checks, 0 failed  (2 fail with the fix reverted)
make git-prompt-test      0 failed
norminette             clean on every touched file
```

Runs in CI with no wiring — `tests/pty_suite.sh` discovers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
