### PR TITLE
Release 2.8.1 — cross-platform: macOS and WSL green for the first time

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Line endings.
+#
+# GitHub's Windows runners check out with core.autocrlf=true, which rewrites
+# LF to CRLF on the way to the working tree. That is harmless for C, and fatal
+# for anything with a shebang: the WSL rung died on
+#
+#   docker/smoke.sh: line 19: set: -
+#   : invalid option
+#   docker/smoke.sh: line 28: syntax error near unexpected token `$'{\r''
+#
+# because bash read the trailing CR as part of each token. So the files that
+# are EXECUTED are pinned to LF here, where the rule travels with the repo and
+# protects anyone cloning on Windows -- not just CI.
+#
+# Deliberately not `* text=auto eol=lf`. Around a hundred files in this tree
+# are already stored with CRLF (mostly older headers, and a handful of golden
+# fixtures under tests/ whose bytes the suite compares exactly). A blanket rule
+# would renormalize all of them in one unreviewable commit and could quietly
+# change what the golden suite asserts. Every pattern below was checked to be
+# LF in the index today, so none of them changes a single stored byte.
+*.sh        text eol=lf
+*.py        text eol=lf
+*.bash      text eol=lf
+*.zsh       text eol=lf
+Makefile    text eol=lf
+*.mk        text eol=lf
+tests/tester text eol=lf
+
+# Dockerfiles break the same way, one layer down: a CR rides along on every
+# RUN line and lands inside the command the shell in the image runs.
+Dockerfile   text eol=lf
+Dockerfile.* text eol=lf
+
+# Binary, so no end-of-line handling is attempted at all.
+*.png       binary
+*.pdf       binary

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -137,13 +137,31 @@ jobs:
       - name: Portability smoke
         run: bash docker/smoke.sh ./build/bin/hellish
       - uses: ./.github/actions/oracle
+      # `tail -3` on a green run is all anyone wants to read; on a RED one it
+      # is useless -- it shows the "N FAILED" line and nothing about which
+      # case, so an arm64-only divergence arrives with no evidence attached.
+      # Print the failing cases on failure, and keep the log as an artifact.
       - name: Golden suite vs pinned bash 5.3.9
         run: |
           make re CC=${{ matrix.cc }} > build.log 2>&1 || {
             sed 's/\x1b\[[0-9;]*[A-Za-z]//g' build.log | tail -80; exit 1; }
           cd tests
-          ./tester 2>&1 | sed 's/\x1b\[[0-9;]*[A-Za-z]//g' | tee ../suite.log | tail -3
-          grep -q 'ALL [0-9]* TESTS PASSED' ../suite.log
+          ./tester 2>&1 | sed 's/\x1b\[[0-9;]*[A-Za-z]//g' > ../suite.log \
+            || true
+          tail -3 ../suite.log
+          if ! grep -q 'ALL [0-9]* TESTS PASSED' ../suite.log; then
+            echo "::error::golden suite failed on arm64/${{ matrix.cc }}"
+            echo "--- failing cases ---"
+            sed -n '/SUMMARY/,$p' ../suite.log | head -120
+            exit 1
+          fi
+      - name: Upload the suite log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: arm64-${{ matrix.cc }}-suite-log
+          path: suite.log
+          if-no-files-found: ignore
 
   # ── Apple ────────────────────────────────────────────────────────────────
   # There is no Docker route to macOS: the kernel is not distributable in a

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -193,8 +193,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Apple Silicon only. macos-13 (the last Intel image) is being
+          # retired and its queue never drains -- the job sat QUEUED for the
+          # whole run, which is worse than not running it: a queued job
+          # keeps its run open and holds concurrency. If Intel coverage is
+          # wanted back it needs a runner that actually exists.
           - { runner: macos-14, arch: "arm64" }
-          - { runner: macos-13, arch: "x86_64" }
     steps:
       - uses: actions/checkout@v4
         with:
@@ -242,6 +246,14 @@ jobs:
         with:
           distribution: Ubuntu-22.04
           additional-packages: build-essential libreadline-dev git python3 ca-certificates
+        env:
+          # WSL does not inherit the runner's Windows environment. Without
+          # this, $GITHUB_WORKSPACE is unset inside wsl-bash and every step
+          # below died on "GITHUB_WORKSPACE: unbound variable" before doing
+          # anything at all. WSLENV is the documented Windows<->WSL bridge;
+          # the /p suffix also translates D:\a\... into /mnt/d/a/..., which
+          # is the form a Linux `cd` can actually use.
+          WSLENV: GITHUB_WORKSPACE/p
       # The shell is set PER STEP, not as a job-level default. `wsl-bash` does
       # not exist until the action above registers it, and a job-level default
       # applies to the whole job -- which made the first run here die before
@@ -249,6 +261,8 @@ jobs:
       # the failure attached to the step that caused it.
       - name: Show the environment
         shell: wsl-bash {0}
+        env:
+          WSLENV: GITHUB_WORKSPACE/p
         run: |
           uname -a
           cat /etc/os-release | head -2
@@ -256,12 +270,16 @@ jobs:
           echo "WSL_DISTRO_NAME=${WSL_DISTRO_NAME:-unset}"
       - name: Build
         shell: wsl-bash {0}
+        env:
+          WSLENV: GITHUB_WORKSPACE/p
         run: |
           cd "$GITHUB_WORKSPACE"
           make OPT=1 SAFE=1 2>&1 | tail -60
           test -x build/bin/hellish
       - name: Portability smoke
         shell: wsl-bash {0}
+        env:
+          WSLENV: GITHUB_WORKSPACE/p
         run: |
           cd "$GITHUB_WORKSPACE"
           bash docker/smoke.sh ./build/bin/hellish

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -287,7 +287,12 @@ jobs:
         run: |
           set -e
           rm -rf ~/hellish && mkdir -p ~/hellish
-          time tar -C "$GITHUB_WORKSPACE" -cf - . | tar -C ~/hellish -xf -
+          # .git is excluded because it is the largest thing in the tree and
+          # the build never reads it: this rung is SAFE=1, so the Makefile's
+          # one `git submodule update` fallback (the SAFE=0 ft_malloc fetch)
+          # is not on the path, and the version is a compile-time #define.
+          time tar -C "$GITHUB_WORKSPACE" --exclude=./.git -cf - . \
+            | tar -C ~/hellish -xf -
           df -h ~/hellish | tail -1
       - name: Build
         shell: wsl-bash {0}

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -268,21 +268,67 @@ jobs:
           cat /etc/os-release | head -2
           gcc --version | head -1
           echo "WSL_DISTRO_NAME=${WSL_DISTRO_NAME:-unset}"
-      - name: Build
+      # $GITHUB_WORKSPACE lives on D:, which WSL sees through drvfs -- a
+      # 9p/virtio bridge to the Windows filesystem. Every open(), stat() and
+      # write() on it is a round trip out of the VM, and a build here is ~970
+      # compiler invocations doing thousands of them. The first run of this
+      # job was still building when the 60-minute timeout killed it, which is
+      # why the log ends in `Terminate batch job (Y/N)?` with nothing useful
+      # above it: the batch wrapper being Ctrl-C'd by the cancellation.
+      #
+      # So the tree is copied onto the distro's own ext4 first. One bulk read
+      # off drvfs is cheap; ~970 compiles against it are not. The copy is a
+      # `tar | tar` rather than `cp -a` because it is a single pass in each
+      # direction instead of one syscall storm per file.
+      - name: Stage the tree on the WSL filesystem
         shell: wsl-bash {0}
         env:
           WSLENV: GITHUB_WORKSPACE/p
         run: |
-          cd "$GITHUB_WORKSPACE"
-          make OPT=1 SAFE=1 2>&1 | tail -60
+          set -e
+          rm -rf ~/hellish && mkdir -p ~/hellish
+          time tar -C "$GITHUB_WORKSPACE" -cf - . | tar -C ~/hellish -xf -
+          df -h ~/hellish | tail -1
+      - name: Build
+        shell: wsl-bash {0}
+        run: |
+          cd ~/hellish
+          # An explicit timeout, well under the job's 60 minutes, so a stall
+          # ends in a message we can read instead of a cancelled batch job.
+          if ! timeout 2400 make OPT=1 SAFE=1 2>&1 | tail -60; then
+            echo "::error::build did not finish within 40 minutes inside WSL"
+            exit 1
+          fi
           test -x build/bin/hellish
       - name: Portability smoke
         shell: wsl-bash {0}
+        run: |
+          cd ~/hellish
+          bash docker/smoke.sh ./build/bin/hellish
+      # The one thing no Linux container covers: the Windows filesystem seen
+      # from inside the VM. Kept to what is honestly about the SHELL -- can it
+      # enter a drvfs directory, glob it, and read a file back. Deliberately
+      # not the permission checks: `chmod 000` on drvfs without metadata
+      # support is a no-op, so a failure there would be Windows telling the
+      # truth, not hellish getting it wrong.
+      - name: Windows filesystem (drvfs) reachability
+        shell: wsl-bash {0}
         env:
           WSLENV: GITHUB_WORKSPACE/p
         run: |
-          cd "$GITHUB_WORKSPACE"
-          bash docker/smoke.sh ./build/bin/hellish
+          set -e
+          sh="$HOME/hellish/build/bin/hellish"
+          d="$GITHUB_WORKSPACE/.wsl-drvfs-probe"
+          rm -rf "$d" && mkdir -p "$d"
+          : > "$d/a.t"; : > "$d/b.t"; echo hello > "$d/read.me"
+          got=$("$sh" -c "cd '$d' && echo *.t")
+          [ "$got" = "a.t b.t" ] || { echo "glob on drvfs: got '$got'"; exit 1; }
+          got=$("$sh" -c "cat '$d/read.me'")
+          [ "$got" = "hello" ] || { echo "read on drvfs: got '$got'"; exit 1; }
+          got=$("$sh" -c "cd '$d' && pwd")
+          [ "$got" = "$d" ] || { echo "pwd on drvfs: got '$got'"; exit 1; }
+          rm -rf "$d"
+          echo "drvfs: glob, read and pwd all agree"
       - name: Say what failed
         if: failure()
         shell: pwsh

--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,19 @@ SAFE ?= 1
 endif
 ifeq ($(SAFE),0)
 SAFE_TAG := ft
-# Force-pull ft_malloc's leak oracle from libft.a so the weakly-referenced
-# malloc_live_bytes in alloc_stats.c binds (a weak ref alone won't pull an
-# archive member). At SAFE=1 there is no -u, so the weak ref resolves to NULL.
-LDFLAGS += -Wl,-u,malloc_live_bytes
+# ft_malloc's leak oracle exists only on this backend, so say so at COMPILE
+# time. alloc_stats.c used to work it out at LINK time instead, with a weak
+# undefined reference and a -Wl,-u to force the archive member -- an ELF-only
+# trick. Mach-O reads __attribute__((weak)) on a declaration as a weak
+# DEFINITION rather than a weak import, so Apple's linker demanded a body and
+# the macOS arm64 build died on "Undefined symbols: _malloc_live_bytes".
+# A plain strong reference pulls the archive member by itself, which is why
+# the -u is gone with the weak ref rather than kept alongside this.
+#
+# CFLAGS, not CFLAGS_BASE: CFLAGS is expanded with := about forty lines above
+# this block, so appending to the base here would land after the expansion and
+# do nothing at all.
+CFLAGS += -DHAVE_ALLOC_ORACLE
 else
 SAFE_TAG := libc
 endif

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,49 @@ shows you how to drive the shell.
 
 ---
 
+## v2.8.1
+
+A portability release. No behaviour changes on Linux — every fix here is
+about hellish building and running correctly somewhere it previously did
+not, and about CI being able to tell you when it does not.
+
+**Fixed**
+
+- **macOS (Apple Silicon) builds again.** Four separate defects, each
+  hidden behind the last: `st_mtim` is `st_mtimespec` on Darwin, `SIGPWR`
+  and the realtime signals do not exist there, `bcopy` is a fortified
+  macro, and `MB_CUR_MAX` is an `int` rather than a `size_t` — which made a
+  correct-on-Linux comparison a `-Werror=sign-compare` failure.
+
+- **A library function that was declared, called, and never defined.**
+  `get_original_tty_job_signals()` had been missing a body for months.
+  GNU ld lets a shared library keep undefined symbols and hope; Apple's
+  does not, which is the only reason anyone found out. It is a real bug
+  everywhere: a crash waiting for the first caller.
+
+- **The allocator-backend probe no longer relies on ELF semantics.** An
+  undefined *weak* symbol resolves to NULL on Linux and is a link error on
+  macOS. Which heap is being built is now a compile-time fact, which is
+  what it always was.
+
+- **Windows checkouts no longer break the scripts.** `.gitattributes`
+  pins everything with a shebang to LF, so `core.autocrlf` cannot turn
+  `set -u` into `set -u\r`.
+
+**Testing**
+
+- Two new gates reproduce the macOS and Windows failures **on Linux**, in
+  about a second each: `link_closure_test.py` asks GNU ld the question
+  Apple's linker asks by default, and `crlf_hygiene_test.py` checks both
+  that no executed file is stored with CRLF and that every one of them is
+  covered by a rule — the second being the half that catches the next file
+  someone adds.
+
+- The WSL rung builds on the distro's own filesystem rather than through
+  the Windows bridge, where the same build could not finish inside an hour.
+
+---
+
 ## v2.8.0
 
 **Added**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,18 +33,30 @@ not, and about CI being able to tell you when it does not.
   macOS. Which heap is being built is now a compile-time fact, which is
   what it always was.
 
+- **Process substitution works off Linux.** `<(cmd)` and `>(cmd)` re-exec
+  the shell, and did it through the literal `/proc/self/exe` — a path that
+  exists on Linux and nowhere else, so on macOS both produced nothing at
+  all. Now resolved at runtime (`_NSGetExecutablePath` on Darwin). The
+  same assumption was in three more places: the ENOEXEC script-interpreter
+  fallback, and the update machinery's idea of where it lives — which had
+  been classifying every non-Linux install as a downloaded binary, so
+  `update` would have offered to overwrite a source checkout.
+
 - **Windows checkouts no longer break the scripts.** `.gitattributes`
   pins everything with a shebang to LF, so `core.autocrlf` cannot turn
   `set -u` into `set -u\r`.
 
 **Testing**
 
-- Two new gates reproduce the macOS and Windows failures **on Linux**, in
-  about a second each: `link_closure_test.py` asks GNU ld the question
-  Apple's linker asks by default, and `crlf_hygiene_test.py` checks both
-  that no executed file is stored with CRLF and that every one of them is
+- Three new gates reproduce the macOS and Windows failures **on Linux**, in
+  about a second each. `link_closure_test.py` asks GNU ld the question
+  Apple's linker asks by default. `crlf_hygiene_test.py` checks both that
+  no executed file is stored with CRLF and that every one of them is
   covered by a rule — the second being the half that catches the next file
-  someone adds.
+  someone adds. `linux_only_apis_test.py` asserts that `/proc/self/exe`
+  is named in exactly one file, which is the property that actually broke:
+  the knowledge had been copied into four, so porting meant finding all
+  four.
 
 - The WSL rung builds on the distro's own filesystem rather than through
   the Windows bridge, where the same build could not finish inside an hour.

--- a/incs/sys.h
+++ b/incs/sys.h
@@ -40,9 +40,6 @@ getcwd() failed: No such file or directory\n"
 # define MINISHELL "./minishell"
 # define EQ '='
 # define FB_SH "/bin/sh"
-//# define PATH_HELLISH "/usr/bin/hellish"
-# define PATH_HELLISH "/proc/self/exe"
-# define PROC_SELF_EXE "/proc/self/exe"
 # define BLACK_HOLE "/dev/null"
 # define CMD_OPT "-c"
 # define EXIT_CMD_NOT_EXEC 126
@@ -110,5 +107,9 @@ getcwd() failed: No such file or directory\n"
 # ifndef TRACE_DEBUG
 #  define TRACE_DEBUG 0
 # endif
+
+/* Path of the running binary, resolved once. NULL when the kernel will not
+   say. Read-only, and never freed by the caller. */
+char	*self_exe_path(void);
 
 #endif

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.8.0"
+# define HELLISH_VERSION "2.8.1"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/builtins/builtin_test_posix.c
+++ b/src/builtins/builtin_test_posix.c
@@ -76,16 +76,28 @@ int	eval_four(char **av)
 	return (-1);
 }
 
+/* The nanosecond mtime field is spelled differently per platform: POSIX
+   2008 and glibc/musl call it st_mtim, Darwin calls it st_mtimespec. Same
+   struct timespec either way, so the FIELD NAME is the macro and the
+   comparison below reads identically on both. (The BSDs also use
+   st_mtimespec; add them here if a BSD rung is ever added to CI -- they
+   are not in the matrix today, so this stays a claim I have tested.) */
+#ifdef __APPLE__
+# define ST_MTIM st_mtimespec
+#else
+# define ST_MTIM st_mtim
+#endif
+
 /* Three-way mtime comparison at nanosecond resolution (bash and dash both
-   compare st_mtim, not just st_mtime — two files touched within the same
-   second must not read as "newer"). Returns <0, 0, >0 like strcmp. */
+   compare the timespec, not just st_mtime — two files touched within the
+   same second must not read as "newer"). Returns <0, 0, >0 like strcmp. */
 static int	mtime_cmp(struct stat *a, struct stat *b)
 {
-	if (a->st_mtim.tv_sec != b->st_mtim.tv_sec)
-		return ((a->st_mtim.tv_sec > b->st_mtim.tv_sec) * 2 - 1);
-	if (a->st_mtim.tv_nsec == b->st_mtim.tv_nsec)
+	if (a->ST_MTIM.tv_sec != b->ST_MTIM.tv_sec)
+		return ((a->ST_MTIM.tv_sec > b->ST_MTIM.tv_sec) * 2 - 1);
+	if (a->ST_MTIM.tv_nsec == b->ST_MTIM.tv_nsec)
 		return (0);
-	return ((a->st_mtim.tv_nsec > b->st_mtim.tv_nsec) * 2 - 1);
+	return ((a->ST_MTIM.tv_nsec > b->ST_MTIM.tv_nsec) * 2 - 1);
 }
 
 /* -nt / -ot / -ef, matching bash's filecomp(): -ef is true only when both

--- a/src/builtins/builtin_trap.c
+++ b/src/builtins/builtin_trap.c
@@ -14,6 +14,19 @@
 #include "executor.h"
 #include <signal.h>
 
+/* SIGSTKFLT and SIGPWR are Linux-only; Darwin and the BSDs have neither.
+   The table is a fixed 1..31 layout, so the entries stay put and carry -1
+   where the platform has no such signal -- sig_from_name already rejects
+   -1, so `trap - PWR` on a Mac reports an unknown signal instead of the
+   whole file failing to compile. Keeping the rows means the numbering and
+   `trap -l` output do not silently shift per platform. */
+#ifndef SIGSTKFLT
+# define SIGSTKFLT -1
+#endif
+#ifndef SIGPWR
+# define SIGPWR -1
+#endif
+
 /* The signal name table is stored in a static local so it is initialised
    exactly once and shared between every call (no heap allocation needed).
    The sentinel `{NULL, -1}` lets callers iterate without knowing the count.

--- a/src/execution/run_utils.c
+++ b/src/execution/run_utils.c
@@ -14,21 +14,35 @@
 #include "sys.h"
 #include "libft.h"
 
+/* Our own script extensions, run under this shell rather than /bin/sh. */
+static int	is_hellish_script(char *path, size_t len)
+{
+	if (len >= 8 && ft_strcmp(path + len - 8, ".hellish") == 0)
+		return (1);
+	if (len >= 5 && ft_strcmp(path + len - 5, ".hell") == 0)
+		return (1);
+	if (len >= 3 && ft_strcmp(path + len - 3, ".sh") == 0)
+		return (1);
+	return (0);
+}
+
 /* Pick an interpreter for a file that failed execve with ENOEXEC.  We
-   recognise our own script extensions (.sh, .hell, .hellish) and run them
-   under the hellish binary; everything else falls back to /bin/sh (FB_SH).
-   This mirrors what bash does for the "#!" shebang-less case. */
+   recognise our own script extensions and run them under the running
+   binary; everything else falls back to /bin/sh (FB_SH).  This mirrors
+   what bash does for the "#!" shebang-less case.
+
+   self_exe_path() rather than a literal "/proc/self/exe": that path is
+   Linux-only, so on any other kernel this handed execve something that
+   does not exist and the script simply failed.  When the kernel will not
+   say where we are, /bin/sh is a better answer than a made-up path -- it
+   is a POSIX shell, and these are POSIX scripts. */
 static char	*select_fallback_shell(char *path)
 {
-	size_t	len;
+	char	*self;
 
-	len = ft_strlen(path);
-	if (len >= 8 && ft_strcmp(path + len - 8, ".hellish") == 0)
-		return (PATH_HELLISH);
-	if (len >= 5 && ft_strcmp(path + len - 5, ".hell") == 0)
-		return (PATH_HELLISH);
-	if (len >= 3 && ft_strcmp(path + len - 3, ".sh") == 0)
-		return (PATH_HELLISH);
+	self = self_exe_path();
+	if (self && is_hellish_script(path, ft_strlen(path)))
+		return (self);
 	return (FB_SH);
 }
 

--- a/src/expander/expander_private.h
+++ b/src/expander/expander_private.h
@@ -157,6 +157,7 @@ t_string	word_to_hrdoc_string(t_ast_node node);
 t_env		assignment_to_env(t_shell *state, t_ast_node *node);
 t_env		assignment_to_env(t_shell *state, t_ast_node *node);
 void		assignment_word_to_word(t_ast_node *node);
+void		procsub_exec_self(t_shell *state, const char *cmd);
 char		*create_procsub_input(t_shell *state, const char *cmd);
 char		*create_procsub_output(t_shell *state, const char *cmd);
 char		*expand_proc_sub(t_shell *state, t_ast_node *node);

--- a/src/helpers/alloc_stats.c
+++ b/src/helpers/alloc_stats.c
@@ -6,7 +6,7 @@
 /*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/06/06 00:00:00 by dlesieur          #+#    #+#             */
-/*   Updated: 2026/06/06 00:00:00 by dlesieur         ###   ########.fr       */
+/*   Updated: 2026/08/22 00:00:00 by dlesieur         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,21 +14,43 @@
 #include "libft.h"
 #include <stdlib.h>
 
-/* ft_malloc's leak oracle, imported weakly so this TU is backend-agnostic and
-   needs no -D: at SAFE=0 it binds to the real symbol in libft; at SAFE=1 (libc)
-   the symbol is absent and resolves to NULL, so the report is skipped. */
-size_t	malloc_live_bytes(void) __attribute__((weak));
-
-/* SAFE=0 leak oracle. ASan/valgrind are blind to ft_malloc, so with
+/* SAFE=0 leak oracle. ASan and valgrind are blind to ft_malloc, so with
    HELLISH_ALLOC_STATS set the main process prints the bytes still live on the
-   ft_malloc heap after free_all_state(). No-op on the libc backend. */
+   ft_malloc heap after free_all_state(). No-op on the libc backend.
+
+   HAVE_ALLOC_ORACLE comes from the Makefile, which already knows which heap it
+   is building. This used to be decided at LINK time instead -- a weak
+   undefined reference plus a -Wl,-u to drag the archive member in -- so the
+   file needed no -D. That is an ELF-only trick. Mach-O reads
+   __attribute__((weak)) on a DECLARATION as a weak definition rather than a
+   weak import, so Apple's linker wanted a body for it and the macOS arm64
+   build stopped at:
+
+     Undefined symbols for architecture arm64:
+       "_malloc_live_bytes", referenced from: _free_all_state in lto.o
+
+   The reference below is strong, which is also what retired the -Wl,-u: a
+   strong reference pulls an archive member on its own; only a weak one
+   does not. */
+#ifdef HAVE_ALLOC_ORACLE
+
+size_t	malloc_live_bytes(void);
+
 void	alloc_live_report(void)
 {
 	char	*n;
 
-	if (!malloc_live_bytes || !getenv("HELLISH_ALLOC_STATS"))
+	if (!getenv("HELLISH_ALLOC_STATS"))
 		return ;
 	n = ft_itoa((int)malloc_live_bytes());
 	ft_eprintf("[ft_malloc] live bytes after cleanup: %s\n", n);
 	xfree(n);
 }
+
+#else
+
+void	alloc_live_report(void)
+{
+}
+
+#endif

--- a/src/infrastructure/mascot_anim.c
+++ b/src/infrastructure/mascot_anim.c
@@ -38,7 +38,13 @@ int	*anim_status(void)
    or a line already wide enough to wrap means the cursor row is not
    ours to predict -- report unsafe and let the caller skip the tick.
    Getting this wrong is not cosmetic: an undershoot lands the repaint
-   ON the input row and ESC[2K eats the user's paste. */
+   ON the input row and ESC[2K eats the user's paste.
+
+   mbrtowc's error returns are spelled out as (size_t)-1 / (size_t)-2
+   rather than tested with `n > MB_CUR_MAX`. The short form is the same
+   test on glibc, where MB_CUR_MAX is size_t -- and a -Werror=sign-compare
+   build failure on Darwin, where it is an int. That is the whole of the
+   macOS bug; the long form is also what the rest of the tree uses. */
 static int	anim_line_fits(void)
 {
 	mbstate_t	st;
@@ -55,7 +61,7 @@ static int	anim_line_fits(void)
 		if ((unsigned char)rl_line_buffer[i] < ' ')
 			return (0);
 		n = mbrtowc(&wc, rl_line_buffer + i, MB_CUR_MAX, &st);
-		if (n == 0 || n > MB_CUR_MAX)
+		if (n == (size_t) - 1 || n == (size_t) - 2 || n == 0)
 			return (0);
 		if (wcwidth(wc) < 0)
 			return (0);

--- a/src/platform/posix/create_procsub_output.c
+++ b/src/platform/posix/create_procsub_output.c
@@ -13,16 +13,14 @@
 #include "expander_private.h"
 #include "sys.h"
 
+/* Fork a child for a >(cmd) process substitution.  The child reads from
+   pipefd[0] and re-execs the shell; see procsub_exec_self for why that is
+   not "/proc/self/exe" any more. */
 static pid_t	fork_and_exec_procsub(t_shell *state,
 								int pipefd[2],
 								const char *cmd)
 {
-	pid_t		pid;
-	char *const	argv_ms[]
-		= {(char *)PROC_SELF_EXE, (char *)CMD_OPT, (char *)cmd, NULL};
-	char *const	argv_sh[]
-		= {(char *)PATH_HELLISH, (char *)CMD_OPT, (char *)cmd, NULL};
-	char		**envp;
+	pid_t	pid;
 
 	pid = fork();
 	if (pid == -1)
@@ -32,13 +30,7 @@ static pid_t	fork_and_exec_procsub(t_shell *state,
 		close(pipefd[1]);
 		dup2(pipefd[0], STDIN_FILENO);
 		close(pipefd[0]);
-		envp = get_envp_all(state, PATH_HELLISH);
-		execve(PATH_HELLISH, argv_sh, envp);
-		envp = get_envp_all(state, PROC_SELF_EXE);
-		execve(PROC_SELF_EXE, argv_ms, envp);
-		if (envp)
-			free_tab(envp);
-		exit(127);
+		procsub_exec_self(state, cmd);
 	}
 	return (pid);
 }

--- a/src/platform/posix/procsub_input.c
+++ b/src/platform/posix/procsub_input.c
@@ -13,20 +13,46 @@
 #include "expander_private.h"
 #include "sys.h"
 
+/* Re-exec THIS shell to run `cmd`, in an already-forked child.  Never
+   returns: it execs, or exits 127 the way any failed exec would.
+
+   Both halves of process substitution used to exec the literal
+   "/proc/self/exe" -- twice, under two names that expanded to the same
+   string, so the second attempt was dead code -- and that path exists on
+   Linux and nowhere else.  On macOS every <(cmd) and >(cmd) exec'd
+   something that was not there and produced nothing.  self_exe_path()
+   asks the kernel, and has an answer on Darwin too.
+
+   A NULL from it means the kernel will not say where we are.  There is
+   nothing sensible to exec at that point, and inventing a path would run
+   the WRONG shell rather than fail, so the child just exits. */
+void	procsub_exec_self(t_shell *state, const char *cmd)
+{
+	char	*self;
+	char	*argv[4];
+	char	**envp;
+
+	self = self_exe_path();
+	if (self)
+	{
+		argv[0] = self;
+		argv[1] = (char *)CMD_OPT;
+		argv[2] = (char *)cmd;
+		argv[3] = NULL;
+		envp = get_envp_all(state, self);
+		execve(self, argv, envp);
+		if (envp)
+			free_tab(envp);
+	}
+	exit(127);
+}
+
 /* Fork a child for a <(cmd) process substitution.  The child connects its
-   stdout to pipefd[1] and exec's the preferred shell binary.  Two exec
-   attempts are made: PATH_HELLISH first (the installed shell), then
-   PROC_SELF_EXE (the currently running binary via /proc/self/exe) as a
-   fallback when running from the build tree.  exit(127) if both fail. */
+   stdout to pipefd[1] and re-execs the shell. */
 static pid_t	fork_and_exec_procsub_input(t_shell *state, int pipefd[2],
 						const char *cmd)
 {
-	pid_t		pid;
-	char *const	argv_ms[] = {(char *)PROC_SELF_EXE, (char *)CMD_OPT,
-		(char *)cmd, NULL};
-	char *const	argv_sh[] = {(char *)PATH_HELLISH, (char *)CMD_OPT,
-		(char *)cmd, NULL};
-	char		**envp;
+	pid_t	pid;
 
 	pid = fork();
 	if (pid == -1)
@@ -36,13 +62,7 @@ static pid_t	fork_and_exec_procsub_input(t_shell *state, int pipefd[2],
 		close(pipefd[0]);
 		dup2(pipefd[1], STDOUT_FILENO);
 		close(pipefd[1]);
-		envp = get_envp_all(state, PATH_HELLISH);
-		execve(PATH_HELLISH, argv_sh, envp);
-		envp = get_envp_all(state, PROC_SELF_EXE);
-		execve(PROC_SELF_EXE, argv_ms, envp);
-		if (envp)
-			free_tab(envp);
-		exit(127);
+		procsub_exec_self(state, cmd);
 	}
 	return (pid);
 }

--- a/src/platform/posix/self_exe.c
+++ b/src/platform/posix/self_exe.c
@@ -15,8 +15,25 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <stdlib.h>
+/* _NSGetExecutablePath is declared here rather than by including
+   <mach-o/dyld.h>, and that is not laziness.
+
+   That header contains `enum DYLD_BOOL { FALSE, TRUE };`, and libft's
+   ft_stddef.h already has `typedef enum e_bool { FALSE, TRUE } t_bool;`.
+   Two enums cannot define the same enumerator names in one translation
+   unit, so including both is a hard error whichever order they come in:
+
+     dyld.h:153:20: error: redefinition of enumerator 'FALSE'
+     ft_stddef.h:203:2: note: previous definition is here
+
+   Neither header is ours to change and the collision is symmetric, so the
+   only fix that does not spread is to not include the header. One stable,
+   documented ABI symbol is a cheaper thing to declare than an enum
+   namespace is to negotiate. */
 #ifdef __APPLE__
-# include <mach-o/dyld.h>
+
+int	_NSGetExecutablePath(char *buf, uint32_t *bufsize);
+
 #endif
 
 /* Deliberately here and not in a shared header: this file is the one place

--- a/src/platform/posix/self_exe.c
+++ b/src/platform/posix/self_exe.c
@@ -1,0 +1,90 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   self_exe.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/22 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/22 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "sys.h"
+#include <unistd.h>
+#include <stdint.h>
+#ifdef __APPLE__
+# include <mach-o/dyld.h>
+#endif
+
+/* Deliberately here and not in a shared header: this file is the one place
+   that is allowed to know the name, so that porting to a kernel without
+   procfs is one edit rather than a search. tests/linux_only_apis_test.py
+   enforces that. */
+#define PROC_SELF_EXE "/proc/self/exe"
+
+/* Where the running binary lives, asked of the kernel.
+
+   This used to be the literal string "/proc/self/exe", handed straight to
+   execve. That works on Linux and on nothing else: procfs is not in POSIX,
+   and Darwin has no /proc at all -- so every <(cmd) and >(cmd) on macOS
+   exec'd a path that does not exist, and exited 127 with an empty result.
+
+   Darwin's answer is _NSGetExecutablePath, which writes into a caller
+   buffer and takes the size BY POINTER: on success it is left alone, and
+   on overflow it is rewritten with the size actually needed. Passing the
+   size by value would compile and corrupt the stack, so it is a uint32_t
+   local rather than a cast in the call. */
+#ifdef __APPLE__
+
+static int	self_exe_fill(char *buf, size_t n)
+{
+	uint32_t	sz;
+
+	sz = (uint32_t)n;
+	if (_NSGetExecutablePath(buf, &sz) != 0)
+		return (0);
+	buf[n - 1] = '\0';
+	return (1);
+}
+
+#else
+
+static int	self_exe_fill(char *buf, size_t n)
+{
+	ssize_t	r;
+
+	r = readlink(PROC_SELF_EXE, buf, n - 1);
+	if (r <= 0)
+		return (0);
+	buf[r] = '\0';
+	return (1);
+}
+
+#endif
+
+/* The path, resolved once and cached, or NULL if the kernel will not say.
+
+   Cached because it cannot change: a process keeps the image it was
+   exec'd from for its whole life. Callers must treat the result as
+   read-only and must not free it.
+
+   NULL is a real answer, not an oversight -- a kernel with no procfs and
+   no Darwin lookup has nothing to tell us, and a caller that execs this
+   is better off failing on a NULL check than on a path it invented. */
+char	*self_exe_path(void)
+{
+	static char	buf[4096];
+	static int	state;
+
+	if (state == 0)
+	{
+		if (self_exe_fill(buf, sizeof(buf)))
+			state = 1;
+		else
+			state = -1;
+	}
+	if (state == 1)
+		return (buf);
+	return (NULL);
+}

--- a/src/platform/posix/self_exe.c
+++ b/src/platform/posix/self_exe.c
@@ -11,8 +11,10 @@
 /* ************************************************************************** */
 
 #include "sys.h"
+#include "libft.h"
 #include <unistd.h>
 #include <stdint.h>
+#include <stdlib.h>
 #ifdef __APPLE__
 # include <mach-o/dyld.h>
 #endif
@@ -22,6 +24,11 @@
    procfs is one edit rather than a search. tests/linux_only_apis_test.py
    enforces that. */
 #define PROC_SELF_EXE "/proc/self/exe"
+
+/* Comfortably over PATH_MAX on every target here (Darwin says 1024,
+   Linux 4096), so the "buffer too small" arm of either lookup is
+   unreachable rather than merely unlikely. */
+#define SELF_EXE_MAX 4096
 
 /* Where the running binary lives, asked of the kernel.
 
@@ -34,17 +41,28 @@
    buffer and takes the size BY POINTER: on success it is left alone, and
    on overflow it is rewritten with the size actually needed. Passing the
    size by value would compile and corrupt the stack, so it is a uint32_t
-   local rather than a cast in the call. */
+   local rather than a cast in the call.
+
+   It also does NOT promise an absolute, resolved path -- it hands back
+   the path the process was exec'd through, which may be relative and may
+   be a symlink. Caching a relative one would be a bug with a long fuse:
+   correct until the shell cd's somewhere else, and then exec'ing a
+   sibling of the wrong directory. Apple's own documentation says to run
+   realpath() on it, so that is what happens here. /proc/self/exe needs
+   none of this -- the kernel already resolves it. */
 #ifdef __APPLE__
 
 static int	self_exe_fill(char *buf, size_t n)
 {
 	uint32_t	sz;
+	char		raw[SELF_EXE_MAX];
 
-	sz = (uint32_t)n;
-	if (_NSGetExecutablePath(buf, &sz) != 0)
+	sz = (uint32_t)SELF_EXE_MAX;
+	if (_NSGetExecutablePath(raw, &sz) != 0)
 		return (0);
-	buf[n - 1] = '\0';
+	raw[SELF_EXE_MAX - 1] = '\0';
+	if (!realpath(raw, buf))
+		ft_strlcpy(buf, raw, n);
 	return (1);
 }
 
@@ -74,7 +92,7 @@ static int	self_exe_fill(char *buf, size_t n)
    is better off failing on a NULL check than on a path it invented. */
 char	*self_exe_path(void)
 {
-	static char	buf[4096];
+	static char	buf[SELF_EXE_MAX];
 	static int	state;
 
 	if (state == 0)

--- a/src/platform/posix/update_endpoint.c
+++ b/src/platform/posix/update_endpoint.c
@@ -12,6 +12,7 @@
 
 #include "update.h"
 #include "version.h"
+#include "sys.h"
 #include <sys/utsname.h>
 #include <unistd.h>
 #include <libgen.h>
@@ -77,12 +78,12 @@ int	update_asset_url(const char *tag, const char *asset, char *out, size_t n)
    what to replace. */
 int	update_exe_path(char *buf, size_t n)
 {
-	ssize_t	r;
+	char	*self;
 
-	r = readlink("/proc/self/exe", buf, n - 1);
-	if (r <= 0)
+	self = self_exe_path();
+	if (!self)
 		return (0);
-	buf[r] = '\0';
+	ft_strlcpy(buf, self, n);
 	return (1);
 }
 

--- a/src/platform/posix/update_origin.c
+++ b/src/platform/posix/update_origin.c
@@ -11,19 +11,25 @@
 /* ************************************************************************** */
 
 #include "update.h"
+#include "sys.h"
 #include "version.h"
 #include <sys/wait.h>
 #include <unistd.h>
 
-/* Resolve the path of the running executable. 1 on success. */
+/* Resolve the path of the running executable. 1 on success.
+
+   Via self_exe_path() rather than readlink("/proc/self/exe") directly:
+   that file is Linux-only, so off Linux this always failed and every
+   install was classified ORIGIN_BINARY -- meaning `update` would offer
+   to replace a source checkout as if it were a downloaded binary. */
 static int	exe_path(char *buf, size_t n)
 {
-	ssize_t	r;
+	char	*self;
 
-	r = readlink("/proc/self/exe", buf, n - 1);
-	if (r <= 0)
+	self = self_exe_path();
+	if (!self)
 		return (0);
-	buf[r] = '\0';
+	ft_strlcpy(buf, self, n);
 	return (1);
 }
 

--- a/tests/crlf_hygiene_test.py
+++ b/tests/crlf_hygiene_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Anything with a shebang must be stored with LF, or Windows breaks it.
+
+The report, from the WSL rung:
+
+    docker/smoke.sh: line 19: set: -
+    : invalid option
+    docker/smoke.sh: line 20: $'\\r': command not found
+    docker/smoke.sh: line 28: syntax error near unexpected token `$'{\\r''
+
+Nothing was wrong with smoke.sh. GitHub's Windows runners check out with
+`core.autocrlf=true`, which rewrites LF to CRLF on the way to the working
+tree, and bash then reads the trailing CR as part of every token: `set -u`
+becomes `set -u\\r`, `expect() {` becomes `expect() {\\r`. Harmless for C,
+which the compiler tokenizes on whitespace; fatal for anything executed.
+
+The fix is `.gitattributes` pinning the executed file types to `eol=lf`, so
+the rule travels with the repo and protects anyone cloning on Windows --
+not just CI. This file is the gate on that rule, and it asserts the two
+halves separately because they fail for different reasons:
+
+  1. no tracked script is stored with CRLF in the INDEX. A file that is
+     already CRLF in git will be CRLF everywhere, `.gitattributes` or not.
+  2. every one of them is COVERED by an `eol=lf` attribute. This is the
+     half that matters: today's files are all LF, so check 1 passes on a
+     repo with no .gitattributes at all -- it would have passed on the
+     commit that broke WSL. Coverage is what stops the next file added.
+
+Deliberately not asserted: that the whole tree is LF. Around a hundred
+files here are stored with CRLF already (older headers, and fixtures under
+tests/ whose bytes the golden suite compares exactly). Renormalizing those
+is a separate decision with real risk, and pretending otherwise would make
+this test something nobody can keep green.
+
+Usage: python3 crlf_hygiene_test.py [ignored]
+"""
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FAILS = []
+
+# Extensions and names whose content is EXECUTED by an interpreter that
+# tokenizes lines. A stray CR is a syntax error in every one of them.
+SUFFIXES = (".sh", ".py", ".bash", ".zsh", ".mk")
+NAMES = ("Makefile", "tester", "configure")
+# Dockerfiles break one layer down: the CR rides along on every RUN line and
+# lands inside the command the shell in the image runs.
+PREFIXES = ("Dockerfile",)
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + (" " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def git(*args):
+    p = subprocess.run(["git", "-C", ROOT] + list(args), capture_output=True)
+    return p.stdout.decode(errors="replace")
+
+
+def executed_files():
+    """Tracked files an interpreter reads line by line.
+
+    Selected by name rather than by reading each file, so a file that is
+    MISSING its shebang today is still covered -- the point is the class,
+    not the current contents.
+    """
+    out = []
+    for f in git("ls-files", "-z").split("\0"):
+        if not f:
+            continue
+        base = os.path.basename(f)
+        if f.endswith(".dockerignore"):
+            continue
+        if (f.endswith(SUFFIXES) or base in NAMES
+                or base.startswith(PREFIXES)):
+            out.append(f)
+    return sorted(out)
+
+
+def stored_with_crlf(paths):
+    """Which of `paths` contain a CR in the INDEX, not the working tree.
+
+    The index is the thing that travels. A working tree can be CRLF on
+    Windows and correct in git, which is exactly what .gitattributes
+    arranges, so reading files off disk would ask the wrong question.
+    """
+    bad = []
+    for f in paths:
+        p = subprocess.run(["git", "-C", ROOT, "show", ":" + f],
+                           capture_output=True)
+        if p.returncode == 0 and b"\r\n" in p.stdout:
+            bad.append(f)
+    return bad
+
+
+def uncovered(paths):
+    """Which of `paths` no `eol=lf` attribute applies to."""
+    if not paths:
+        return []
+    out = git("check-attr", "eol", "--", *paths).split("\n")
+    bad = []
+    for line in out:
+        if not line.strip():
+            continue
+        # "<path>: eol: <value>" -- the path may itself contain ": "
+        head, _, value = line.rpartition(": ")
+        if value.strip() != "lf":
+            bad.append(head.rsplit(":", 1)[0])
+    return bad
+
+
+def main():
+    files = executed_files()
+    check("there are executed files to check", len(files) > 10,
+          "found only %d" % len(files))
+    bad = stored_with_crlf(files)
+    check("no executed file is stored with CRLF", not bad,
+          "\n        " + "\n        ".join(bad[:10]))
+    miss = uncovered(files)
+    check("every executed file is covered by an eol=lf attribute",
+          not miss,
+          "\n        not covered by .gitattributes:\n        "
+          + "\n        ".join(miss[:10])
+          + ("\n        (+%d more)" % (len(miss) - 10) if len(miss) > 10
+             else ""))
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/issue13_bg_pid
+++ b/tests/issue13_bg_pid
@@ -1,14 +1,14 @@
-sleep 3 & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
-sleep 3 >/dev/null & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
-sleep 3 </dev/null & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
-sleep 3 2>/dev/null & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
-sleep 3 >/dev/null 2>&1 & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
-A=1 sleep 3 & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
-env sleep 3 & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
-sleep 3 & p=$!; sleep 0.4; kill -STOP $p; sleep 0.3; ps -o stat= -p $p | cut -c1; kill -CONT $p 2>/dev/null; kill -9 $p 2>/dev/null; wait 2>/dev/null
-sleep 3 & p=$!; sleep 0.4; kill -9 $p; wait $p; echo "k9=$?"
-sleep 3 & p=$!; sleep 0.4; kill -TERM $p; wait $p; echo "term=$?"
-sleep 3 & p=$!; sleep 0.4; kill -INT $p; wait $p; echo "int=$?"
+sleep 30 & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
+sleep 30 >/dev/null & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
+sleep 30 </dev/null & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
+sleep 30 2>/dev/null & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
+sleep 30 >/dev/null 2>&1 & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
+A=1 sleep 30 & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
+env sleep 30 & p=$!; sleep 0.4; ps -o comm= -p $p | tr -d ' '; kill $p 2>/dev/null; wait 2>/dev/null
+sleep 30 & p=$!; sleep 0.4; kill -STOP $p; sleep 0.3; ps -o stat= -p $p | cut -c1; kill -CONT $p 2>/dev/null; kill -9 $p 2>/dev/null; wait 2>/dev/null
+sleep 30 & p=$!; sleep 0.4; kill -9 $p; wait $p; echo "k9=$?"
+sleep 30 & p=$!; sleep 0.4; kill -TERM $p; wait $p; echo "term=$?"
+sleep 30 & p=$!; sleep 0.4; kill -INT $p; wait $p; echo "int=$?"
 rm -f leak13a; sh -c 'sleep 0.9; echo leaked > leak13a' & p=$!; sleep 0.4; kill -9 $p 2>/dev/null; sleep 1.2; cat leak13a 2>/dev/null; echo end
 rm -f leak13b; sh -c 'sleep 0.9; echo leaked > leak13b' & p=$!; sleep 0.4; kill -TERM $p 2>/dev/null; sleep 1.2; cat leak13b 2>/dev/null; echo end
 sh -c 'exit 7' & wait $!; echo "st=$?"
@@ -33,4 +33,4 @@ printf 'x\n' & wait $!; echo "printfbg=$?"
 nosuchcmd12345 & wait $!; echo "missing=$?"
 /nonexistent/path & wait $!; echo "nopath=$?"
 sleep 0.1 & p1=$!; sleep 0.1 & p2=$!; wait $p1; r1=$?; wait $p2; echo "$r1 $?"
-sleep 3 & p=$!; sleep 0.4; kill -0 $p; echo "alive=$?"; kill -9 $p 2>/dev/null; wait 2>/dev/null
+sleep 30 & p=$!; sleep 0.4; kill -0 $p; echo "alive=$?"; kill -9 $p 2>/dev/null; wait 2>/dev/null

--- a/tests/link_closure_test.py
+++ b/tests/link_closure_test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Every symbol we call must be DEFINED somewhere -- proved on Linux.
+
+The report, from the macOS arm64 rung:
+
+    Undefined symbols for architecture arm64:
+      "_get_original_tty_job_signals", referenced from:
+          _initialize_traps in initialize_traps.o
+    ld: symbol(s) not found for architecture arm64
+
+`get_original_tty_job_signals` was declared in trap.h and called by
+`initialize_traps()`, and never defined -- by anyone, on any platform. It
+had been that way for months and every Linux job stayed green, because
+the two are not the same question:
+
+  * an EXECUTABLE must resolve everything, so a symbol on a path the
+    linker pulls in is caught. Archives only contribute the members that
+    are actually needed, and nothing needed initialize_traps.o.
+  * a SHARED LIBRARY on GNU ld may keep undefined symbols and hope the
+    loader finds them later. libft.so linked happily with a hole in it.
+  * on Darwin, a dylib may NOT. ld resolves everything or fails.
+
+So the difference is not "macOS is stricter about C". It is that GNU ld
+defaults to `--allow-shlib-undefined` and Apple's does not, and we had
+been shipping a library whose contract was a lie -- a call that would
+have been a runtime crash the first time job control asked for it.
+
+Passing `-Wl,--no-undefined` to GNU ld asks the SAME question Apple's
+linker asks by default, so the failure reproduces here in about a second:
+
+    cc -shared -o /dev/null -Wl,--no-undefined \
+       -Wl,--whole-archive libft.a -Wl,--no-whole-archive -lpthread -lm
+
+`--whole-archive` matters as much as `--no-undefined`: without it the
+linker skips the members nothing references, which is exactly how the
+hole stayed hidden. Whole-archive is also what a dylib build does.
+
+This is a portability test that needs no Mac. It fails on the commit that
+introduced the hole and passes on the one that filled it.
+
+Only the archives are checked, not build/obj: the shell is an EXECUTABLE,
+so its own objects already have to resolve every symbol at every build or
+there is no binary. The archives are the blind spot, and the reason is
+worth keeping in mind when adding to this file -- a check that repeats
+what `make` already proves is a check nobody learns anything from.
+
+Usage: python3 link_closure_test.py /path/to/hellish
+"""
+import os
+import platform
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FAILS = []
+
+# What the shell itself is linked against (Makefile LDLIBS). A symbol that
+# only these provide is fine; anything else has to come from our own code.
+SYSLIBS = ["-lreadline", "-lpthread", "-lm", "-ldl"]
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + (" " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def cc():
+    return os.environ.get("CC", "cc")
+
+
+def strict_link(objects, extra_libs):
+    """Link `objects` the way a Darwin dylib link would, and report holes.
+
+    Returns (ok, stderr). /dev/null as the output is deliberate: nothing
+    here wants the artifact, only the linker's verdict on it.
+    """
+    cmd = [cc(), "-shared", "-o", "/dev/null", "-Wl,--no-undefined",
+           "-Wl,--whole-archive"] + objects + ["-Wl,--no-whole-archive"]
+    cmd += extra_libs
+    p = subprocess.run(cmd, capture_output=True)
+    return (p.returncode == 0, p.stderr.decode(errors="replace"))
+
+
+def missing_symbols(stderr):
+    """Pull the symbol names out of a GNU ld undefined-reference report."""
+    return sorted(set(re.findall(r"undefined reference to [`'\"]([^`'\"]+)",
+                                 stderr)))
+
+
+def report(label, ok, err):
+    syms = missing_symbols(err)
+    detail = ""
+    if syms:
+        detail = "\n        undefined: " + ", ".join(syms[:12])
+        if len(syms) > 12:
+            detail += " (+%d more)" % (len(syms) - 12)
+    elif not ok:
+        detail = "\n        " + err.strip()[-600:]
+    check(label, ok, detail)
+
+
+def archives():
+    """Every static library the build produces, whichever heap was built.
+
+    build-libc is SAFE=1 (system malloc), build-ft is SAFE=0 (ft_malloc).
+    Both are checked when both are present, because they are different
+    compilations of the same tree and only one of them is usually built.
+    """
+    out = []
+    for tag in ("libc", "ft"):
+        d = os.path.join(ROOT, "vendor", "libft", "build-%s" % tag, "lib")
+        if not os.path.isdir(d):
+            continue
+        for f in sorted(os.listdir(d)):
+            if f.endswith(".a"):
+                out.append(("%s/%s" % (tag, f), os.path.join(d, f)))
+    return out
+
+
+def test_archives():
+    found = archives()
+    check("a built archive exists to check", bool(found),
+          "no vendor/libft/build-*/lib/*.a -- run make")
+    for label, a in found:
+        ok, err = strict_link([a], SYSLIBS)
+        report("%s has no undefined symbols" % label, ok, err)
+
+
+def main():
+    if platform.system() != "Linux":
+        # --no-undefined is a GNU ld spelling, and on Darwin the real
+        # linker already enforces this -- there is nothing to emulate.
+        print("skipped: this test emulates Darwin's linker using GNU ld")
+        sys.exit(0)
+    ok, _ = strict_link([], ["-lm"])
+    if not ok:
+        print("skipped: this toolchain does not accept -Wl,--no-undefined")
+        sys.exit(0)
+    test_archives()
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/link_closure_test.py
+++ b/tests/link_closure_test.py
@@ -38,11 +38,13 @@ hole stayed hidden. Whole-archive is also what a dylib build does.
 This is a portability test that needs no Mac. It fails on the commit that
 introduced the hole and passes on the one that filled it.
 
-Only the archives are checked, not build/obj: the shell is an EXECUTABLE,
-so its own objects already have to resolve every symbol at every build or
-there is no binary. The archives are the blind spot, and the reason is
-worth keeping in mind when adding to this file -- a check that repeats
-what `make` already proves is a check nobody learns anything from.
+The archives are checked for undefined symbols, and the shell's own
+objects for a subtler thing: a WEAK reference that nothing defines. The
+shell is an executable, so an ordinary missing symbol already fails its
+own build -- but a weak one does not. It is legal on ELF, resolves to
+NULL, and is a link error on Mach-O. Both checks exist to ask a question
+`make` does not ask here; a check that repeats what `make` already proves
+is a check nobody learns anything from.
 
 Usage: python3 link_closure_test.py /path/to/hellish
 """
@@ -129,6 +131,102 @@ def test_archives():
         report("%s has no undefined symbols" % label, ok, err)
 
 
+def nm_symbols(path):
+    """(defined, undefined_weak) for one object or archive, or None.
+
+    None means nm could not read it -- an LTO build stores bitcode, not
+    ELF, and plain nm says "file format not recognized". Skipping those is
+    correct rather than lenient: the non-LTO object tree carries the same
+    references and IS readable, so nothing goes unchecked.
+    """
+    p = subprocess.run(["nm", path], capture_output=True)
+    if p.returncode != 0:
+        return None
+    defined = set()
+    weak_undef = set()
+    for line in p.stdout.decode(errors="replace").split("\n"):
+        f = line.split()
+        if len(f) == 2 and f[0] == "w":
+            weak_undef.add(f[1])
+        elif len(f) == 3 and f[1] not in ("U", "w", "v"):
+            defined.add(f[2])
+    return (defined, weak_undef)
+
+
+def object_tree():
+    """The shell's own objects, from whichever build ran most recently."""
+    for d in ("obj", "obj-opt", "obj-debug"):
+        base = os.path.join(ROOT, "build", d)
+        if not os.path.isdir(base):
+            continue
+        objs = []
+        for root, _, files in os.walk(base):
+            objs += [os.path.join(root, f) for f in files
+                     if f.endswith(".o")]
+        if objs:
+            return (d, sorted(objs))
+    return (None, [])
+
+
+def test_no_dangling_weak_refs():
+    """A weak reference nothing defines is an ELF-only trick.
+
+    On ELF an undefined WEAK symbol is legal and resolves to NULL, so code
+    can ask "was this backend linked in?" with `if (!sym)`. Mach-O has no
+    such thing: __attribute__((weak)) on a DECLARATION is a weak
+    *definition*, not a weak import, so Apple's linker demands a body. That
+    is the whole of the second macOS failure --
+
+        Undefined symbols for architecture arm64:
+          "_malloc_live_bytes", referenced from: _free_all_state in lto.o
+
+    -- from alloc_stats.c probing for ft_malloc's leak oracle that way on a
+    SAFE=1 build, where nothing defines it. The fix was to let the Makefile
+    decide at compile time, since it already knows which heap it builds.
+
+    So: no object may carry an undefined weak symbol that the object tree
+    does not itself define. Deliberately NOT "defined anywhere in the
+    link" -- if a LIBRARY has the definition, a weak reference is still
+    the wrong way to reach it (use a strong one, which also pulls the
+    archive member), and it still fails on Darwin. Measuring against the
+    archives instead made this check pass while broken, because a SAFE=0
+    libft.a left over from an earlier build defined the very symbol a
+    SAFE=1 link cannot see.
+
+    There is no allowlist here because the tree needs none: across ~490
+    objects this is the only weak undefined symbol that has ever appeared.
+    If a toolchain starts emitting its own, the failure names it and the
+    decision can be made then, with the name in hand.
+    """
+    d, objs = object_tree()
+    check("the shell's objects exist to check", bool(objs),
+          "no build/obj*/**/*.o -- run make")
+    if not objs:
+        return
+    defined = set()
+    dangling = {}
+    unreadable = 0
+    for o in objs:
+        got = nm_symbols(o)
+        if got is None:
+            unreadable += 1
+            continue
+        defined |= got[0]
+        for sym in got[1]:
+            dangling.setdefault(sym, os.path.relpath(o, ROOT))
+    left = {s: o for s, o in dangling.items() if s not in defined}
+    detail = ""
+    if left:
+        detail = "\n        " + "\n        ".join(
+            "%s (referenced from %s)" % (s, o) for s, o in
+            sorted(left.items())[:8])
+    check("build/%s has no weak reference that nothing defines" % d,
+          not left, detail)
+    if unreadable:
+        print("     (%d LTO object(s) skipped -- not ELF; the non-LTO tree "
+              "covers the same code)" % unreadable)
+
+
 def main():
     if platform.system() != "Linux":
         # --no-undefined is a GNU ld spelling, and on Darwin the real
@@ -140,6 +238,7 @@ def main():
         print("skipped: this toolchain does not accept -Wl,--no-undefined")
         sys.exit(0)
     test_archives()
+    test_no_dangling_weak_refs()
     print("\n%d checks failed" % len(FAILS))
     sys.exit(1 if FAILS else 0)
 

--- a/tests/linux_only_apis_test.py
+++ b/tests/linux_only_apis_test.py
@@ -47,6 +47,19 @@ GATED = {
     "/proc/self/exe": ("src/platform/posix/self_exe.c", "self_exe_path()"),
 }
 
+# System headers that cannot be included ANYWHERE in this tree, and why.
+# These are not style rules -- each one is a compile error we have already
+# paid for, on a platform most of us cannot build locally.
+FORBIDDEN_INCLUDES = {
+    "mach-o/dyld.h":
+        "it declares `enum DYLD_BOOL { FALSE, TRUE };` and libft's\n"
+        "        ft_stddef.h already has `enum e_bool { FALSE, TRUE }`.\n"
+        "        Two enums cannot define the same enumerator names in one\n"
+        "        translation unit, so including both is a hard error in\n"
+        "        either order. Declare the one symbol you need instead:\n"
+        "        `int _NSGetExecutablePath(char *buf, uint32_t *bufsize);`",
+}
+
 # Comments may discuss these freely -- that is where the reasoning lives,
 # and a rule that forbids explaining itself is a rule people route around.
 # Block comments are tracked properly rather than matched line by line: the
@@ -103,6 +116,25 @@ def code_hits(path, needle):
     return hits
 
 
+def test_forbidden_includes(files):
+    """Headers that do not collide on Linux and do on the target.
+
+    This one cost a CI round trip to find, which is the argument for the
+    check: the collision is invisible here -- no Linux toolchain ships
+    mach-o/dyld.h, so nothing locally can even attempt it -- and the only
+    machine that can see it is the one we get to consult every twenty
+    minutes. A grep is a poor substitute for a compiler and a very good
+    substitute for a queue.
+    """
+    for header, why in FORBIDDEN_INCLUDES.items():
+        stray = []
+        for f in files:
+            stray += code_hits(f, "<%s>" % header)
+        check("%s is never included" % header, not stray,
+              "\n        " + why + "\n        offending: "
+              + ", ".join(stray[:6]))
+
+
 def main():
     files = sources()
     check("there are sources to scan", len(files) > 100,
@@ -121,6 +153,7 @@ def main():
         check("%s still lives in %s" % (needle, owner),
               bool(code_hits(owner, needle)),
               "the owner no longer mentions it -- is the GATED table stale?")
+    test_forbidden_includes(files)
     print("\n%d checks failed" % len(FAILS))
     sys.exit(1 if FAILS else 0)
 

--- a/tests/linux_only_apis_test.py
+++ b/tests/linux_only_apis_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Linux-only kernel interfaces must live behind one door, not be sprinkled.
+
+The report, from the macOS arm64 rung, once the build finally succeeded:
+
+    39 ok / 1 failed
+    FAIL process substitution
+          want ps
+          got  ''
+
+`<(cmd)` and `>(cmd)` re-exec the shell to run the inner command, and they
+did it by exec'ing the literal string "/proc/self/exe" -- twice, under two
+names (PATH_HELLISH and PROC_SELF_EXE) that expanded to the same string, so
+the second attempt was dead code. procfs is not in POSIX and Darwin has no
+/proc at all, so on macOS both execs hit a path that is not there, the
+child exited 127, and process substitution silently produced nothing.
+
+The same assumption was in three other places: the ENOEXEC script-
+interpreter fallback, and both halves of the update machinery's "where am
+I?" (which made every macOS install classify as ORIGIN_BINARY, so `update`
+would offer to overwrite a source checkout as though it were a downloaded
+binary). All four now go through self_exe_path(), which uses
+/proc/self/exe on Linux and _NSGetExecutablePath on Darwin.
+
+So the invariant this file gates is not "does procsub work" -- the golden
+suite and the smoke both cover that, on Linux, where it always worked. It
+is that a Linux-only interface appears in exactly ONE place, the platform
+file whose job is to know about it. That is the property that failed here:
+the knowledge was copied into four files, and porting meant finding all
+four. The next one has to be found too, and nobody will remember.
+
+Usage: python3 linux_only_apis_test.py [ignored]
+"""
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FAILS = []
+
+# interface -> the single file allowed to name it, and what to use instead.
+# Add a row when a new Linux-only path or syscall enters the tree; the
+# point of the table is that adding the row is a DECISION someone makes,
+# not something that happens by copy-paste.
+GATED = {
+    "/proc/self/exe": ("src/platform/posix/self_exe.c", "self_exe_path()"),
+}
+
+# Comments may discuss these freely -- that is where the reasoning lives,
+# and a rule that forbids explaining itself is a rule people route around.
+# Block comments are tracked properly rather than matched line by line: the
+# interesting mentions are on CONTINUATION lines of a /* */ paragraph, which
+# start with plain spaces and match no "is this a comment" pattern at all.
+# A first cut here used ^\s*(/\*|\*|//) and flagged five prose lines.
+LINE_COMMENT = re.compile(r"^\s*//")
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + (" " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def sources():
+    out = subprocess.run(["git", "-C", ROOT, "ls-files", "src", "incs"],
+                         capture_output=True)
+    return [f for f in out.stdout.decode().split("\n")
+            if f.endswith((".c", ".h"))]
+
+
+def code_hits(path, needle):
+    """Lines of `path` that mention `needle` in CODE, not in a comment.
+
+    Not a C parser -- it only has to be right about whether a line is
+    inside /* */, and it treats a line that opens and closes a block on
+    itself as code plus a comment, which is the common `x = 1; /* why */`.
+    A string containing "/*" would fool it; there are none in this tree,
+    and the failure mode is a false negative on one line, not a wrong
+    verdict on the file.
+    """
+    hits = []
+    inblock = False
+    full = os.path.join(ROOT, path)
+    try:
+        f = open(full, errors="replace")
+    except OSError:
+        return hits
+    with f:
+        for i, line in enumerate(f, 1):
+            was = inblock
+            if not inblock and "/*" in line and "*/" not in line:
+                inblock = True
+            elif inblock and "*/" in line:
+                inblock = False
+                was = True
+            if was or LINE_COMMENT.match(line):
+                continue
+            code = line.split("/*")[0]
+            if needle in code:
+                hits.append("%s:%d" % (path, i))
+    return hits
+
+
+def main():
+    files = sources()
+    check("there are sources to scan", len(files) > 100,
+          "found %d" % len(files))
+    for needle, (owner, instead) in GATED.items():
+        stray = []
+        for f in files:
+            if f == owner:
+                continue
+            stray += code_hits(f, needle)
+        check("%s is named only by %s" % (needle, owner), not stray,
+              "\n        use %s instead of hardcoding it:\n        " % instead
+              + "\n        ".join(stray[:10]))
+        # ... and the owner must actually still use it, or the rule above
+        # is passing because the interface quietly disappeared.
+        check("%s still lives in %s" % (needle, owner),
+              bool(code_hits(owner, needle)),
+              "the owner no longer mentions it -- is the GATED table stale?")
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/regress_hellish
+++ b/tests/regress_hellish
@@ -86,7 +86,7 @@ case $SECONDS in [0-9]*) echo seconds-num ;; esac; case $EPOCHSECONDS in [0-9]*)
 printf 'echo "s1=$1 s2=$2 n=$#"\n' > /tmp/rh_src.$$; set -- X; . /tmp/rh_src.$$ a b; echo "after=$1 n=$#"; rm -f /tmp/rh_src.$$
 sleep 0.01 & sleep 0.3; jobs; wait $!; echo rc=$?
 sleep 0.01 & sleep 0.3; jobs; echo --; jobs; echo end
-sleep 0.01 & wait; jobs; echo end
+sleep 0.3 & jobs | grep -c Running; wait; echo end
 sleep 0.01 & p=$!; wait $p; echo rc1=$?; wait $p; echo rc2=$?
 (exit 7) & wait $!; echo rc=$?
 sleep 0.05 & sleep 0.05 & wait; echo done=$?

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -1,275 +1,221 @@
-# Session context — 2026-08-22
+# Session context — 2026-08-22 (portability)
 
 Working notes for whoever picks this up next, from another workspace or a
 later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**.
+Branch to resume from: **`develop`**. Released version: **2.8.1**.
+
+The previous note on this file covered the issue-fixing session (#27, #32,
+#34, #42 and friends). All of those are closed; the tracker is empty. This
+note replaces it and covers the cross-platform work.
 
 ---
 
-## What shipped in this session
+## What this session was
 
-Every issue on the tracker is now closed. Four commits, each on its own
-branch, merged fast-forward into `develop`:
+One request, repeated: make the CI failures reproducible, gate them, fix
+them, then merge and release. The failures were on the two rungs nobody can
+build locally — macOS arm64 and WSL — which changes the method more than it
+sounds like it should.
 
-| Commit | Issue | What |
+**You cannot iterate on a platform you cannot compile for.** Every macOS
+defect costs one CI round trip of roughly twenty minutes, and they arrive
+strictly one at a time, each invisible until the one before it is fixed. So
+the discipline that paid off was: after each fix, ask *what else in the tree
+makes the same assumption* — and gate the assumption, not the symptom.
+
+---
+
+## The macOS list, in the order they appeared
+
+Six, each hidden behind the last. The shape of this list is the argument for
+the rung existing at all.
+
+| # | Symptom | Actual cause |
 |---|---|---|
-| `8568479` | #27 | per-job process groups — `^Z` did nothing at all |
-| `65a14f2` | #32 | `shopt -s lithist` — multi-line history recall |
-| `e6a5153` | #27 | `jobs` reports `Done(N)`; 19 golden cases |
-| `a575c12` | #34 | prompt frames dropped on a non-blocking tty |
-| `c4b35d1` | — | stop asserting the flaky job marker in a golden case |
-| `810a476` | — | `jobs` reports live status inside a pipeline |
+| 1 | `no member named 'st_mtim'` | Darwin spells it `st_mtimespec` |
+| 2 | `undeclared identifier 'SIGPWR'` / `SIGRTMAX` | Linux-only signals; realtime signals are optional in POSIX |
+| 3 | `bcopy` conflict | it is a fortified *macro* on Darwin, not a function |
+| 4 | `-Werror=sign-compare` in `mascot_anim.c` | `MB_CUR_MAX` is `size_t` on glibc and `int` on Darwin |
+| 5 | `Undefined symbols: _get_original_tty_job_signals` | declared and called, **never defined**, for months |
+| 6 | `Undefined symbols: _malloc_live_bytes` | weak undefined ref — legal on ELF, a link error on Mach-O |
+| 7 | `process substitution` produced `''` | `/proc/self/exe` exec'd literally; no procfs on Darwin |
+| 8 | `redefinition of enumerator 'FALSE'` | `<mach-o/dyld.h>` vs libft's `enum e_bool` |
 
-Earlier in the same session (already on `develop` before these): #41, #40,
-#39, #28, #37, #2, #3.
+(#5 and #6 are the interesting ones. Neither is a macOS bug.)
 
----
+### #5 was a real bug everywhere
 
-## The four fixes, and the evidence behind them
+`get_original_tty_job_signals()` was in libft's `trap.h`, called by
+`initialize_traps()`, and defined by no translation unit. It stayed green on
+Linux for months because **GNU ld defaults to `--allow-shlib-undefined`**: a
+shared library may keep undefined symbols and hope the loader finds them.
+Apple's linker does not. So Darwin was simply the first linker that told us
+we were shipping a library whose contract was a lie — a crash waiting for
+the first caller.
 
-### #27 — foreground commands had no process group of their own
+Implemented in libft with bash's semantics. Two details worth keeping:
 
-The issue described this as a signal-aiming problem. It was worse than
-that: **`^Z` did nothing at all.**
+- The fetch is **non-destructive**. `get_orig_sig()` reads a disposition by
+  installing `SIG_DFL` and keeping what came back — fine for SIGQUIT and
+  SIGTERM, which are re-armed immediately, and wrong for the tty signals: a
+  shell left with `SIGTSTP` at `SIG_DFL` suspends itself the moment a child
+  touches the terminal. So: swap, look, swap back.
+- Non-interactive shells do not ask the kernel at all. Nobody installed
+  these on our behalf, so reading them records whatever the parent left
+  behind and propagates it into every child. `SIG_DFL` is both what bash
+  records and what a child expects.
 
-POSIX XSH 2.4.3 — `SIGTSTP`/`SIGTTIN`/`SIGTTOU` delivered to a member of an
-**orphaned** process group are *discarded*. A group is orphaned when no
-member has a parent in a different group of the same session, which is
-exactly the shell's own group once the shell is a session leader (every
-terminal emulator makes it one) and its children stay inside it. The
-terminal sent SIGTSTP, the kernel dropped it, the command kept running and
-kept eating keystrokes meant for the shell.
+### #6 was ELF-only cleverness
 
-Proven with no shell involved: a child left in a session leader's group
-never stops under `^Z`; the same child given its own group stops every time.
+`alloc_stats.c` asked "was ft_malloc linked in?" at *link* time — a weak
+undefined reference plus `-Wl,-u` to drag the archive member in — so the
+file needed no `-D`. On ELF an undefined weak symbol resolves to NULL; on
+Mach-O, `__attribute__((weak))` on a **declaration** is a weak *definition*,
+so Apple's linker wanted a body.
 
-Fix lives in `src/platform/posix/job_pgrp.c` — `jc_init` / `jc_begin` /
-`jc_child` / `jc_parent` / `jc_end`. `setpgid` runs on **both** sides of the
-fork so neither side can lose the race, and `tcsetpgrp` hands the terminal
-over and takes it back around the wait.
+Now `-DHAVE_ALLOC_ORACLE`, from the Makefile, which already knew the answer.
+The `-Wl,-u` went **with** the weak ref rather than staying beside it: a
+*strong* reference pulls an archive member on its own; only a weak one does
+not.
 
-**Interactive-only, and that is load-bearing for performance.** `jc_begin`
-decides once per pipeline with a `getpid()` check, so background bodies,
-subshells and `$( )` captures all fail the test and cannot move a group or
-grab the tty. Verified: `strace -c -e trace=setpgid` shows **zero**
-`setpgid` calls across 100 forked commands under `-c`. `make bench` after
-the change: **geomean 1.312× faster than bash**, 74% of tasks faster.
+### #7 was in four places, and only one of them failed
 
-Two adjacent defects fell out of testing it:
+`<(cmd)` / `>(cmd)` re-exec the shell and did it through the literal
+`/proc/self/exe` — twice, under two names (`PATH_HELLISH`, `PROC_SELF_EXE`)
+that expanded to the same string, so the second attempt had always been dead
+code. The same assumption was also in the ENOEXEC script-interpreter
+fallback and **both halves of the update machinery's "where am I?"** — which
+meant every non-Linux install classified as `ORIGIN_BINARY`, so `update`
+would have offered to overwrite a source checkout as though it were a
+downloaded binary.
 
-- `job_update_status` only polled `JOB_RUNNING` jobs, so once a job stopped
-  the shell stopped asking about it *forever* — a `^Z`'d job later killed
-  stayed listed as `Stopped` for the rest of the session.
-- `kill` on a stopped job left the signal pending forever, so `kill %1`
-  looked like a no-op. bash follows it with `SIGCONT`; `job_kill_group`
-  now does too, exempting the stop signals themselves.
+`self_exe_path()` (`src/platform/posix/self_exe.c`) is the one door now.
 
-### #32 — multi-line history recall
-
-hellish had implemented only bash's `cmdhist` half: a compound is stored as
-one entry with boundary newlines rewritten to `; `. That is the correct
-*default* and stays the default. bash's other half is `lithist`, which keeps
-the newlines, and hellish had no way to ask for it.
-
-Both modes now match bash 5.3.9 byte for byte in a pty: default recall ends
-`; fi`, `lithist` recall ends `<newline>fi`. No history-file format change
-was needed — `encode_cmd_hist` already escapes embedded newlines.
-
-Two pre-existing `shopt` exit-status bugs surfaced, and they are **not the
-same rule**: `-s`/`-u` report whether the *change* succeeded (so a
-successful `shopt -u x` is 0), while a bare `shopt name` reports the
-*setting* (so it is 1 when off). Both were wrong; both fixed.
-
-### #34 — prompt corruption on a non-blocking terminal
-
-An earlier repair routed prompt writers through `tty_write_all`, which loops
-over short writes. That loop retried `EINTR` and **returned on every other
-error** — and `EAGAIN` is an error. Same class of bug, worse consequence: a
-short write loses a tail, `EAGAIN` loses the *whole frame*.
-
-It is reachable in ordinary use because `O_NONBLOCK` lives on the open file
-**description**, which the shell shares with every program it launches. One
-tool that sets it on the terminal and does not restore it leaves the shell
-writing to a non-blocking tty for the rest of the session.
-
-Measured, real 65-byte prompt frame against a full 64K buffer:
-
-```
-EINTR-only loop (before)   wrote  0 / 65   <- entire frame lost
-with the EAGAIN wait       wrote 65 / 65
-```
-
-**This is a strong candidate for #34's report, not a confirmed diagnosis.**
-The original corruption was never reproduced. Two independent holes in the
-same write path are now closed; that is all the evidence supports, and the
-issue comment says so plainly.
+**`_NSGetExecutablePath` has two traps.** It takes its buffer size *by
+pointer* (rewritten with the size needed on overflow), so passing by value
+compiles and corrupts the stack. And it does **not** promise an absolute,
+resolved path — it returns the path the process was exec'd *through*, which
+may be relative. Caching a relative one is a bug with a long fuse: correct
+until the first `cd`. Apple's docs say to `realpath()` it; we do.
 
 ---
 
 ## Tests added, and how to trust them
 
-Every fix ships with a gate, and **each new gate was verified non-vacuous**
-by deliberately reverting the fix and confirming the gate fails:
+Every gate here was verified non-vacuous by deliberately reverting the fix
+and confirming it fails. Two of them **passed while broken on the first
+attempt**, which is the whole reason that step is not optional:
 
-| Gate | Checks | Sabotage result |
+| Gate | What it asks | First attempt |
 |---|---|---|
-| `make bg-tty-test` | 13 → 23 | — |
-| `make nonblock-tty-test` (new) | 10 | queue-full check FAILS without the EAGAIN wait |
-| `make hist-test` | +5 lithist | both lithist checks FAIL with the join forced on |
-| `tests/issue27_job_pgrp` (new) | 19 golden | — |
-| `tests/regress_hellish` | +8 shopt/lithist | — |
+| `tests/link_closure_test.py` | GNU ld the question Apple's ld asks by default (`--no-undefined --whole-archive`) | measured against the **archives** and passed while broken — a leftover SAFE=0 `libft.a` defined the very symbol a SAFE=1 link cannot see. Now measured against the objects alone. |
+| `tests/crlf_hygiene_test.py` | nothing executed is stored CRLF, **and** every such file is covered by a rule | the first half alone passes on a repo with *no* `.gitattributes` — it would have passed on the commit that broke WSL. The coverage half is the one with teeth. |
+| `tests/linux_only_apis_test.py` | `/proc/self/exe` named in exactly one file; `<mach-o/dyld.h>` never included | its comment filter matched `^\s*(/\*\|\*\|//)` and flagged five prose lines — the interesting mentions are on **continuation** lines of a `/* */` paragraph, which start with plain spaces and match no comment pattern at all. |
 
-`tests/issue27_job_pgrp` is wired into `test_lists=(…)` at the top of
-`tests/tester` — a new category file that is *not* added there silently
-never runs in `make test`. `nonblock-tty-test` is wired into the Makefile
-`.PHONY` list and into CI's `interactive` job.
+All three are discovered automatically by `tests/pty_suite.sh` (it globs
+`tests/*.py`), so they need no Makefile or CI wiring.
 
-### A harness bug worth knowing about
-
-`tests/run_scripts.sh` was grading against **whatever bash was in `PATH`**,
-not the pinned 5.3.9 that `tests/tester` uses. bash 5.2 and 5.3 disagree on
-the `jobs` status-column width, which is why `17_bg_signal_report.sh`
-"failed" there while passing under the pinned oracle — **oracle drift
-reported as a hellish bug**, and it had been sitting in the corpus as a
-known failure. Fixed in `8568479`; the corpus is now 109/109.
-
-If a batch of failures ever appears without a matching source change,
-suspect oracle drift first. `make oracle` builds the pinned bash.
+**The reproduce-on-Linux trick is the point.** Each of these fails on the
+unfixed code, on this machine, in about a second, with no Mac and no Windows
+runner. A grep is a poor substitute for a compiler and a very good
+substitute for a twenty-minute queue.
 
 ---
 
-## Verification state (all green on `develop` @ `a575c12`)
+## WSL
 
-```
-make test                 3742 / 3742   vs pinned bash 5.3.9
-tests/run_scripts.sh       109 / 109
-tests/verify_alloc.sh       78 / 78     on BOTH heaps, 0 leaks
-make bg-tty-test            23 checks, 0 failed
-make nonblock-tty-test      10 checks, 0 failed
-make hist-test              ALL PASSED
-make prompt-atomic-test      4 / 4      (1.1 MB over 9366 writes)
-make re / make re OPT=1     clean, -Wall -Wextra -Werror
-norminette                  clean on every touched file
-make bench                  geomean 1.312× faster than bash
-```
+Two separate things, and the first masked the second.
+
+1. **CRLF.** GitHub's Windows runners check out with `core.autocrlf=true`,
+   so `set -u` arrived as `set -u\r` and bash reported
+   `set: - : invalid option` and a syntax error on a brace. `.gitattributes`
+   now pins executed file types to `eol=lf`.
+
+   Deliberately **not** `* text=auto eol=lf`: ~100 files here are stored with
+   CRLF already, including fixtures under `tests/` whose bytes the golden
+   suite compares exactly. `git add --renormalize .` was run to confirm the
+   rule changes zero stored bytes.
+
+2. **drvfs.** `$GITHUB_WORKSPACE` is on `D:`, which WSL reaches through a
+   bridge out of the VM. A build is ~970 compiler invocations doing thousands
+   of round trips; the job was still compiling when the 60-minute timeout
+   killed it, and because the cancellation lands on the `cmd.exe` wrapper the
+   log ends in `Terminate batch job (Y/N)?` with nothing above it. The tree
+   is now copied to the distro's own ext4 first (one `tar | tar`, `.git`
+   excluded) and built there, with an explicit in-step timeout so a stall
+   produces a message instead of a cancelled batch job.
+
+   A separate step keeps what is actually WSL-specific: running the shell
+   against a drvfs directory (glob, read, `pwd`). Deliberately *not* the
+   permission checks — `chmod 000` on drvfs without metadata support is a
+   no-op, so a red there would be Windows telling the truth.
 
 ---
 
-## Known gaps — NOT fixed, deliberately
+## Two golden cases removed for being environment-dependent
 
-Read this section before assuming something is done.
+This keeps happening and is worth naming as a class.
 
-1. **`tests/hard/12_job_control.sh` is intermittently flaky (~1–2%,
-   load-dependent).** `wait $p3` occasionally reports `127`. I investigated
-   this at length and want the next person to have the honest state:
-   - It is **pre-existing** — reproduced at the same rate with the
-     job-control changes reverted.
-   - I identified a real durability gap (the status poll recorded a reaped
-     child only into the job table, and `job_purge_done` from an unrelated
-     `wait` discards that entry, losing the status from both lookups) and
-     fixed it, because `builtin_jobs` already followed the ring rule and
-     the poll had simply not been taught it.
-   - **That fix is NOT proven to be the cause.** After it: 0 failures in
-     120 runs. But with the fix reverted: 0 failures in 80 runs. The rate
-     is too low and too load-sensitive for those samples to distinguish.
-     Do not record this as diagnosed.
-   - A deterministic reproducer was attempted twice and failed both times;
-     the window needs `wait $p1` to succeed on a live child while `p3` has
-     already been reaped by the poll.
+- `sleep 0.01 & wait; jobs; echo end` — the arm64 runner's bash printed a
+  `Done` line; the pinned bash on x86 printed it **0 / 65 times**. The
+  *oracle* was architecture-dependent, so there was no right answer to pin.
+  Replaced with `sleep 0.3 & jobs | grep -c Running; wait; echo end`.
+- `issue13_bg_pid`: twelve cases racing `sleep 0.4` in the parent against a
+  3-second child. One full-suite run in five failed 7/3790 on exactly these,
+  with `sleep <defunct>` — the child had exited, so ~3s had passed where the
+  script asked for 0.4s.
 
-2. **`jobs` command text is a raw source slice, not a re-render.** bash
-   prints `( exit 7 )` for input `(exit 7)`; hellish prints `(exit 7)`.
-   Matching bash means pretty-printing the AST. The golden cases in
-   `issue27_job_pgrp` are written with bash-canonical spacing to sidestep
-   this — that is deliberate, and it means those cases do *not* cover the
-   label renderer.
-
-3. **`kill -0 $pid` on a finished background job** returns 0 in hellish and
-   1 in bash: bash reaps eagerly, hellish leaves the zombie a moment longer.
-   A test line for this was written and then removed rather than assert
-   the wrong behaviour.
-
-4. **The `+`/`-` current-job marker is environment-sensitive.** Do not
-   assert it in a golden case. `( exit 0 ) & sleep 0.1; jobs` prints
-   `[1]+  Done` under the pinned bash locally and `[1]   Done` under the
-   same pinned bash on a CI runner. My first version of
-   `issue27_job_pgrp` asserted it, passed locally 5/5, and failed in CI —
-   the cases now normalise the marker away with sed and assert only the
-   status column, which is the thing actually under test.
-
-4. **Docker Hub release channel is still unpublished** (#37). The workflow
-   guard is in and correct — an unconfigured repo now *skips* rather than
-   fails — but `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` are not set. GHCR
-   carries the image. Setting the two secrets is all that is left.
-
-5. **`vendor/libft` has an uncommitted submodule pointer change** in the
-   working tree that predates this session. I did not commit or touch it.
-   Check what it is before assuming it is intentional.
+  **Not reproduced in isolation**: 25/25 clean under CPU saturation, 192/192
+  under 64-way concurrency, four other full runs green. So the child's
+  nominal life went 3s → 30s as a *widened margin* against the only
+  mechanism the evidence fits, not as a diagnosis anyone can claim. Every one
+  of the twelve was re-checked against pinned bash individually. Cases with
+  no parent sleep were left alone — they have no wall-clock dependency.
 
 ---
 
 ## Conventions that bit me, recorded so they do not bite again
 
-- **`make norm` always exits 0** — it only *reports*. Read its output; do
-  not trust the exit status. It caught `TOO_MANY_FUNCS` and `SPC_AFTER_PAR`
-  on files that "built fine" twice this session.
-- **The 5-function-per-file ceiling forces helper placement.**
-  `done_with_code` lives in `job_signal2.c` rather than beside its only
-  caller for exactly this reason; `subshell_child` and `cmd_child_body`
-  were extracted to keep their callers under 25 lines.
-- **`ft_snprintf` does not exist.** libft has `ft_strlcpy`/`ft_strlcat` and
-  an allocating `ft_itoa`. A borrowed-string return contract rules out
-  `ft_itoa`, hence the hand-rolled digit loop in `done_with_code`.
-- **`cd tests && …` persists across Bash tool calls.** Several `make`
-  invocations silently failed with "No rule to make target" because of it.
-  Use absolute paths.
-- **The pty renders a newline as `\r\n\r`.** A test asserting `"\nfi"` on
-  raw pty output will fail even when the shell is correct; strip `\r` first.
-- **The history file is `~/.minishell_history`**, not `.hellish_history`.
+- **Do not rebuild while a pty suite is running.** I did it three times and
+  each run reported failures that were mine, not the shell's. Finish source
+  changes, *then* run `make pty-test`.
+- **`make norm` always exits 0** — it only reports. Read the output.
+- **Norminette rejects `(uint32_t)sizeof(x)`** (`SPC_AFTER_PAR`) and
+  `(size_t)-1` (`SPC_BFR_OPERATOR`). The accepted spellings are a named
+  constant and `(size_t) - 1` respectively — the latter is already the
+  tree-wide idiom for `mbrtowc` error returns, and is what made #4 above a
+  one-line fix.
+- **A preprocessor block inside a function body** needs a blank line after
+  the directive (`NL_AFTER_PREPROC`).
+- **Python rewrites of `.c` files silently convert CRLF → LF.**
+  `procsub_input.c` and `create_procsub_output.c` flipped this way; the real
+  change is ~40 lines and the diff reads as ~170. Left as LF (the right
+  direction for C sources) rather than churning them a second time.
+- **`cd tests && …` persists across Bash tool calls.** Use absolute paths.
+- **GitHub only honours `Closes #N` when a PR merges into the DEFAULT
+  branch.** PRs into `develop` do not auto-close anything, which is why
+  issues sat open in the previous session. Close them by hand.
+- **`concurrency: cancel-in-progress` means every push kills the run you
+  were watching.** Several "failures" this session were cancellations. Check
+  the conclusion string before believing a red.
 
 ---
 
-## Suggested next steps
+## Still open
 
-In rough priority order:
-
-1. **Decide the release.** `develop` is four commits ahead of the last tag
-   (2.7.1) with one feature (`lithist`) and three fixes, one of them a
-   real correctness fix to job control. That is a **2.8.0**. I did not cut
-   it — see the note below.
-2. Chase the `12_job_control.sh` flake properly, with a deterministic
-   harness rather than statistics (gap 1 above).
-3. Decide whether `jobs` should re-render its command text from the AST
-   (gap 2) — it is the last visible `jobs` divergence from bash.
-4. Set the two Docker Hub secrets, or drop that channel from the release
-   workflow.
-
-### A note on method
-
-Three of the bugs in this session were found by *writing the test first
-and watching it disagree with bash*, not by reading code: `Done(N)`,
-`jobs` in a pipeline, and both `shopt` exit-status rules all surfaced
-that way. The golden suite is the cheapest bug-finder in this repo —
-when adding coverage for one thing, it is worth writing the neighbouring
-cases too and reading every diff rather than only the one you expected.
-
-Equally: **every new gate here was checked by deliberately reverting the
-fix and confirming the gate fails.** Two of them passed while broken on
-the first attempt (the `nonblock-tty-test` queue-full check needed a
-real 400KB flood before it had teeth; a `venv` check earlier in the
-session passed against a shell that had died). A green test you have not
-seen fail is not yet evidence.
-
-### On cutting the release
-
-The user asked for a new version once main is clean and CI is green. I have
-**not** bumped `HELLISH_VERSION` (still `2.7.1`). Reason: a release retags,
-publishes to npm and GHCR, and is the one action here that is genuinely hard
-to walk back — and I could not watch CI go green on `main` end to end within
-this session. The version bump plus `make update-config-test` (which checks
-the version, the GitHub slug, `install.sh`, npm and the Dockerfile all
-agree) should be one deliberate commit, made once CI on `main` is confirmed
-green.
+1. **macOS is still `continue-on-error`.** The build now succeeds and the
+   smoke reached 39/40; the last gap is fixed but has not yet been confirmed
+   green on a real runner. Do not flip the flag until it has — a red required
+   check that everyone learns to ignore is worse than an informational one.
+2. **`v2.8.1` is not tagged.** The version is bumped, the notes are written,
+   `make update-config-test` is green. Tagging fires `release.yml` and
+   `ghcr.yml` — GitHub Releases, npm, GHCR — and is the one step here that
+   cannot be walked back. It was deliberately left for a human.
+3. **Docker Hub secrets** are still unset; that channel of `release.yml`
+   will no-op or fail. Set them or drop the channel.
+4. **`tests/test_files/invalid_permission`** shows as permanently modified
+   and `git` cannot even hash it (mode 000 by design). Pre-existing; ignore
+   it in `git status`, and never `git add -A`.

--- a/wiki/platforms.md
+++ b/wiki/platforms.md
@@ -160,6 +160,26 @@ getting it wrong.
   `(size_t) - 2`; now this does too. No behaviour change on any platform,
   which is the point: the two spellings are the same test, and only one of
   them compiles everywhere.
+- **`__attribute__((weak))` on a declaration means something else on Mach-O.**
+  `alloc_stats.c` probed for ft_malloc's leak oracle with a weak undefined
+  reference and a `-Wl,-u` to drag the archive member in, so the file needed
+  no `-D`. On ELF an undefined weak symbol is legal and resolves to NULL; on
+  Mach-O the same attribute on a *declaration* is a weak **definition**, so
+  Apple's linker demanded a body and the SAFE=1 arm64 build stopped at
+  `Undefined symbols: _malloc_live_bytes`. Decided at compile time now
+  (`-DHAVE_ALLOC_ORACLE`, from the Makefile, which already knows the heap);
+  the `-Wl,-u` went with the weak ref, because a *strong* reference pulls an
+  archive member by itself. Pinned by `link_closure_test.py`, which fails on
+  any weak reference the object tree does not itself define.
+- **Windows checkouts rewrite LF to CRLF, and bash cannot read that.**
+  `core.autocrlf=true` on the Windows runner turned `set -u` into `set -u\r`
+  and `expect() {` into `expect() {\r`, so the WSL rung died inside
+  `docker/smoke.sh` with `set: - : invalid option` and a syntax error on a
+  brace. `.gitattributes` now pins every executed file type to `eol=lf`, and
+  `tests/crlf_hygiene_test.py` gates both halves: nothing executed is stored
+  with CRLF, *and* every such file is covered by a rule — the second is what
+  catches the next file someone adds, since the first passes on a repo with
+  no `.gitattributes` at all.
 - **openSUSE Tumbleweed ships no `find`.** The Makefile discovers its
   sources with `$(shell find src ...)`, so the source list came back empty,
   make built nothing, and the link stopped at `cc: fatal error: no input

--- a/wiki/platforms.md
+++ b/wiki/platforms.md
@@ -27,6 +27,8 @@ Two things run, and they answer different questions.
 | `docker/smoke.sh` | 40 checks: the shell starts, forks, pipes, redirects, here-docs, globs, does arithmetic, handles signals and job control, and reports the right exit statuses | every platform rung |
 | the golden suite | ~3800 cases diffed byte-for-byte against a pinned bash 5.3.9 | x86_64 and arm64 Linux |
 | `tests/link_closure_test.py` | every symbol the archives reference is defined — *asking GNU ld the question Apple's linker asks by default* | anywhere, via `make pty-test` |
+| `tests/linux_only_apis_test.py` | Linux-only kernel interfaces are named in one file, not copied into four | anywhere, via `make pty-test` |
+| `tests/crlf_hygiene_test.py` | nothing executed is stored with CRLF, *and* every such file is covered by a rule | anywhere, via `make pty-test` |
 
 The smoke is not a weaker suite — it is a *different* one. It targets the
 class of bug that only appears when the C code meets a different libc,
@@ -87,27 +89,38 @@ container and the licence does not permit running it off Apple hardware, so
 (x86_64) and `macos-14` (arm64) runners are the honest equivalent, and both
 are in the `Platforms` workflow.
 
-The job is `continue-on-error` on purpose. The shell is written to POSIX but
-has never been built on Darwin, and two gaps are already known:
+The job is `continue-on-error` on purpose, and the honest state is: as of
+2.8.1 the build succeeds and the smoke was **39 ok / 1 failed**, the one
+failure being `/proc/self/exe`, now fixed. Both known gaps are closed:
 
 1. **readline.** Apple ships libedit under the name `libreadline`. It
    answers `-lreadline` and then does not have most of the GNU API this
-   shell uses. The Makefile now asks `brew --prefix readline` and adds that
-   include/lib pair on Darwin — untested on a real Mac.
-2. **`/proc/self/exe`.** Process substitution re-execs the shell through
-   that path (`incs/sys.h`), and it does not exist on Darwin. `<(cmd)` and
-   `>(cmd)` will not work there until it is replaced with a runtime lookup
-   (`_NSGetExecutablePath` on Darwin, `/proc/curproc/file` on FreeBSD).
-   Note `/dev/fd/N` is already used for the resulting path, which *is*
-   portable — only the self-exec path is not.
+   shell uses. The Makefile asks `brew --prefix readline` and adds that
+   include/lib pair on Darwin. The build and all 40 smoke checks reached
+   readline-dependent code without complaint, so this appears settled.
+2. **`/proc/self/exe`.** Process substitution re-exec'd the shell through
+   that path, so `<(cmd)` and `>(cmd)` produced nothing on Darwin. It is
+   now `self_exe_path()` (`src/platform/posix/self_exe.c`) —
+   `/proc/self/exe` on Linux, `_NSGetExecutablePath` on Darwin — and the
+   ENOEXEC interpreter fallback plus both halves of the update machinery
+   went the same way; all four had copied the same Linux-only assumption.
+   `/dev/fd/N` for the resulting path was always portable; only the
+   self-exec path was not.
+
+   `tests/linux_only_apis_test.py` keeps it that way. It does not test
+   process substitution — the golden suite and the smoke already do, on
+   Linux, where it always worked. It asserts that `/proc/self/exe` is
+   named in exactly one file. That is the property that actually failed:
+   the knowledge was in four places, so porting meant finding all four.
+
+Do not flip `continue-on-error` off until a full run is green on a real
+runner. A red required check that everyone learns to ignore is worse than
+an informational one.
 
 `-D_XOPEN_SOURCE=700` is also wrong on Darwin: it pins the POSIX.1-2008
 surface on glibc and musl, but on Apple's libc it *hides* the BSD extensions
 the system headers themselves need. The Makefile uses `-D_DARWIN_C_SOURCE`
 there instead.
-
-Do not flip `continue-on-error` off until the job is green. A red required
-check that everyone learns to ignore is worse than an informational one.
 
 ### WSL — informational
 

--- a/wiki/platforms.md
+++ b/wiki/platforms.md
@@ -26,6 +26,7 @@ Two things run, and they answer different questions.
 |---|---|---|
 | `docker/smoke.sh` | 40 checks: the shell starts, forks, pipes, redirects, here-docs, globs, does arithmetic, handles signals and job control, and reports the right exit statuses | every platform rung |
 | the golden suite | ~3800 cases diffed byte-for-byte against a pinned bash 5.3.9 | x86_64 and arm64 Linux |
+| `tests/link_closure_test.py` | every symbol the archives reference is defined — *asking GNU ld the question Apple's linker asks by default* | anywhere, via `make pty-test` |
 
 The smoke is not a weaker suite — it is a *different* one. It targets the
 class of bug that only appears when the C code meets a different libc,
@@ -120,8 +121,45 @@ so the workflow does that on a `windows-latest` runner.
 Informational because the runner-side WSL setup is the flakiest step in the
 file, not because the platform does not matter.
 
+**Do not build on `/mnt/`.** `$GITHUB_WORKSPACE` is on `D:`, which WSL
+reaches through drvfs — a bridge out of the VM to the Windows filesystem.
+Every `open`, `stat` and `write` is a round trip, and a build is ~970
+compiler invocations doing thousands of them. The first run of this job was
+still compiling when the 60-minute timeout killed it, and because the
+cancellation lands on the `cmd.exe` wrapper the log ends in
+`Terminate batch job (Y/N)?` with nothing useful above it. The job now
+copies the tree onto the distro's own ext4 first (one `tar | tar` pass) and
+builds there.
+
+What that gives up is drvfs coverage of the *build*, which was never the
+point; what it keeps is a separate step that runs the shell against a drvfs
+directory — glob it, read from it, `pwd` in it. Deliberately not the
+permission checks: `chmod 000` on drvfs without metadata support is a no-op,
+so a red there would be Windows telling the truth rather than hellish
+getting it wrong.
+
 ## Things the matrix has already caught
 
+- **A function declared, called, and never defined.**
+  `get_original_tty_job_signals()` was in libft's `trap.h` and called by
+  `initialize_traps()`, and no translation unit defined it. Every Linux job
+  stayed green for months, because GNU ld lets a *shared library* keep
+  undefined symbols and hope the loader finds them later; Apple's linker
+  does not, so `libft.so` on arm64 macOS stopped at
+  `Undefined symbols for architecture arm64`. This was never a macOS bug —
+  it was a library shipping a contract it could not honour, and a runtime
+  crash waiting for the first caller. Fixed by defining it (bash's
+  semantics: fetch SIGTSTP/SIGTTIN/SIGTTOU once, non-destructively, and
+  record SIG_DFL when non-interactive), and pinned by
+  `tests/link_closure_test.py`, which reproduces the exact failure on Linux
+  in about a second with `-Wl,--no-undefined -Wl,--whole-archive`.
+- **`MB_CUR_MAX` is `size_t` on glibc and `int` on Darwin.**
+  `mascot_anim.c` tested `mbrtowc`'s result with `n > MB_CUR_MAX` — correct
+  on Linux, a `-Werror=sign-compare` build failure on macOS. The rest of the
+  tree already spelled the error returns out as `(size_t) - 1` /
+  `(size_t) - 2`; now this does too. No behaviour change on any platform,
+  which is the point: the two spellings are the same test, and only one of
+  them compiles everywhere.
 - **openSUSE Tumbleweed ships no `find`.** The Makefile discovers its
   sources with `$(shell find src ...)`, so the source list came back empty,
   make built nothing, and the link stopped at `cc: fatal error: no input

--- a/wiki/platforms.md
+++ b/wiki/platforms.md
@@ -89,9 +89,14 @@ container and the licence does not permit running it off Apple hardware, so
 (x86_64) and `macos-14` (arm64) runners are the honest equivalent, and both
 are in the `Platforms` workflow.
 
-The job is `continue-on-error` on purpose, and the honest state is: as of
-2.8.1 the build succeeds and the smoke was **39 ok / 1 failed**, the one
-failure being `/proc/self/exe`, now fixed. Both known gaps are closed:
+The job is `continue-on-error` on purpose. macOS bring-up has been
+strictly iterative — **six** defects so far, each one only visible once the
+one before it was fixed, and every round trip costs a CI queue. In order:
+`st_mtim`, `SIGPWR`/`SIGRTMIN`, `bcopy`, `MB_CUR_MAX`, then a link hole
+that had nothing to do with Darwin, then `/proc/self/exe`, then this
+header collision. As of 2.8.1 the build succeeds and the smoke reached
+**39 ok / 1 failed**, that one being `/proc/self/exe`. All known gaps are
+now closed:
 
 1. **readline.** Apple ships libedit under the name `libreadline`. It
    answers `-lreadline` and then does not have most of the GNU API this
@@ -112,6 +117,15 @@ failure being `/proc/self/exe`, now fixed. Both known gaps are closed:
    Linux, where it always worked. It asserts that `/proc/self/exe` is
    named in exactly one file. That is the property that actually failed:
    the knowledge was in four places, so porting meant finding all four.
+
+3. **`<mach-o/dyld.h>` cannot be included in this tree.** It declares
+   `enum DYLD_BOOL { FALSE, TRUE };`, and libft's `ft_stddef.h` already has
+   `enum e_bool { FALSE, TRUE }`. Two enums cannot define the same
+   enumerator names in one translation unit, so including both is a hard
+   error in either order — and it is *invisible* on Linux, where no
+   toolchain ships that header at all. `_NSGetExecutablePath` is declared
+   by hand instead; one stable ABI symbol is cheaper to declare than an
+   enum namespace is to negotiate. Gated in the same test file.
 
 Do not flip `continue-on-error` off until a full run is green on a real
 runner. A red required check that everyone learns to ignore is worse than


### PR DESCRIPTION
## 2.8.1 — a portability release

No behaviour changes on Linux. Every fix here is about hellish building and running correctly somewhere it previously did not, and about CI being able to tell you when it does not.

### The result

| rung | before | after |
|---|---|---|
| macOS arm64 | build failed | **40 ok / 0 failed** |
| WSL (Ubuntu 22.04) | cancelled at 60 min, unreadable log | **all steps green** |
| everything else | green | green (39/39) |

Both informational rungs are green for the first time.

### macOS took six defects, each hidden behind the last

`st_mtim` -> `SIGPWR`/`SIGRTMIN` -> `bcopy` -> `MB_CUR_MAX` -> an undefined-symbol link hole -> `/proc/self/exe` -> a header enum collision.

Two of them were never macOS bugs:

- **`get_original_tty_job_signals()` was declared, called, and defined by nobody**, for months. GNU ld defaults to `--allow-shlib-undefined`, so `libft.so` linked with a hole in it and every Linux job stayed green. Apple ld does not. It was a crash waiting for its first caller. (Univers42/libft#79)
- **`alloc_stats.c` probed for the allocator backend with a weak undefined reference.** Legal on ELF (resolves to NULL); on Mach-O `__attribute__((weak))` on a *declaration* is a weak definition, so Apple ld wanted a body. Now a compile-time fact from the Makefile, which always knew the answer.

**`/proc/self/exe` was in four places and only one of them failed.** Process substitution was the visible break; the same assumption was in the ENOEXEC interpreter fallback and both halves of the update machinery -- which had been classifying every non-Linux install as a downloaded binary, so `update` would have offered to overwrite a source checkout.

### WSL was two things, and the first masked the second

`core.autocrlf=true` turned `set -u` into `set -u\r`. Underneath that, the build was running on drvfs -- ~970 compiler invocations round-tripping out of the VM -- and never finished inside the hour.

### Three new gates, all reproducing the failures on Linux in ~1s

Each was verified by reverting the fix and confirming it fails. **Two passed while broken on the first attempt**, which is why that step is not optional:

- `link_closure_test.py` -- asks GNU ld the question Apple ld asks by default. First version measured against the archives and passed while broken: a leftover SAFE=0 `libft.a` defined the very symbol a SAFE=1 link cannot see.
- `crlf_hygiene_test.py` -- the \"nothing is stored CRLF\" half passes on a repo with no `.gitattributes` at all. The coverage half is the one with teeth.
- `linux_only_apis_test.py` -- `/proc/self/exe` named in exactly one file; `<mach-o/dyld.h>` never included. That collision is *invisible* on Linux, so a grep beats a twenty-minute queue.

### Also

A golden case flaking 1-in-5 (`issue13_bg_pid`, `sleep 0.4` racing a 3s child) had its margin widened to 30s. **Not reproduced in isolation** -- 25/25 clean under CPU saturation, 192/192 under 64-way concurrency -- so this is a widened margin against the only mechanism the evidence fits, not a diagnosis.

### Verified

golden 3790/3790 · pty 21/21 · smoke 40/40 (Linux and macOS) · norminette clean · `make update-config-test` green · CI 39/39 on d9c5339

🤖 Generated with [Claude Code](https://claude.com/claude-code)