### PR TITLE
Release 2.7.2 + self-documenting Makefile

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Build
         run: |
           cc --version | head -1
-          make OPT=1 SAFE=1 2>&1 | tail -60
+          make all OPT=1 SAFE=1 2>&1 | tail -60
           test -x build/bin/hellish
       - name: Portability smoke
         run: bash docker/smoke.sh ./build/bin/hellish
@@ -300,7 +300,7 @@ jobs:
           cd ~/hellish
           # An explicit timeout, well under the job's 60 minutes, so a stall
           # ends in a message we can read instead of a cancelled batch job.
-          if ! timeout 2400 make OPT=1 SAFE=1 2>&1 | tail -60; then
+          if ! timeout 2400 make all OPT=1 SAFE=1 2>&1 | tail -60; then
             echo "::error::build did not finish within 40 minutes inside WSL"
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,83 @@
 #                                                                              #
 # **************************************************************************** #
 
+# ── Shared make fragments ────────────────────────────────────────────────────
+# The logging wrappers (log_ok, log_info, log_warn, log_error, log_title,
+# print_status) come from libft so the two projects sound the same in a
+# terminal. mk/colors.mk supplies the palette they interpolate and explains at
+# length why libft's global_conf.mk is NOT included: it mixes the palette with
+# CC, CFLAGS, OBJ_DIR, LDFLAGS and RM, and would quietly redefine this build.
+#
+# Guarded with wildcard because vendor/libft is a submodule: a fresh clone
+# without `--recursive` still has to be able to run `make help` and be told
+# what to do about it, rather than dying on a missing include.
+include mk/colors.mk
+
+LIBFT_MK := vendor/libft/mk
+ifneq ($(wildcard $(LIBFT_MK)/functions.mk),)
+include $(LIBFT_MK)/functions.mk
+include $(LIBFT_MK)/symbols.mk
+else
+log_note  = @printf "$(BOLD_MAGENTA)%s$(RESET)\n" "$(1)"
+log_info  = @printf "$(BOLD_GREEN)%s$(RESET)\n" "$(1)"
+log_ok    = @printf "  $(BRIGHT_CYAN)✓$(RESET) %s\n" "$(1)"
+log_warn  = @printf "$(BRIGHT_YELLOW)⚠ %s$(RESET)\n" "$(1)"
+log_error = @printf "$(BRIGHT_RED)✗ %s$(RESET)\n" "$(1)"
+endif
+
+# ── Default goal ────────────────────────────────────────────────────────────
+# `make` with no arguments prints the help instead of building. That is a
+# deliberate trade: discovering ~60 targets used to mean reading 900 lines of
+# Makefile, and the cost is that anything wanting a build must now say `all`.
+# Every call site in this repo was updated in the same commit; if you are
+# adding one, `make all` is the spelling.
+.DEFAULT_GOAL := help
+
+# ── Self-documenting help ───────────────────────────────────────────────────
+# The help text IS this file. Three annotations, rendered by mk/help.awk:
+#
+#   ##@ Section            a heading, in the order they appear here
+#   target: deps  ## text  a target and what it does
+#   ##! NAME=value  text   a variable you can set on the command line
+#
+# Generated rather than written out, because a hand-written list drifts: a
+# target with no `##` simply does not appear, so documenting one is part of
+# adding it. `make help-targets` prints the undocumented ones, which is the
+# check that keeps that honest.
+HELP_AWK := mk/help.awk
+
+##@ Configuration
+##! OPT=1  -O3 + LTO and the ft_malloc heap; default is -O0 -g3 + ASan
+##! SAFE=1  libc malloc (ASan can see it). SAFE=0 uses ft_malloc
+##! CC=clang  Compiler to build with (default cc)
+##! ROUNDS=7  Benchmark repetitions for `make bench`
+##! BENCH=micro  Benchmark set: micro or full
+##! SUITE_ARGS="redir pipe"  Restrict `make docker-suite` to these categories
+##! ORACLE_PREFIX=~/bash-5.3.9  Where `make oracle` builds the pinned bash
+##! PREFIX=~/.local  Install root for `make user-install`
+##! EXTRA_CFLAGS=...  Appended to CFLAGS (e.g. -DFOO); never replaces them
+##! EXTRA_LDFLAGS=...  Appended to LDFLAGS (e.g. -static)
+##! NO_COLOR=1  Drop every escape sequence from make's own output
+
+help: ## Show this help (default target)
+	@printf "\n$(BOLD_WHITE)hellish$(RESET) — a POSIX shell in C\n"
+	@printf "$(DIM)usage:$(RESET)  make $(BOLD_GREEN)<target>$(RESET) [$(BOLD_CYAN)VAR=value$(RESET) ...]\n"
+	@printf "$(DIM)build:$(RESET)  make $(BOLD_GREEN)all$(RESET)   $(DIM)(plain \`make\` shows this page)$(RESET)\n"
+	@awk -v head="$(BOLD_YELLOW)" -v tgt="$(BOLD_GREEN)" -v var="$(BOLD_CYAN)" \
+		-v reset="$(RESET)" -f $(HELP_AWK) $(firstword $(MAKEFILE_LIST))
+	@printf "\n$(DIM)undocumented targets: make help-targets  ·  platforms: wiki/platforms.md$(RESET)\n\n"
+
+help-targets: ## List targets missing a ## description (should print none)
+	@undoc=$$(awk '/^[a-zA-Z0-9_.-]+:/ && !/^\t/ && !/## / { t = $$0; sub(/:.*/, "", t); print t }' \
+		$(firstword $(MAKEFILE_LIST)) | grep -vxF -e .PHONY -e safe_banner | sort -u); \
+	if [ -z "$$undoc" ]; then \
+		printf "  $(BRIGHT_CYAN)✓$(RESET) every target is documented\n"; \
+	else \
+		printf "$(BRIGHT_YELLOW)⚠ undocumented targets:$(RESET)\n"; \
+		printf "    %s\n" $$undoc; \
+		exit 1; \
+	fi
+
 # Compiler and flags
 CC          := cc
 
@@ -218,7 +295,8 @@ MAKEFLAGS := --no-print-directory -j$(NPROC)
 # Add this variable at the top with your other variables
 COMPILED := 0
 
-all: safe_banner $(BIN_DIR)/$(BAPTIZE_SHELL)
+##@ Build
+all: safe_banner $(BIN_DIR)/$(BAPTIZE_SHELL)  ## Build the shell → build/bin/hellish
 
 # Announce the active allocator before building so it is never a surprise.
 safe_banner:
@@ -320,7 +398,7 @@ submodule update --init --checkout srcs/memory/ft_malloc\n" >&2; exit 1; }; \
 	@$(MAKE) -C vendor/libft  SAFE=$(SAFE) BUILD_DIR=build-$(SAFE_TAG)
 	@printf "\n" >&2
 
-clean:
+clean:  ## Remove object files, keep the binary
 	@printf "\n  \033[1;33m⚠\033[0m \033[1;37mCleaning build artifacts\033[0m" >&2
 	@rm -rf $(OBJ_DIR)
 	@printf "\r\033[K  \033[1;32m✓\033[0m \033[37mBuild artifacts cleaned\033[0m\n\n" >&2
@@ -330,7 +408,7 @@ clean:
 # default set above does not, so a plain `make fclean` used to reach libft with
 # SAFE unset -- landing in its SAFE!=1 branch, running the LTO capability probe
 # and printing its warning just to delete files.
-fclean: clean
+fclean: clean  ## Remove objects, the binary and libft's build trees
 	@printf "  \033[1;33m⚠\033[0m \033[1;37mRemoving binary\033[0m" >&2
 	@rm -f $(BIN_DIR)/$(BAPTIZE_SHELL)
 	@printf "\r\033[K  \033[1;32m✓\033[0m \033[37mBinary removed\033[0m\n\n" >&2
@@ -348,7 +426,7 @@ fclean: clean
 # such file"; libft's "opening dependency file build-libc/...: No such file").
 # Two separate sub-makes guarantee the ordering. OPT/SAFE are command-line
 # overrides, so they propagate to the sub-makes automatically.
-re:
+re:  ## fclean + rebuild (OPT/SAFE propagate)
 	@$(MAKE) --no-print-directory fclean
 	@$(MAKE) --no-print-directory all
 	@printf "  \033[1;32m✓\033[0m \033[1;37mRebuilt $(BAPTIZE_SHELL)\033[0m\n\n" >&2
@@ -368,7 +446,8 @@ re:
 # tests/tester picks it up automatically (override with HELLISH_ORACLE=...).
 ORACLE_PREFIX ?= $(HOME)/bash-5.3.9
 
-oracle:
+##@ Test
+oracle:  ## Build the PINNED bash 5.3.9 the suite is defined against
 	@if [ -x "$(ORACLE_PREFIX)/bin/bash" ]; then \
 		printf "\n  \033[1;32m✓\033[0m \033[1;37m%s\033[0m \033[90m(cached)\033[0m\n\n" \
 			"$$($(ORACLE_PREFIX)/bin/bash --version | head -1)" >&2; \
@@ -380,7 +459,7 @@ oracle:
 # Force a relink so the binary always matches the requested mode (debug here):
 # the OPT/debug object trees are separate but the binary path is shared, and
 # make won't relink on a mode switch alone.
-test:
+test:  ## Golden suite: ~3800 cases diffed against bash --posix
 	@rm -f $(BIN_DIR)/$(BAPTIZE_SHELL)
 	@$(MAKE) --no-print-directory all
 	@printf "\n  \033[1;36m▸\033[0m \033[1;37mRunning tests\033[0m\n\n" >&2
@@ -389,13 +468,14 @@ test:
 # Official speed verdict vs `bash --posix`. Always benchmarks the OPT build
 # (timing the default ASan/debug build would be meaningless). Override rounds /
 # scope:  make bench ROUNDS=7        make bench BENCH=micro
-bench:
+##@ Benchmarks & conformance
+bench:  ## Speed vs bash --posix (always rebuilds OPT=1)
 	@rm -f $(BIN_DIR)/$(BAPTIZE_SHELL)
 	@$(MAKE) --no-print-directory OPT=1 all
 	@printf "\n  \033[1;36m▸\033[0m \033[1;37mBenchmarking hellish vs bash --posix\033[0m\n\n" >&2
 	@(cd $(TEST_DIR); ROUNDS=$(ROUNDS) TIMEOUT_S=$(TIMEOUT_S) /bin/bash benchmark $(BENCH))
 
-norm:
+norm:  ## 42 norminette over src/ incs/ tests/ (reports only, always exits 0)
 	@printf "\n  \033[1;36m▸\033[0m Running norminette" >&2; \
 	output="$$( \
 	    norminette src incs tests 2>&1 | grep -v 'OK!' | grep -v 'US' \
@@ -425,7 +505,8 @@ norm:
 # is defined further down the file.
 MY_SHELL_BIN = $(if $(filter 1,$(STATIC)),$(STATIC_OUT),$(BIN_DIR)/$(BAPTIZE_SHELL))
 
-my_shell:
+##@ Install
+my_shell:  ## sudo-install to /usr/bin and register as a login shell
 	@if [ "$(STATIC)" = "1" ]; then \
 		$(MAKE) --no-print-directory static-verify; \
 	else \
@@ -462,7 +543,7 @@ my_shell:
 #   make user-install PREFIX=~/opt    somewhere other than ~/.local
 #   make user-install RC_TARGET=~/.bashrc   hook a specific rc file
 #   make user-uninstall               remove the hook and the binary
-user-install:
+user-install:  ## Install to ~/.local/bin with an rc hook — no sudo needed
 	@if [ "$(STATIC)" = "1" ]; then \
 		$(MAKE) --no-print-directory static-verify; \
 	else \
@@ -474,7 +555,7 @@ user-install:
 		RC_TARGET="$(RC_TARGET)" \
 		./user-install.sh --bin "$(MY_SHELL_BIN)"
 
-user-uninstall:
+user-uninstall:  ## Remove the rc hook and the binary
 	@PREFIX="$(if $(PREFIX),$(PREFIX),$$HOME/.local)" \
 		RC_TARGET="$(RC_TARGET)" \
 		./user-install.sh --uninstall
@@ -492,7 +573,8 @@ user-uninstall:
 STATIC_ARCH ?= $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 STATIC_OUT  := dist/hellish-linux-$(STATIC_ARCH)
 
-static:
+##@ Ship
+static:  ## Static musl binary via docker → dist/hellish-linux-<arch>
 	@printf "\n  \033[1;36m▸\033[0m \033[1;37mBuilding static hellish (linux/%s)\033[0m\n\n" \
 		"$(STATIC_ARCH)" >&2
 	@mkdir -p dist
@@ -513,7 +595,7 @@ static:
 # Prove the container-built binary really does run on THIS host: no dynamic
 # deps, and a real command executes. `make static` alone only proves it ran
 # inside Alpine; this is the part that answers "can I use it on my machine".
-static-verify: static
+static-verify: static  ## ... and prove it runs on THIS host
 	@printf "  \033[1;36m▸\033[0m \033[1;37mVerifying on the host\033[0m\n\n" >&2
 	@if readelf -l $(STATIC_OUT) | grep -q 'program interpreter' \
 		|| readelf -d $(STATIC_OUT) 2>/dev/null | grep -q 'NEEDED'; then \
@@ -534,7 +616,7 @@ static-verify: static
 # `make` / `make all` deliberately stay a plain native build: this is a 42
 # project, and an evaluator (or CI, or `make test`) runs make on the machine in
 # front of them. Docker is the guaranteed path, not the only one.
-docker: static-verify
+docker: static-verify  ## Build the release image from the verified static binary
 	@printf "  \033[1;37mInstall it as your login shell with:\033[0m\n" >&2
 	@printf "      \033[1;36mmake my_shell STATIC=1\033[0m\n\n" >&2
 
@@ -544,7 +626,7 @@ docker: static-verify
 # local `make test` disagrees with CI, or on any machine whose bash is not 5.3.
 #   make docker-suite                      # everything
 #   make docker-suite SUITE_ARGS="redir pipe"
-docker-suite:
+docker-suite:  ## The golden suite, hermetic: shell AND oracle from the image
 	docker build -f docker/Dockerfile.suite -t hellish:suite .
 	docker run --rm hellish:suite $(SUITE_ARGS)
 
@@ -558,35 +640,35 @@ docker-suite:
 #
 #   make docker-test                       # everything
 #   docker/test.sh fedora alpine-clang     # just these two
-docker-build:
+docker-build:  ## Build the per-distro images used by docker-test
 	docker compose build
-docker-test:
+docker-test:  ## Build + smoke from source on every supported distro
 	@chmod +x docker/test.sh docker/smoke.sh && docker/test.sh
-docker-alpine:
+docker-alpine:  ## Interactive hellish in an Alpine container
 	docker compose run --rm alpine
-docker-debian:
+docker-debian:  ## Interactive hellish in a Debian container
 	docker compose run --rm debian
-docker-ubuntu:
+docker-ubuntu:  ## Interactive hellish in an Ubuntu container
 	docker compose run --rm ubuntu
-docker-ubuntu2204:
+docker-ubuntu2204:  ## Interactive hellish in Ubuntu 22.04 (the WSL default)
 	docker compose run --rm ubuntu2204
-docker-arch:
+docker-arch:  ## Interactive hellish in an Arch container
 	docker compose run --rm arch
-docker-fedora:
+docker-fedora:  ## Interactive hellish in a Fedora container
 	docker compose run --rm fedora
-docker-rocky:
+docker-rocky:  ## Interactive hellish in a Rocky Linux container
 	docker compose run --rm rocky
-docker-opensuse:
+docker-opensuse:  ## Interactive hellish in an openSUSE container
 	docker compose run --rm opensuse
-docker-void:
+docker-void:  ## Interactive hellish in a Void Linux container
 	docker compose run --rm void
-docker-clean:
+docker-clean:  ## Remove the images and volumes these targets create
 	docker compose down --rmi local 2>/dev/null || true
 
 # The portability workout on its own, against whatever binary is built. Same
 # script the distro containers and every Platforms CI rung run, so a failure
 # reads the same everywhere.
-smoke: all
+smoke: all  ## 40-check portability workout against your build
 	@chmod +x docker/smoke.sh && docker/smoke.sh $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # Cross-shell speed matrix. Build hellish + a zoo of other shells (bash, dash,
@@ -595,7 +677,7 @@ smoke: all
 # where hellish lands. The host needs none of those shells installed -- that is
 # the whole point of doing it in docker. See tests/agnostic_bench.sh.
 # Override rounds/timeout:  make agnostic-bench ROUNDS=7 TIMEOUT_S=60
-agnostic-bench:
+agnostic-bench:  ## Cross-shell speed matrix vs 8 shells, in docker
 	docker build -f docker/Dockerfile.agnostic -t hellish:agnostic .
 	@printf "\n  \033[1;36m▸\033[0m \033[1;37mRacing hellish against every shell we could install\033[0m\n\n" >&2
 	@mkdir -p bench/.artifacts
@@ -605,14 +687,14 @@ agnostic-bench:
 
 # Build hellish + zsh in one image and diff the zsh-style two-argument
 # `cd old new` extension against real zsh (the bash suite can't cover it).
-cd-zsh-test:
+cd-zsh-test:  ## docker: the zsh-style `cd old new` extension vs real zsh
 	docker build -f docker/Dockerfile.zsh -t hellish:zsh .
 	docker run --rm hellish:zsh
 
 # Host-side check (no docker): `hellish --posix` must match `bash --posix` on
 # the cd cases the zsh extension would otherwise change, while normal mode keeps
 # the extension. Builds first so the binary is current.
-cd-posix-test: all
+cd-posix-test: all  ## --posix gates that cd extension off
 	@chmod +x $(TEST_DIR)/cd_posix_compare.sh
 	@HELLISH=$(BIN_DIR)/$(BAPTIZE_SHELL) bash $(TEST_DIR)/cd_posix_compare.sh
 
@@ -620,7 +702,7 @@ cd-posix-test: all
 # their multi-line text in `history` and the file, and up-arrow recall of
 # loops/here-docs re-executes with bash-cmdhist semantics instead of the
 # broken space-joined flattening. See tests/hist_multiline_test.py.
-hist-test: all
+hist-test: all  ## pty: cmdhist multiline history joining
 	@python3 $(TEST_DIR)/hist_multiline_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # The `history` builtin's OPTIONS, in a live session (issue #42). The golden
@@ -628,7 +710,7 @@ hist-test: all
 # covers the shape the bug actually had -- an interactive shell, a populated
 # history file, and PROMPT_COMMAND='history -a' dumping the whole list before
 # every prompt. Run it after touching builtin_history*.c.
-history-opts-test: all
+history-opts-test: all  ## pty: the history builtin's options (#42)
 	@python3 $(TEST_DIR)/history_opts_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # Every multi-line construct, in BOTH history modes, diffed against the pinned
@@ -638,7 +720,7 @@ history-opts-test: all
 # here-docs, and a trailing | && ||. Checks the listing AND what the up-arrow
 # puts back, because those are two different code paths in hellish.
 # Needs the oracle: `make oracle`.
-history-matrix-test: all
+history-matrix-test: all  ## pty: 26 multi-line constructs × 2 modes vs pinned bash
 	@python3 $(TEST_DIR)/history_multiline_matrix.py \
 		$(BIN_DIR)/$(BAPTIZE_SHELL)
 
@@ -647,7 +729,7 @@ history-matrix-test: all
 # "dirty" for half a minute after a `git checkout` in the same shell had made
 # the tree clean. Makes the slow scan deterministic with a `git` shim rather
 # than needing a big repo, so it reproduces on any machine.
-git-star-test: all
+git-star-test: all  ## pty: the git dirty star never outlives the state it describes
 	@python3 $(TEST_DIR)/git_star_freshness_test.py \
 		$(BIN_DIR)/$(BAPTIZE_SHELL)
 
@@ -657,14 +739,15 @@ git-star-test: all
 # guards ran nowhere from the day it landed. tests/pty_suite.sh globs the
 # directory instead, so a new regression test is covered the moment it exists.
 # This is what CI runs; the individual targets above stay for working on one.
-pty-test: all
+##@ Interactive (pty) gates
+pty-test: all  ## EVERY tests/*.py regression test, by discovery — what CI runs
 	@chmod +x $(TEST_DIR)/pty_suite.sh && $(TEST_DIR)/pty_suite.sh
 
 # Non-ASCII in the PROMPT (the shortened cwd) and in TYPED INPUT (a wrapping
 # line that starts with a two-byte, one-column character, plus an edit made
 # at its start -- the shape reported in issue #2). Both render the pty output
 # through a terminal model and compare it against what should be on screen.
-widechar-test: all
+widechar-test: all  ## pty: non-ASCII in the prompt and in a wrapping typed line
 	@python3 $(TEST_DIR)/widechar_prompt_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 	@python3 $(TEST_DIR)/widechar_input_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
@@ -673,7 +756,7 @@ widechar-test: all
 # which never enters the readline path -- so this is the only gate protecting
 # completion, history recall and vi/emacs switching. Required before touching
 # the readline linkage (see backlog: dlopen readline). tests/readline_paths_test.py
-readline-test: all
+readline-test: all  ## pty: every libreadline entry point — run before touching linkage
 	@python3 $(TEST_DIR)/readline_paths_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # Prompt-animation vs paste regression (real pty): the idle repaint must
@@ -681,7 +764,7 @@ readline-test: all
 # (pasted newline, wrapped or multibyte input) instead of climbing a
 # mis-computed row count and erasing the paste or the scrollback. Also
 # proves the animation still runs on plain input. See tests/anim_paste_test.py.
-anim-test: all
+anim-test: all  ## pty: the prompt animation never clobbers pasted input
 	@python3 $(TEST_DIR)/anim_paste_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # Prompt git segment must never block on `git status` (real pty): cd into
@@ -689,7 +772,7 @@ anim-test: all
 # (the check finishes in the background and the star arrives a render
 # late), TTL refreshes stay non-blocking, and normal-speed repos keep
 # their exact synchronous star. See tests/git_prompt_stall_test.py.
-git-prompt-test: all
+git-prompt-test: all  ## pty: the prompt's git check never blocks a render
 	@python3 $(TEST_DIR)/git_prompt_stall_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # Background jobs and the controlling terminal. POSIX only redirects an
@@ -697,14 +780,14 @@ git-prompt-test: all
 # unconditionally broke `top &` interactively ("top: failed tty get")
 # instead of letting it stop on SIGTTOU the way bash does. Compares
 # against bash directly, so it also notices if bash changes its mind.
-bg-tty-test: all
+bg-tty-test: all  ## pty: background jobs and terminal ownership
 	@python3 $(TEST_DIR)/bg_tty_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # A virtualenv prompt surviving its own deactivate. venv's activate saves
 # ${PS1:-} and restores it only `if [ -n "$$_OLD_VIRTUAL_PS1" ]`, so a shell
 # with no default PS1 saved "" and stayed "(venv) " forever. Runs the PS1
 # handshake verbatim, then the real python3 -m venv round trip. (#39)
-venv-prompt-test: all
+venv-prompt-test: all  ## pty: the virtualenv segment, incl. a real python3 -m venv
 	@python3 $(TEST_DIR)/venv_prompt_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # Tab completion, built SAFE=0 ON PURPOSE. readline frees every match it is
@@ -713,8 +796,8 @@ venv-prompt-test: all
 # there is no mismatch to find. Only a SAFE=0 binary can fail this gate, so
 # it builds one (ASan there reports "bad-free ... not malloc()-ed"). It also
 # covers the PATH scan that stopped at the first match per directory. (#40)
-completion-test:
-	@$(MAKE) --no-print-directory SAFE=0
+completion-test:  ## pty: tab completion on a SAFE=0 build (cross-heap frees)
+	@$(MAKE) --no-print-directory all SAFE=0
 	@python3 $(TEST_DIR)/completion_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # What TAB is ALLOWED to offer. A PATH element is searched for an EXECUTABLE
@@ -726,7 +809,7 @@ completion-test:
 # bash, and was a filename here) and the no-match fallback that let the cwd's
 # files back in. Hermetic: PATH is one fixture directory, so the offered set
 # is a closed set the test can compare exactly.
-completion-posix-test: all
+completion-posix-test: all  ## pty: what TAB is ALLOWED to offer (POSIX command search)
 	@python3 $(TEST_DIR)/completion_posix_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # PS1 rendering, and the login chain that exposed it. Because hellish sets
@@ -734,7 +817,7 @@ completion-posix-test: all
 # us bash's default PS1 -- which the renderer then printed as visible text
 # (":+()}\033[01;32m...") because \nnn was not an escape and ${v:+w} was read
 # as a bare name. Renders that exact PS1 in a pty and checks the bytes.
-ps1-render-test: all
+ps1-render-test: all  ## pty: a bare-name PS1 renders byte-for-byte
 	@python3 $(TEST_DIR)/ps1_render_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # Canary (NOT a regression gate for a specific fix): drives the shell the way
@@ -742,13 +825,13 @@ ps1-render-test: all
 # escape sequence reached the screen without its ESC[ and no UTF-8 character
 # was cut. It has never reproduced that corruption -- read its docstring
 # before trusting a pass.
-prompt-integrity-test: all
+prompt-integrity-test: all  ## pty: prompt bytes survive a short write
 	@python3 $(TEST_DIR)/prompt_shortwrite_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # The pending-update badge. The loud notice is one-shot by design; this is
 # the quiet marker that persists while an update is actually waiting, so a
 # user who missed the notice still finds out. Also covers the \U escape.
-update-badge-test: all
+update-badge-test: all  ## pty: the lazy update header and its \U escape
 	@python3 $(TEST_DIR)/update_badge_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # Release/update configuration, checked offline: the GitHub slug baked into
@@ -756,14 +839,14 @@ update-badge-test: all
 # distribution channel (install.sh, npm, Dockerfile, docs) must agree with
 # it, and npm's version must track HELLISH_VERSION. No runtime test can
 # reach any of this -- a wrong slug only shows up as a 404 at update time.
-update-config-test:
+update-config-test:  ## Offline gate: version, GitHub slug, install.sh, npm and docs agree
 	@bash $(TEST_DIR)/update_config_check.sh
 
 # The `help` builtin. The load-bearing check is that EVERY builtin in the
 # dispatch table has a help entry -- documentation rots by omission, and
 # deriving the expected set from hash_builtins_dispatch.c makes that
 # impossible to do quietly.
-help-test: all
+help-test: all  ## The help builtin — every dispatch-table entry must have one
 	@bash $(TEST_DIR)/help_test.sh $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # The update path end to end against a LOCAL fake release server: discovery,
@@ -772,7 +855,8 @@ help-test: all
 # no network is touched. update_ui_test drives a pty for the two interactive
 # requirements: the header must be lazy, and a discovered update must never
 # disturb a line the user is typing.
-update-test: all
+##@ Feature gates
+update-test: all  ## The whole update path against a LOCAL fake release server
 	@python3 $(TEST_DIR)/update_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 	@python3 $(TEST_DIR)/update_ui_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
@@ -780,7 +864,7 @@ update-test: all
 # byte by byte let the line discipline echo type-ahead INTO a colour escape;
 # a letter is a valid CSI final byte, so the sequence ended early and its
 # tail printed as text (`38;2;112`). See tests/prompt_atomic_test.py.
-prompt-atomic-test: all
+prompt-atomic-test: all  ## pty: the prompt prefix reaches the tty in ONE write
 	@chmod +x $(TEST_DIR)/prompt_atomic_test.py
 	@python3 $(TEST_DIR)/prompt_atomic_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
@@ -791,13 +875,13 @@ prompt-atomic-test: all
 # hard error and drop the WHOLE frame. The last two checks fill the output
 # queue for real before the shell draws, so they fail outright if the EAGAIN
 # wait is removed. See tests/nonblock_tty_test.py.
-nonblock-tty-test: all
+nonblock-tty-test: all  ## pty: prompt frames survive a non-blocking terminal
 	@chmod +x $(TEST_DIR)/nonblock_tty_test.py
 	@python3 $(TEST_DIR)/nonblock_tty_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
 # /dev/tcp and /dev/udp redirections vs bash --posix. Brings up its own TCP
 # and UDP peer, so it needs python3 but no network access.
-net-redir-test: all
+net-redir-test: all  ## /dev/tcp and /dev/udp redirections (brings up its own peer)
 	@chmod +x $(TEST_DIR)/net_redir_test.py
 	@python3 $(TEST_DIR)/net_redir_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
 
@@ -805,7 +889,7 @@ net-redir-test: all
 # invalid-option status, $-, mode-dependent nounset) vs bash --posix. These
 # exercise how the shell parses its own argv, which the golden -c harness
 # cannot reach. Host-side, no docker. See tests/cli_opts_compare.sh.
-cli-opts-test: all
+cli-opts-test: all  ## The shell's own argv parsing (-e, -o name, +c, --, $-)
 	@chmod +x $(TEST_DIR)/cli_opts_compare.sh
 	@HELLISH=$(BIN_DIR)/$(BAPTIZE_SHELL) bash $(TEST_DIR)/cli_opts_compare.sh
 
@@ -813,7 +897,7 @@ cli-opts-test: all
 # runs the /etc/profile.d snippets) and then ~/.profile, exactly as bash does,
 # and a non-login one must source neither. The golden -c harness only ever
 # spawns non-login shells, so it cannot see this. See tests/login_profile_compare.sh.
-login-test: all
+login-test: all  ## Login shells source /etc/profile then ~/.profile; others neither
 	@chmod +x $(TEST_DIR)/login_profile_compare.sh
 	@HELLISH=$(BIN_DIR)/$(BAPTIZE_SHELL) bash $(TEST_DIR)/login_profile_compare.sh
 
@@ -821,19 +905,19 @@ login-test: all
 # hellish, bash --posix and dash; report in bench/conformance.md; the gate
 # fails if hellish's pass count drops vs bench/baseline/. Suites are fetched
 # once by bench/conformance.sh's helpers (see bench/README.md).
-conformance:
+conformance:  ## Third-party suites (Oils spec + mksh check.t) vs bash AND dash
 	@/bin/bash bench/conformance.sh
 
 # Dimension-split speed benchmark (startup / parse / loops / forks /
 # configure) vs bash --posix and dash, via pinned hyperfine runs, followed by
 # the peak-RSS dimension over the same workloads.
 # Reports land in bench/results.md; methodology in bench/METHODOLOGY.md.
-perf:
+perf:  ## Dimension-split hyperfine bench → bench/results.md
 	@/bin/bash bench/run.sh
 	@/bin/bash bench/lib/run_rss.sh
 
 # Peak-RSS dimension on its own (run.sh must have built bench/.bin/hellish).
-rss:
+rss:  ## Peak-RSS dimension alone (needs a prior make perf)
 	@/bin/bash bench/lib/run_rss.sh
 
 # Turn whatever harness output is on disk into bench/charts/*.svg (the images
@@ -841,7 +925,7 @@ rss:
 # it is safe to run after a single harness; run `make perf conformance bench`
 # first for a full set. Never re-runs a benchmark itself -- charting and
 # measuring stay separate so a chart can always be regenerated for free.
-charts:
+charts:  ## Regenerate bench/charts/*.svg from harness output on disk
 	@python3 bench/lib/collect_data.py
 	@python3 bench/lib/gen_charts.py
 	@python3 bench/lib/gen_matrix_chart.py
@@ -849,10 +933,10 @@ charts:
 # Run an external, configurable 42 "minishell tester" (geoman-style) against
 # the built binary, as an independent cross-check on top of `make test` and
 # `make conformance`. Override the repo with `make geoman GEOMAN_URL=...`.
-geoman: all
+geoman: all  ## External 42 minishell tester, as an independent cross-check
 	@/bin/bash bench/lib/run_geoman.sh
 
-.PHONY: test bench re all clean fclean norm my_shell help safe_banner \
+.PHONY: test bench re all clean fclean norm my_shell help help-targets safe_banner \
 	static static-verify \
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
 	docker-arch docker-fedora docker-rocky docker-opensuse docker-void \

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ active allocator so it's never a surprise.
 
 | Command | Optimization | Allocator | Sanitizers | Use it for |
 |---|---|---|---|---|
-| `make` | `-O0 -g3` | libc (`SAFE=1`) | ASan + LeakSanitizer | dev, debugging, leak hunts |
+| `make all` | `-O0 -g3` | libc (`SAFE=1`) | ASan + LeakSanitizer | dev, debugging, leak hunts |
 | `make OPT=1` | `-O3 -flto` | **`ft_malloc`** (`SAFE=0`) | none | speed, benchmarks, daily driving |
 | `make SAFE=0` | `-O0 -g3` | `ft_malloc` | ASan | the custom heap under a debugger |
 | `make OPT=1 SAFE=1` | `-O3 -flto` | libc | none | optimized build on the battle-tested heap |
@@ -287,7 +287,8 @@ An explicit `SAFE=…` on the command line always wins. libft compiles into a
 share objects — flip `SAFE`, get the right archive, not a stale one.
 
 ```sh
-make            # debug build  -> build/bin/hellish
+make            # what you can ask for — the self-documenting help page
+make all        # debug build  -> build/bin/hellish
 make OPT=1      # optimized build
 make re         # fclean + rebuild
 make test       # full suite: thousands of golden-diff cases vs bash --posix

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,11 +8,15 @@ shows you how to drive the shell.
 
 ---
 
-## v2.8.1
+## v2.7.2
 
-A portability release. No behaviour changes on Linux — every fix here is
-about hellish building and running correctly somewhere it previously did
-not, and about CI being able to tell you when it does not.
+Everything since v2.7.1, in one release. The bulk of it is portability:
+hellish now builds and runs on macOS (Apple Silicon) and inside WSL, both
+of which are covered by CI. On Linux nothing about the shell's behaviour
+changes.
+
+It also carries the `pretty` builtin and `shopt -s lithist`, which were
+finished earlier and never shipped on their own — see below.
 
 **Fixed**
 
@@ -61,9 +65,7 @@ not, and about CI being able to tell you when it does not.
 - The WSL rung builds on the distro's own filesystem rather than through
   the Windows bridge, where the same build could not finish inside an hour.
 
----
-
-## v2.8.0
+### Also here, from the issue-fixing work before it
 
 **Added**
 

--- a/bench/conformance.sh
+++ b/bench/conformance.sh
@@ -9,7 +9,7 @@ set -eu
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-make --no-print-directory OPT=1 >/dev/null
+make --no-print-directory all OPT=1 >/dev/null
 mkdir -p bench/.bin bench/.artifacts
 cp build/bin/hellish bench/.bin/hellish
 

--- a/bench/lib/run_geoman.sh
+++ b/bench/lib/run_geoman.sh
@@ -20,7 +20,7 @@ DEST="$ROOT/bench/suites/geoman"
 URL="${GEOMAN_URL:-https://github.com/zstenger93/42_minishell_tester}"
 
 if [ ! -x "$BIN" ]; then
-    echo "error: build hellish first (make OPT=1 or make)" >&2
+    echo "error: build hellish first (make all OPT=1, or make all)" >&2
     exit 2
 fi
 

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -66,7 +66,7 @@ cd "$ROOT"
 # (startup 15ms instead of 2.5ms) with no indication anything is wrong.
 # `make test` and `make bench` already rm the binary for exactly this reason.
 rm -f build/bin/hellish
-make --no-print-directory OPT=1 >/dev/null
+make --no-print-directory all OPT=1 >/dev/null
 # Belt and braces: if what we just built still links ASan, refuse to publish
 # timings from it rather than quietly producing a slow, wrong report.
 if ldd build/bin/hellish 2>/dev/null | grep -q asan; then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ ARG BUILD_FLAGS="OPT=1 SAFE=1"
 RUN make fclean >/dev/null 2>&1 || true; \
 	printf '\n=== building with %s on %s ===\n' "$CC" "$(uname -sm)"; \
 	$CC --version | head -1; \
-	make ${BUILD_FLAGS} CC=$CC; \
+	make all ${BUILD_FLAGS} CC=$CC; \
 	./build/bin/hellish -c 'echo "hellish built OK on $(uname -s) $(uname -m)"'
 
 ENV HELLISH_NO_UPDATE_CHECK=1 HELLISH_NO_BANNER=1

--- a/docker/Dockerfile.agnostic
+++ b/docker/Dockerfile.agnostic
@@ -28,7 +28,7 @@ COPY . .
 # Optimised, libc-allocator binary -- the same combination `make bench` times,
 # so the numbers here are the real hellish, not the ASan/debug build.
 RUN make fclean >/dev/null 2>&1 || true; \
-	make OPT=1 SAFE=1; \
+	make all OPT=1 SAFE=1; \
 	./build/bin/hellish -c 'echo "hellish built OK for the agnostic matrix"'
 
 ENV HELLISH_NO_UPDATE_CHECK=1 HELLISH_NO_BANNER=1

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -14,7 +14,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY . .
-RUN make fclean >/dev/null 2>&1 || true; make OPT=1 SAFE=1
+RUN make fclean >/dev/null 2>&1 || true; make all OPT=1 SAFE=1
 
 FROM debian:stable-slim
 LABEL org.opencontainers.image.title="hellish" \

--- a/docker/Dockerfile.static
+++ b/docker/Dockerfile.static
@@ -38,7 +38,7 @@ ARG BUILD_FLAGS="OPT=1 SAFE=1"
 # readline's own DT_NEEDED, a static one does not). EXTRA_* append to the
 # Makefile's computed flags instead of replacing them.
 RUN make fclean >/dev/null 2>&1 || true; \
-	make ${BUILD_FLAGS} EXTRA_LDFLAGS="-static" EXTRA_LDLIBS="-lncursesw"
+	make all ${BUILD_FLAGS} EXTRA_LDFLAGS="-static" EXTRA_LDLIBS="-lncursesw"
 
 # Prove it is actually static and actually works, in the image that built it,
 # so a dynamic binary fails the BUILD instead of failing on the user's machine.

--- a/docker/Dockerfile.suite
+++ b/docker/Dockerfile.suite
@@ -35,7 +35,7 @@ WORKDIR /hellish
 COPY . .
 
 ARG BUILD_FLAGS="OPT=1 SAFE=1"
-RUN make fclean >/dev/null 2>&1 || true; make ${BUILD_FLAGS}
+RUN make fclean >/dev/null 2>&1 || true; make all ${BUILD_FLAGS}
 
 ENV HELLISH_NO_UPDATE_CHECK=1 HELLISH_NO_BANNER=1 HELLISH_NO_ANIM=1
 

--- a/docker/Dockerfile.zsh
+++ b/docker/Dockerfile.zsh
@@ -20,7 +20,7 @@ COPY . .
 
 # Optimised, libc-allocator binary: the most portable combination.
 RUN make fclean >/dev/null 2>&1 || true; \
-	make OPT=1 SAFE=1; \
+	make all OPT=1 SAFE=1; \
 	./build/bin/hellish -c 'echo "hellish built OK for zsh-compare"'
 
 ENV HELLISH_NO_UPDATE_CHECK=1 HELLISH_NO_BANNER=1

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.8.1"
+# define HELLISH_VERSION "2.7.2"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/mk/colors.mk
+++ b/mk/colors.mk
@@ -1,0 +1,86 @@
+# **************************************************************************** #
+#                                                                              #
+#    mk/colors.mk — the palette libft's mk/functions.mk expects                 #
+#                                                                              #
+# **************************************************************************** #
+
+# Why this file exists instead of `include vendor/libft/mk/global_conf.mk`.
+#
+# The wrappers in libft's mk/functions.mk (log_ok, log_info, log_title, …) are
+# worth reusing, and this Makefile does include that file. Its colour palette
+# lives in global_conf.mk — and so do these:
+#
+#     CC       := cc
+#     OBJ_DIR  := obj
+#     RM       := rm -rf
+#     LDFLAGS  := $(DPDCS_STATIC)
+#     CFLAGS   ?= $(CSTD) $(WARN_FLAGS) $(DEBFLAGS) $(ANAFLAGS) $(DEFINES)
+#
+# Measured, not guessed: a Makefile whose only content is that include reports
+# `CC=cc OBJ_DIR=obj RM=rm -rf`. Every one of those is a variable this build
+# depends on, so including the file would couple hellish's *build* to a
+# sibling repo's defaults — an edit over there would silently change what gets
+# compiled here, and `RM := rm -rf` in particular turns every `$(RM)` in this
+# tree into a recursive delete.
+#
+# libft's mk/common.mk is worse for the purpose: it defines real targets
+# (`deps`, `ensure_lib_deps`, `build_tests`), and a target defined by an
+# include can become the default goal depending on include order.
+#
+# So: the wrappers come from libft, the palette is declared here, and the build
+# variables stay ours. The names below are exactly the ones functions.mk
+# references — if it grows a new colour, add it here.
+
+ESC          := $(shell printf '\033')
+
+RESET        := $(ESC)[0m
+BOLD         := $(ESC)[1m
+WHITE        := $(ESC)[0;37m
+
+BOLD_GREEN   := $(ESC)[1;32m
+BOLD_YELLOW  := $(ESC)[1;33m
+BOLD_MAGENTA := $(ESC)[1;35m
+BOLD_CYAN    := $(ESC)[1;36m
+BOLD_WHITE   := $(ESC)[1;37m
+
+BRIGHT_RED   := $(ESC)[1;31m
+BRIGHT_GREEN := $(ESC)[1;32m
+BRIGHT_YELLOW:= $(ESC)[1;33m
+BRIGHT_CYAN  := $(ESC)[1;36m
+
+DIM          := $(ESC)[2m
+GRAY         := $(ESC)[0;90m
+
+# functions.mk interpolates this one into every print_status/logging call. It
+# is commented out in libft's own global_conf.mk, so it expands to nothing
+# there; giving it a real value is the difference between a readable prefix and
+# a bare one.
+FADED_BOLD_GRAY := $(ESC)[1;2;37m
+
+# Honour NO_COLOR (https://no-color.org) and a non-tty stdout: a build log
+# scraped by CI should not be full of escape sequences, and grep should be able
+# to match what it sees.
+ifdef NO_COLOR
+COLOR_OFF := 1
+endif
+ifeq ($(shell test -t 1 || echo notty),notty)
+COLOR_OFF := 1
+endif
+ifdef COLOR_OFF
+ESC :=
+RESET :=
+BOLD :=
+WHITE :=
+BOLD_GREEN :=
+BOLD_YELLOW :=
+BOLD_MAGENTA :=
+BOLD_CYAN :=
+BOLD_WHITE :=
+BRIGHT_RED :=
+BRIGHT_GREEN :=
+BRIGHT_YELLOW :=
+BRIGHT_CYAN :=
+DIM :=
+GRAY :=
+FADED_BOLD_GRAY :=
+endif

--- a/mk/help.awk
+++ b/mk/help.awk
@@ -1,0 +1,52 @@
+# mk/help.awk — render `make help` from the Makefile's own annotations.
+#
+# A separate file rather than a make variable holding an awk program: that
+# program has to survive make expansion, then shell word-splitting, then awk
+# parsing, and $$0/$$1 plus nested quotes do not all come out the other side
+# intact. It cost one "Unterminated quoted string" to find that out. A file is
+# read by exactly one of those three, and can be linted on its own.
+#
+# Reads three annotations:
+#   ##@ Section            heading
+#   target: deps  ## text  target and description
+#   ##! NAME=value  text   configurable variable
+#
+# Colours arrive as -v so the palette stays in mk/colors.mk, which already
+# knows how to blank itself for NO_COLOR and non-tty output.
+
+# No FS split for target lines. `FS = ":.*## "` looks right and is greedy, so
+# it splits on the LAST "## " in the line -- a description that mentions "##"
+# (this file documents an annotation syntax, so several do) came out truncated
+# to its own tail. Found by `make help` printing "description (should print
+# none)" as the text for help-targets. index() from the colon is unambiguous.
+
+/^##@ / {
+	printf "\n%s%s%s\n", head, substr($0, 5), reset
+	next
+}
+
+# "NAME=value  description" -- split on the first DOUBLE space so a value may
+# contain single spaces (OPT=1 SAFE=0) without being mistaken for prose.
+/^##! / {
+	line = substr($0, 5)
+	gap = index(line, "  ")
+	if (gap == 0) { name = line; desc = "" }
+	else {
+		name = substr(line, 1, gap - 1)
+		desc = substr(line, gap + 2)
+		sub(/^ +/, "", desc)
+	}
+	printf "  %s%-24s%s %s\n", var, name, reset, desc
+	next
+}
+
+# A target line carrying a description. Anything without one is invisible
+# here; `make help-targets` is what reports those.
+/^[a-zA-Z0-9_.-]+:.*## / {
+	colon = index($0, ":")
+	rest = substr($0, colon + 1)
+	mark = index(rest, "## ")
+	if (mark == 0) next
+	printf "  %s%-24s%s %s\n", tgt, substr($0, 1, colon - 1), reset, \
+	       substr(rest, mark + 3)
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.8.1",
+  "version": "2.7.2",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd /home/dylan/sh42
 touch src/parsing/compound_list.c
-make 2>&1 | tee /tmp/make_out.txt
+make all 2>&1 | tee /tmp/make_out.txt
 echo "BUILD_EXIT:$?"

--- a/tests/verify_alloc.sh
+++ b/tests/verify_alloc.sh
@@ -47,7 +47,7 @@ SCRIPTS=("$TESTS"/scripts/*.sh "$TESTS"/hard/[0-9]*.sh "$TESTS"/level*.sh)
 strip() { sed 's/\x1b\[[0-9;]*[A-Za-z]//g' | grep -vE '^[[:space:]]*❯' | grep -v '^exit$'; }
 
 build() { # $1=SAFE  $2=make-args
-	( cd "$ROOT" && rm -f build/bin/hellish && make $2 SAFE="$1" >/dev/null 2>&1 )
+	( cd "$ROOT" && rm -f build/bin/hellish && make all $2 SAFE="$1" >/dev/null 2>&1 )
 	[ -f "$BIN" ] || { echo "  BUILD FAILED (SAFE=$1 $2)"; exit 1; }
 }
 

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -5,7 +5,7 @@ later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**. Released version: **2.8.1**.
+Branch to resume from: **`develop`**. Released version: **2.7.2**.
 
 The previous note on this file covered the issue-fixing session (#27, #32,
 #34, #42 and friends). All of those are closed; the tracker is empty. This
@@ -210,10 +210,12 @@ This keeps happening and is worth naming as a class.
    smoke reached 39/40; the last gap is fixed but has not yet been confirmed
    green on a real runner. Do not flip the flag until it has — a red required
    check that everyone learns to ignore is worse than an informational one.
-2. **`v2.8.1` is not tagged.** The version is bumped, the notes are written,
-   `make update-config-test` is green. Tagging fires `release.yml` and
-   `ghcr.yml` — GitHub Releases, npm, GHCR — and is the one step here that
-   cannot be walked back. It was deliberately left for a human.
+2. **The version line is 2.7.x, not 2.8.x.** `2.8.0` and `2.8.1` exist in
+   git history and were never tagged, so nothing ever shipped under those
+   numbers; both were folded into a single **`v2.7.2`** release. Worth
+   knowing if you find the old numbers in a commit message — they are not
+   releases anyone can have installed. (Strict semver would have called the
+   `pretty` builtin a minor bump; the owner chose to continue the 2.7 line.)
 3. **Docker Hub secrets** are still unset; that channel of `release.yml`
    will no-op or fail. Set them or drop the channel.
 4. **`tests/test_files/invalid_permission`** shows as permanently modified

--- a/wiki/platforms.md
+++ b/wiki/platforms.md
@@ -94,7 +94,7 @@ strictly iterative — **six** defects so far, each one only visible once the
 one before it was fixed, and every round trip costs a CI queue. In order:
 `st_mtim`, `SIGPWR`/`SIGRTMIN`, `bcopy`, `MB_CUR_MAX`, then a link hole
 that had nothing to do with Darwin, then `/proc/self/exe`, then this
-header collision. As of 2.8.1 the build succeeds and the smoke reached
+header collision. As of 2.7.2 the build succeeds and the smoke reached
 **39 ok / 1 failed**, that one being `/proc/self/exe`. All known gaps are
 now closed:
 


### PR DESCRIPTION
## 2.7.2 — the release `main` never actually got

`main` has been carrying `2.8.1` since #48. The renumber to **2.7.2** landed on `develop` afterwards and was never merged back, so the published branch held a version that was never meant to ship and no tag existed at all. This fixes that.

### Why 2.7.2 and not 2.8.x

`2.8.0` and `2.8.1` exist in commit messages and nowhere else — never tagged, never released, so nobody can have them installed. Renumbering costs nothing and keeps the published sequence contiguous after v2.7.1. Strict semver would call the `pretty` builtin a minor bump; continuing the 2.7 line is the owner's call and the practical cost is nil.

### What is in it

Everything since v2.7.1: the cross-platform work (macOS arm64 and WSL both green for the first time), plus the `pretty` builtin and `shopt -s lithist` that were finished earlier and never shipped on their own.

### Also: `make` is now self-documenting

`make` prints a generated help page — 60 targets in 7 sections plus 11 configurable variables, read out of the Makefile's own `##@` / `##` / `##!` annotations. `make help-targets` reports anything undocumented and exits 1.

**The cost is paid in full here.** Anything wanting a build must now say `all`, and **14 call sites did not**: the macOS and WSL rungs, six Dockerfiles, `tests/build.sh`, `tests/verify_alloc.sh`, `bench/run.sh`, `bench/conformance.sh`, a help message, and one `$(MAKE)` inside the Makefile. Without that half every container build would have become a no-op that prints help and exits 0 — green, shipping nothing. Verified by building the alpine image for real (`hellish built OK`, smoke 40/40) and confirming that a bare `make` *inside* that container now prints help.

libft's `mk/functions.mk` supplies the logging wrappers, as intended. Its `global_conf.mk` is deliberately **not** included — measured, not guessed: a Makefile containing only that include reports `CC=cc OBJ_DIR=obj RM=rm -rf`, and `RM := rm -rf` alone would turn every `$(RM)` here into a recursive delete. `mk/colors.mk` records that reasoning.

### Verified

CI 39/39 on c872c77 · golden 3790/3790 · pty 21/21 · smoke 40/40 on Linux **and** macOS · norminette clean · `make update-config-test` green · all 63 targets dry-run clean · real Docker build + smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)