### PR TITLE
chore(release): 2.7.3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,78 @@ shows you how to drive the shell.
 
 ---
 
+## v2.7.3
+
+A bug-fix release: two issues reported from real machines, both on the path
+between installing hellish and getting a usable prompt. Nothing else changes.
+
+**Fixed**
+
+- **The prompt's process tracker is back** (#50). The built-in prompt shows
+  a background-jobs badge — ` ⚙N` — on its info row, next to `took N.Ns`
+  after a slow command. Both silently disappeared in 2.7.0 and neither was
+  coming back on its own.
+
+  The prompt keeps mirrors of the process state, because it is also
+  repainted from a timer between commands with no shell state in hand. The
+  refresh sat below an early return that only became reachable-from-nowhere
+  when 2.7.0 gave interactive shells a default `PS1` of `\B` (so a Python
+  virtualenv could restore it, #39). From that release every shell took the
+  early return, the mirrors stayed frozen at zero, and both badges rendered
+  as nothing at all. If you never set your own `PS1`, this is the release
+  that gives them back.
+
+- **`make my_shell` now creates `~/.hellishrc`** (#51). It never did. The
+  seeding lived inside `user-install.sh`, so only the no-sudo route ever ran
+  it, and anyone who installed with `make my_shell` met a shell with no
+  config at all — no `EDITOR`, no aliases, no prompt theme — and no hint one
+  was meant to exist. Both routes now call `tools/seed_hellishrc.sh`, which
+  still never touches an rc you already have.
+
+- **`shopt -o` stopped ignoring its arguments** (#51). `-o` selects the
+  `set -o` roster; it was being parsed as an *action*, so the names, the
+  `-q` and the `-p` were all discarded. Ubuntu's stock `~/.bashrc` asks
+
+      if ! shopt -oq posix; then ... fi
+
+  which dumped all 27 option lines onto the screen at every login **and**
+  returned success regardless of the setting — so the branch was decided
+  wrongly, not merely loudly. `shopt -o NAME`, `-op`, `-oq`, `-so` and
+  `-uo` now match bash byte for byte, including its distinct
+  "invalid option name" rejection.
+
+- **`shopt -q progcomp` no longer errors on every login** (#51).
+  `/etc/profile.d/bash_completion.sh` probes it, and hellish did not know
+  the name, so each login opened with
+  `hellish: shopt: progcomp: invalid shell option name`. It is now a known
+  option that is **off** — hellish has no `complete` builtin, so there is no
+  programmable completion to enable, and reporting it honestly is also what
+  makes bash-completion correctly skip itself instead of feeding hellish a
+  2500-line bash script.
+
+**Changed**
+
+- **`hellishrc.example` no longer edits `PATH`.** It shipped an active
+  `case ":$PATH:" ... esac` prepend of `~/.local/bin` that the login chain
+  had already done moments earlier — a login hellish sources `/etc/profile`
+  and then `~/.profile`, and on Debian/Ubuntu `~/.profile` is exactly what
+  adds `~/.local/bin` and `~/bin`. Redundant, and it read as the pattern you
+  were meant to copy. It is now a commented example with the reasoning
+  attached. Your own `~/.hellishrc` is never rewritten, so nothing changes
+  under you; this only affects a freshly seeded one.
+
+**Tests**
+
+Four new regression files, all picked up automatically by the pty suite:
+`prompt_jobs_badge_test.py` (the badge on all three prompt routes),
+`shopt_setopt_test.py` (every `-o` form against bash),
+`login_chain_test.py` (a real login against Ubuntu's stock dotfiles, in a
+sandbox so CI runners without those files agree), and
+`hellishrc_seed_test.py` (seeds when absent, never clobbers, and both
+install routes still call the seeder).
+
+---
+
 ## v2.7.2
 
 Everything since v2.7.1, in one release. The bulk of it is portability:

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.7.2"
+# define HELLISH_VERSION "2.7.3"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -5,7 +5,7 @@ later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**. Released version: **2.7.2**.
+Branch to resume from: **`develop`**. Released version: **2.7.3**.
 
 The previous note on this file covered the issue-fixing session (#27, #32,
 #34, #42 and friends). All of those are closed; the tracker is empty. This


### PR DESCRIPTION
Cuts **v2.7.3** on top of the two issue fixes already on `develop`.

| | |
|---|---|
| #50 | the built-in prompt's process tracker (`⚙N`) and duration badge, gone since 2.7.0 shipped a default `PS1` and stranded the state refresh behind an early return that was suddenly always taken — PR #52 |
| #51 | `make my_shell` never seeded `~/.hellishrc`; `shopt -o` discarded its names, `-q` and `-p`, so Ubuntu's stock `~/.bashrc` dumped the option table at every login and read the wrong status back; `shopt -q progcomp` errored on every login — PR #53 |

**Patch, not minor.** No new builtin, no new option, no interface added. The one
user-visible change beyond the fixes: a freshly seeded `hellishrc.example` no
longer prepends `~/.local/bin` to PATH, which the login chain had already done.
An existing `~/.hellishrc` is never rewritten, so nobody's config moves under them.

Bumped together, as the release checklist requires: `incs/version.h`,
`npm/package.json`, `RELEASE.md`, `wiki/context.md`.

- `make update-config-test` — 0 failed
- the binary reports `hellish, version 2.7.3`

Tagging `v2.7.3` fires `release.yml` and `ghcr.yml` and is left for a human, per
`wiki/context.md`.
