### PR TITLE
Release 2.7.3 — the prompt's process tracker, and a clean login chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,7 +497,14 @@ norm:  ## 42 norminette over src/ incs/ tests/ (reports only, always exits 0)
 
 
 # Install as the login shell. This is the binary you live in, so it is rebuilt
-# optimized AND safe (OPT=1 SAFE=1 -> libc allocator) by default. You may force
+# optimized AND safe (OPT=1 SAFE=1 -> libc allocator) by default.
+#
+# It also seeds ~/.hellishrc, which it used not to: the seeding lived inside
+# user-install.sh, so this route installed a binary and stopped, and the
+# first thing you met was a shell with no config -- no EDITOR, no aliases,
+# no PS1 (issue #51). Both routes now call tools/seed_hellishrc.sh, which
+# never touches an rc you already have. It runs BEFORE chsh: the config
+# should be in place before anything can log you into the new shell. You may force
 # the custom heap with `make my_shell SAFE=0`, but then stability is on you.
 # Which binary gets installed. STATIC=1 takes the container-built static one
 # from dist/ instead of compiling here -- the "build it in docker, then run it
@@ -515,6 +522,8 @@ my_shell:  ## sudo-install to /usr/bin and register as a login shell
 	fi
 	@echo "Installing hellish shell from $(MY_SHELL_BIN)..."
 	sudo install -m 755 $(MY_SHELL_BIN) /usr/bin/hellish
+	@echo "Seeding your config..."
+	@./tools/seed_hellishrc.sh
 	@echo "Registering shell..."
 	./vendor/scripts/register_shell.sh
 	@echo "Done. Log out and log back in to use hellish as your default shell."

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,78 @@ shows you how to drive the shell.
 
 ---
 
+## v2.7.3
+
+A bug-fix release: two issues reported from real machines, both on the path
+between installing hellish and getting a usable prompt. Nothing else changes.
+
+**Fixed**
+
+- **The prompt's process tracker is back** (#50). The built-in prompt shows
+  a background-jobs badge — ` ⚙N` — on its info row, next to `took N.Ns`
+  after a slow command. Both silently disappeared in 2.7.0 and neither was
+  coming back on its own.
+
+  The prompt keeps mirrors of the process state, because it is also
+  repainted from a timer between commands with no shell state in hand. The
+  refresh sat below an early return that only became reachable-from-nowhere
+  when 2.7.0 gave interactive shells a default `PS1` of `\B` (so a Python
+  virtualenv could restore it, #39). From that release every shell took the
+  early return, the mirrors stayed frozen at zero, and both badges rendered
+  as nothing at all. If you never set your own `PS1`, this is the release
+  that gives them back.
+
+- **`make my_shell` now creates `~/.hellishrc`** (#51). It never did. The
+  seeding lived inside `user-install.sh`, so only the no-sudo route ever ran
+  it, and anyone who installed with `make my_shell` met a shell with no
+  config at all — no `EDITOR`, no aliases, no prompt theme — and no hint one
+  was meant to exist. Both routes now call `tools/seed_hellishrc.sh`, which
+  still never touches an rc you already have.
+
+- **`shopt -o` stopped ignoring its arguments** (#51). `-o` selects the
+  `set -o` roster; it was being parsed as an *action*, so the names, the
+  `-q` and the `-p` were all discarded. Ubuntu's stock `~/.bashrc` asks
+
+      if ! shopt -oq posix; then ... fi
+
+  which dumped all 27 option lines onto the screen at every login **and**
+  returned success regardless of the setting — so the branch was decided
+  wrongly, not merely loudly. `shopt -o NAME`, `-op`, `-oq`, `-so` and
+  `-uo` now match bash byte for byte, including its distinct
+  "invalid option name" rejection.
+
+- **`shopt -q progcomp` no longer errors on every login** (#51).
+  `/etc/profile.d/bash_completion.sh` probes it, and hellish did not know
+  the name, so each login opened with
+  `hellish: shopt: progcomp: invalid shell option name`. It is now a known
+  option that is **off** — hellish has no `complete` builtin, so there is no
+  programmable completion to enable, and reporting it honestly is also what
+  makes bash-completion correctly skip itself instead of feeding hellish a
+  2500-line bash script.
+
+**Changed**
+
+- **`hellishrc.example` no longer edits `PATH`.** It shipped an active
+  `case ":$PATH:" ... esac` prepend of `~/.local/bin` that the login chain
+  had already done moments earlier — a login hellish sources `/etc/profile`
+  and then `~/.profile`, and on Debian/Ubuntu `~/.profile` is exactly what
+  adds `~/.local/bin` and `~/bin`. Redundant, and it read as the pattern you
+  were meant to copy. It is now a commented example with the reasoning
+  attached. Your own `~/.hellishrc` is never rewritten, so nothing changes
+  under you; this only affects a freshly seeded one.
+
+**Tests**
+
+Four new regression files, all picked up automatically by the pty suite:
+`prompt_jobs_badge_test.py` (the badge on all three prompt routes),
+`shopt_setopt_test.py` (every `-o` form against bash),
+`login_chain_test.py` (a real login against Ubuntu's stock dotfiles, in a
+sandbox so CI runners without those files agree), and
+`hellishrc_seed_test.py` (seeds when absent, never clobbers, and both
+install routes still call the seeder).
+
+---
+
 ## v2.7.2
 
 Everything since v2.7.1, in one release. The bulk of it is portability:

--- a/hellishrc.example
+++ b/hellishrc.example
@@ -73,20 +73,26 @@ export EDITOR=vim
 export PAGER=less
 export LESS='-R'        # let pagers pass ANSI colors through
 
-# PATH. A LOGIN hellish (chsh, or --login) sources /etc/profile — and so
-# the .sh snippets in /etc/profile.d, which is where your distro adds
-# things like /snap/bin — and then ~/.profile, before it gets here. So the
-# PATH you had under bash carries over; you do not need to rebuild it.
-# What you still add by hand is anything you only want under hellish.
-# The case guard makes each addition idempotent: this file is re-sourced
-# by every nested interactive hellish, and an unguarded prepend would
-# stack a fresh copy each time until PATH is mostly duplicates.
-case ":$PATH:" in
-	*":$HOME/.local/bin:"*) ;;
-	*) export PATH="$HOME/.local/bin:$PATH" ;;
-esac
-
-# Same shape for anything else you keep outside the system prefixes:
+# PATH — deliberately NOT set here, and that is the whole point.
+#
+# A LOGIN hellish (chsh, or --login) sources /etc/profile — and so the .sh
+# snippets in /etc/profile.d, which is where your distro adds things like
+# /snap/bin — and then ~/.profile, which on Debian/Ubuntu is what puts
+# ~/.local/bin and ~/bin on PATH. All of that runs BEFORE this file. The
+# PATH you had under bash carries over whole; there is nothing to rebuild.
+#
+# This file used to ship an active prepend of ~/.local/bin anyway, which
+# the login chain had already done a moment earlier. Redundant, and worse:
+# it read as the pattern you were meant to follow, so PATH edits got
+# copy-pasted in over and over (issue #51). Your ~/.bashrc does not need a
+# block like this to work, and neither does this file.
+#
+# You only need a line here for a directory your login chain does NOT
+# already cover, or one you want under hellish and nowhere else. If you do
+# add one, keep the case guard: this file is re-sourced by every nested
+# interactive hellish, and an unguarded prepend stacks a fresh copy each
+# time until PATH is mostly duplicates.
+#
 # case ":$PATH:" in
 #	*":$HOME/.cargo/bin:"*) ;;
 #	*) export PATH="$HOME/.cargo/bin:$PATH" ;;

--- a/incs/shell.h
+++ b/incs/shell.h
@@ -335,6 +335,11 @@ typedef struct s_shell
 # define SHOPT_AUTOCD 0x100
 # define SHOPT_CDSPELL 0x200
 # define SHOPT_LITHIST 0x400
+/* progcomp is KNOWN but off, and stays off: hellish has no `complete`
+   builtin, so there is no programmable completion to switch on. It is
+   here so /etc/profile.d/bash_completion.sh's `shopt -q progcomp` gets a
+   truthful "no" instead of an error on every login -- issue #51. */
+# define SHOPT_PROGCOMP 0x800
 
 /* Directory matcher ctx for glob expansion */
 typedef struct s_dir_matcher

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.7.2"
+# define HELLISH_VERSION "2.7.3"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/builtins/builtin_shopt.c
+++ b/src/builtins/builtin_shopt.c
@@ -30,7 +30,8 @@ static unsigned int	shopt_bit(const char *name)
 	{"extglob", SHOPT_EXTGLOB}, {"lastpipe", SHOPT_LASTPIPE},
 	{"histappend", SHOPT_HISTAPPEND}, {"checkwinsize", SHOPT_CHECKWINSIZE},
 	{"autocd", SHOPT_AUTOCD}, {"cdspell", SHOPT_CDSPELL},
-	{"lithist", SHOPT_LITHIST}, {NULL, 0}};
+	{"lithist", SHOPT_LITHIST}, {"progcomp", SHOPT_PROGCOMP},
+	{NULL, 0}};
 	int							i;
 
 	i = 0;
@@ -98,7 +99,7 @@ static int	shopt_print_all(t_shell *state, char act, int quiet)
 {
 	static const char *const	names[] = {"autocd", "cdspell",
 		"checkwinsize", "dotglob", "extglob", "globstar", "histappend",
-		"lastpipe", "lithist", "nocaseglob", "nullglob", NULL};
+		"lastpipe", "lithist", "nocaseglob", "nullglob", "progcomp", NULL};
 	int							i;
 
 	i = 0;
@@ -109,22 +110,34 @@ static int	shopt_print_all(t_shell *state, char act, int quiet)
 
 /* `shopt -o` addresses the `set -o` options, not shopt's own -- bash
    documents it as "restrict to option names defined for set -o", which is
-   why `shopt -o` and `set -o` print the same table. hellish listed its
-   shopt names there instead, so a script asking about `allexport` got an
-   answer about `autocd`. list_set_options already renders that table for
-   `set -o`, so this is a delegation, not a second copy. */
+   why bare `shopt -o` and bare `set -o` print the same table. hellish
+   listed its shopt names there instead, so a script asking about
+   `allexport` got an answer about `autocd`.
+
+   -o is a SCOPE, not an action, and that distinction is the bug behind
+   issue #51. It used to be parsed as one of the actions, so it lost every
+   argument that came with it: `shopt -oq posix` -- which is how Ubuntu's
+   stock ~/.bashrc asks whether posix mode is on -- dumped all 27 option
+   lines to the screen at login and returned 0 no matter the setting, and
+   `shopt -op posix` was read as a bare -p that then rejected "posix" as an
+   unknown shopt name. It now rides alongside act and quiet, and
+   shopt_setopt() applies the same action rules to the set -o roster. */
 int	builtin_shopt(t_shell *state, t_vec argv)
 {
 	char	act;
 	int		quiet;
+	int		use_o;
 	size_t	i;
 	int		rc;
 
 	act = 0;
 	quiet = 0;
-	i = shopt_flags(argv, &act, &quiet);
-	if (act == 'o')
+	use_o = 0;
+	i = shopt_flags(argv, &act, &quiet, &use_o);
+	if (use_o && i >= argv.len)
 		return (list_set_options(state));
+	if (use_o)
+		return (shopt_setopt(state, argv, i, (t_shopt_act){act, quiet}));
 	if (i >= argv.len)
 		return (shopt_print_all(state, act, quiet));
 	rc = 0;

--- a/src/builtins/builtin_shopt2.c
+++ b/src/builtins/builtin_shopt2.c
@@ -19,8 +19,15 @@
    just the first: -q is a MODIFIER that combines freely with the action
    flags, so `shopt -qs extglob` means "set it, quietly" and used to be
    parsed as a bare -q (a query) because only argv[i][1] was inspected.
-   That made it report failure on an option it had just switched on. */
-size_t	shopt_flags(t_vec argv, char *act, int *quiet)
+   That made it report failure on an option it had just switched on.
+
+   -o is the same shape of mistake and cost issue #51 a noisy login: it is
+   a SCOPE ("read these names off the set -o roster"), not an action, so it
+   gets its own out-parameter. Sharing `act` meant the last letter of a
+   cluster won -- `shopt -op posix` parsed as a bare -p, which then rejected
+   "posix" as an unknown shopt name -- and that `shopt -oq posix` could not
+   keep both its scope and its -q. */
+size_t	shopt_flags(t_vec argv, char *act, int *quiet, int *use_o)
 {
 	size_t	i;
 	size_t	j;
@@ -34,11 +41,61 @@ size_t	shopt_flags(t_vec argv, char *act, int *quiet)
 		{
 			if (((char **)argv.ctx)[i][j] == 'q')
 				*quiet = 1;
-			else if (ft_strchr("supo", ((char **)argv.ctx)[i][j]))
+			else if (((char **)argv.ctx)[i][j] == 'o')
+				*use_o = 1;
+			else if (ft_strchr("sup", ((char **)argv.ctx)[i][j]))
 				*act = ((char **)argv.ctx)[i][j];
 			j++;
 		}
 		i++;
 	}
 	return (i);
+}
+
+/* One name under `shopt -o`. The action rules are the same ones shopt_one
+   applies to shopt's own names, against the set -o roster instead: -s and
+   -u report whether the CHANGE succeeded (always 0 here, the roster has no
+   read-only entries), while -q and the print forms report the SETTING, so
+   `shopt -oq posix` is 1 while posix mode is off. That status is the whole
+   point of the call -- Ubuntu's stock ~/.bashrc branches on it.
+
+   bash words the rejection differently for this form ("invalid option
+   name", without the "shell" the plain form uses), and the difference is
+   load-bearing: it is how a script tells "no such set -o option" apart
+   from "no such shopt option". */
+static int	shopt_setopt_one(t_shell *state, const char *name, t_shopt_act a)
+{
+	const t_setopt	*e;
+	bool			on;
+
+	e = setopt_find(name, 0);
+	if (!e)
+		return (ft_eprintf("%s: shopt: %s: invalid option name\n",
+				state->ctx, name), 1);
+	if (a.act == 's' || a.act == 'u')
+		return (setopt_put(state, e, a.act == 's'), 0);
+	on = setopt_get(state, e);
+	if (!a.quiet && a.act == 'p' && on)
+		ft_printf("set -o %s\n", name);
+	else if (!a.quiet && a.act == 'p')
+		ft_printf("set +o %s\n", name);
+	else if (!a.quiet && on)
+		ft_printf("%-15s\ton\n", name);
+	else if (!a.quiet)
+		ft_printf("%-15s\toff\n", name);
+	return (!on);
+}
+
+/* Every name after `shopt -o ...`. One bad name does not stop the rest --
+   bash reports each and returns failure once, so a probe over several
+   options still answers for the ones it knows. */
+int	shopt_setopt(t_shell *state, t_vec argv, size_t i, t_shopt_act a)
+{
+	int	rc;
+
+	rc = 0;
+	while (i < argv.len)
+		if (shopt_setopt_one(state, ((char **)argv.ctx)[i++], a))
+			rc = 1;
+	return (rc);
 }

--- a/src/builtins/builtins_private.h
+++ b/src/builtins/builtins_private.h
@@ -242,7 +242,18 @@ void	ulimit_show(const t_ulim *u, int hard, int with_label);
 int		ulimit_set(t_shell *st, const t_ulim *u, char *v, int hard);
 
 int		list_set_options(t_shell *state);
-size_t	shopt_flags(t_vec argv, char *act, int *quiet);
+/* shopt's action ('s' set, 'u' unset, 'p' print reusable, 0 print plain)
+   travelling with its -q modifier. Bundled because -o handling needs both
+   alongside state, argv and the argument index, and the norm allows a
+   function four parameters. */
+typedef struct s_shopt_act
+{
+	char	act;
+	int		quiet;
+}	t_shopt_act;
+
+size_t	shopt_flags(t_vec argv, char *act, int *quiet, int *use_o);
+int		shopt_setopt(t_shell *state, t_vec argv, size_t i, t_shopt_act a);
 
 /* wait plumbing shared between builtin_proc.c and builtin_proc2.c */
 int		reaped_job_status(t_shell *state, pid_t pid);

--- a/src/infrastructure/prompt.c
+++ b/src/infrastructure/prompt.c
@@ -126,15 +126,32 @@ static void	maybe_bench(void)
 	fprintf(stderr, "[prompt-bench] %lld ns/render\n", i / 1000);
 }
 
-/* Build the primary prompt for an interactive read. A user-set PS1 (from
+/* Snapshot the process state the prompt reports on: the last command's
+   status, how long it ran, and how many background jobs are alive. The
+   built-in prompt reads these mirrors rather than the shell state -- the
+   animation repaints its rows between commands, from a timer, with no
+   t_shell in hand -- so they have to be refreshed on EVERY route into the
+   prompt, not just one of them.
+
+   That is the bug this function had. The refresh used to sit below the
+   `if (ps1 && *ps1)` early return, on the PS1-is-unset path, which was
+   fine until 5b6d3d4 gave interactive shells a default PS1 of "\B" (so a
+   virtualenv could restore it, issue #39). From that release the early
+   return was always taken, the mirrors stayed frozen at zero, and the
+   built-in prompt lost the two badges that read them: the background-jobs
+   tracker " \u2699N" and "took N.Ns" -- issue #50. \B renders the same prompt
+   through the same render_extras(), so hoisting the refresh above the
+   branch is what makes both routes agree.
+
+   Build the primary prompt for an interactive read. A user-set PS1 (from
    ~/.hellishrc or the environment) takes over completely, rendered with
    the bash escape set — the built-in two-row prompt is simply the theme
-   you get when PS1 is unset. Otherwise: the frame counter advances only
-   when HELLISH_ANIM selects a live style, so the default prompt is
-   perfectly still and each readline call redraws the SAME glyph; the
-   status is
-   snapshotted before rendering so the arrow colour reflects the command
-   that just finished, not a half-updated value. */
+   you get when PS1 is unset, and "\B" asks for it by name. Otherwise: the
+   frame counter advances only when HELLISH_ANIM selects a live style, so
+   the default prompt is perfectly still and each readline call redraws the
+   SAME glyph; the status is snapshotted before rendering so the arrow
+   colour reflects the command that just finished, not a half-updated
+   value. */
 t_string	prompt_normal(t_shell *state)
 {
 	t_string	ret;
@@ -144,17 +161,17 @@ t_string	prompt_normal(t_shell *state)
 	ensure_locale();
 	maybe_bench();
 	anim_cells()->count = 0;
+	status = state->last_cmd_st_exe.status;
+	*anim_status() = status;
+	*anim_dur_ms() = state->last_cmd_ms;
+	*anim_jobs() = state->job_table.count;
 	ps1 = env_expand(state, "PS1");
 	if (ps1 && *ps1)
 		return (ps1_animated(state, ps1));
 	vec_init(&ret);
 	ret.elem_size = 1;
-	status = state->last_cmd_st_exe.status;
 	if (anim_style(state) != 0)
 		(*anim_frame())++;
-	*anim_status() = status;
-	*anim_dur_ms() = state->last_cmd_ms;
-	*anim_jobs() = state->job_table.count;
 	render_prompt(state, &ret, *anim_frame(), status);
 	return (ret);
 }

--- a/tests/hellishrc_seed_test.py
+++ b/tests/hellishrc_seed_test.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Regression test: every install route seeds ~/.hellishrc -- issue #51.
+
+The report opens with "I tried to do the command make my_shell ... First
+the ~/.hellishrc hasn't been created". It had not, and nothing was going
+to create it: the seeding lived inline in user-install.sh, so the sudo
+route (`make my_shell` -> install to /usr/bin + chsh) installed a binary
+and stopped there. A user who took that route got a shell with no config
+file -- no EDITOR, no aliases, no PS1 -- and no hint that one was meant to
+exist.
+
+The seeding is now tools/seed_hellishrc.sh, called by both routes, and
+this pins the three behaviours that matter:
+
+  * absent   -> seeded from hellishrc.example, byte for byte
+  * present  -> NEVER clobbered; the file is the user's, and re-running an
+                installer must not eat a config they have edited
+  * example missing -> warn and succeed; a missing template is not a
+                reason for an install to fail
+
+plus the wiring itself, because a seeder nobody calls is the bug we just
+fixed. `make my_shell` needs sudo and chsh and so cannot run in CI, so the
+recipe is asserted to invoke the seeder rather than executed.
+
+Usage: python3 hellishrc_seed_test.py [/path/to/hellish]   (shell unused)
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SEEDER = os.path.join(ROOT, "tools", "seed_hellishrc.sh")
+EXAMPLE = os.path.join(ROOT, "hellishrc.example")
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def seed(home, example=EXAMPLE):
+    """Run the seeder against a throwaway HOME."""
+    env = dict(os.environ)
+    env["HOME"] = home
+    return subprocess.run(["sh", SEEDER, "--example", example],
+                          capture_output=True, text=True, env=env,
+                          timeout=30)
+
+
+def main():
+    check("tools/seed_hellishrc.sh exists", os.path.isfile(SEEDER),
+          "no seeder at %s" % SEEDER)
+    if not os.path.isfile(SEEDER):
+        print("\n%d checks failed" % len(FAILS))
+        sys.exit(1)
+    check("the seeder is a valid shell script",
+          subprocess.run(["sh", "-n", SEEDER]).returncode == 0)
+
+    # 1. absent -> seeded, and identical to the template.
+    home = tempfile.mkdtemp()
+    try:
+        p = seed(home)
+        rc_path = os.path.join(home, ".hellishrc")
+        check("absent: the seeder succeeds", p.returncode == 0,
+              "rc=%d %r" % (p.returncode, p.stderr[:200]))
+        check("absent: ~/.hellishrc is created", os.path.isfile(rc_path))
+        if os.path.isfile(rc_path):
+            with open(rc_path) as f:
+                got = f.read()
+            with open(EXAMPLE) as f:
+                want = f.read()
+            check("absent: it is hellishrc.example byte for byte",
+                  got == want, "%d bytes vs %d" % (len(got), len(want)))
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+    # 2. present -> untouched. The strongest guarantee here: someone who
+    #    has customised their rc must be able to re-run any installer.
+    home = tempfile.mkdtemp()
+    try:
+        rc_path = os.path.join(home, ".hellishrc")
+        mine = "# my own rc, do not eat\nalias hi='echo hi'\n"
+        with open(rc_path, "w") as f:
+            f.write(mine)
+        p = seed(home)
+        check("present: the seeder still succeeds", p.returncode == 0,
+              "rc=%d" % p.returncode)
+        with open(rc_path) as f:
+            check("present: the existing rc is untouched", f.read() == mine,
+                  "the seeder overwrote a user's config")
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+    # 3. no template -> warn, do not fail, do not create an empty file.
+    home = tempfile.mkdtemp()
+    try:
+        p = seed(home, example=os.path.join(home, "nope.example"))
+        check("no template: the seeder does not fail the install",
+              p.returncode == 0, "rc=%d" % p.returncode)
+        check("no template: no empty ~/.hellishrc is left behind",
+              not os.path.exists(os.path.join(home, ".hellishrc")))
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+    # 4. both install routes actually call it.
+    with open(os.path.join(ROOT, "Makefile")) as f:
+        mk = f.read()
+    target = mk.split("\nmy_shell:", 1)[-1].split("\n\n", 1)[0]
+    check("make my_shell calls the seeder", "seed_hellishrc.sh" in target,
+          "the sudo route still installs a shell with no config")
+    with open(os.path.join(ROOT, "user-install.sh")) as f:
+        check("user-install.sh calls the seeder",
+              "seed_hellishrc.sh" in f.read(),
+              "the two routes have drifted apart again")
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/login_chain_test.py
+++ b/tests/login_chain_test.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Regression test: a login shell's startup chain -- issue #51.
+
+The report is `make my_shell` on Ubuntu 24: chsh to hellish, log in, and
+the session opens with errors and a PATH the user did not trust, which is
+why they ended up hand-rolling
+
+    case ":$PATH:" in
+        *":$HOME/.local/bin:"*) ;;
+        *) export PATH="$HOME/.local/bin:$PATH" ;;
+    esac
+
+into their rc three times over. They were right that it should not be
+necessary: a LOGIN hellish sources /etc/profile and then ~/.profile, and on
+Debian/Ubuntu ~/.profile is exactly what puts ~/.local/bin and ~/bin on
+PATH. The chain was working; the noise around it made it look like it was
+not.
+
+The noise was two shopt probes in stock dotfiles (see
+shopt_setopt_test.py for the unit-level pinning of both):
+
+    /etc/profile.d/bash_completion.sh:  shopt -q progcomp
+    ~/.bashrc (Ubuntu skel):            if ! shopt -oq posix; then
+
+which printed "shopt: progcomp: invalid shell option name" and then dumped
+all 27 set -o options onto the screen, at every single login.
+
+This test runs the real thing: a login hellish on a pty, against a
+throwaway HOME holding a ~/.profile built from Ubuntu's stock snippets,
+including both probes verbatim. The probes live in the sandbox rather than
+being read from the host's /etc, so the test says the same thing on a
+developer's machine and on a CI runner that has neither file.
+
+Usage: python3 login_chain_test.py /path/to/hellish
+"""
+import fcntl
+import os
+import pty
+import re
+import select
+import shutil
+import struct
+import sys
+import tempfile
+import termios
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "build/bin/hellish")
+FAILS = []
+ESC_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07")
+
+# Ubuntu's stock startup logic, trimmed to the parts that touch this bug.
+# `. ~/.bashrc` is guarded on BASH_VERSION, which hellish advertises, so
+# hellish takes that branch exactly like bash does -- that is how the
+# ~/.bashrc probe reaches it at all.
+PROFILE = """\
+if [ -n "$BASH_VERSION" ]; then
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi
+
+# /etc/profile.d/bash_completion.sh asks this on every login.
+if shopt -q progcomp; then
+    echo PROBE_PROGCOMP=on
+else
+    echo PROBE_PROGCOMP=off
+fi
+
+if [ -d "$HOME/bin" ] ; then
+    PATH="$HOME/bin:$PATH"
+fi
+
+if [ -d "$HOME/.local/bin" ] ; then
+    PATH="$HOME/.local/bin:$PATH"
+fi
+echo PROFILE_DONE
+"""
+
+# Ubuntu's skel ~/.bashrc, trimmed the same way.
+BASHRC = """\
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+shopt -s histappend
+shopt -s checkwinsize
+if ! shopt -oq posix; then
+    echo PROBE_POSIX=off
+fi
+echo BASHRC_DONE
+"""
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def login(home):
+    """Drive `hellish --login` on a pty against a sandboxed HOME."""
+    env = {
+        "HOME": home,
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "TERM": "xterm-256color", "LANG": "C.UTF-8",
+        "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+        "HELLISH_NO_ANIM": "1", "ASAN_OPTIONS": "detect_leaks=0",
+    }
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(env)
+        os.execv(SHELL, [SHELL, "--login"])
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 120, 0, 0))
+    out = b""
+    end = time.time() + 4.0          # let the whole chain settle first
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if r:
+            try:
+                out += os.read(fd, 65536)
+            except OSError:
+                break
+    banner = len(out)
+    for cmd in (b"echo PATHIS=$PATH\n", b"echo EDITORIS=$EDITOR\n"):
+        os.write(fd, cmd)
+        end = time.time() + 2.0
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.1)
+            if r:
+                try:
+                    out += os.read(fd, 65536)
+                except OSError:
+                    break
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    text = ESC_RE.sub("", out.decode(errors="replace"))
+    return text, ESC_RE.sub("", out[:banner].decode(errors="replace"))
+
+
+def main():
+    home = tempfile.mkdtemp()
+    try:
+        os.mkdir(os.path.join(home, "bin"))
+        os.makedirs(os.path.join(home, ".local", "bin"))
+        with open(os.path.join(home, ".profile"), "w") as f:
+            f.write(PROFILE)
+        with open(os.path.join(home, ".bashrc"), "w") as f:
+            f.write(BASHRC)
+        # Seed the rc the way an install does, so this also covers the
+        # config a `make my_shell` user is now given (issue #51's first
+        # line): EDITOR must actually arrive in the session.
+        shutil.copy(os.path.join(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__))), "hellishrc.example"),
+            os.path.join(home, ".hellishrc"))
+
+        out, startup = login(home)
+
+        # 1. The chain runs to the end. If ~/.profile aborts early its PATH
+        #    lines never run, which is the failure the user was papering
+        #    over by hand.
+        check("~/.bashrc is sourced through ~/.profile",
+              "BASHRC_DONE" in out, "got %r" % startup[:300])
+        check("~/.profile runs to completion", "PROFILE_DONE" in out,
+              "got %r" % startup[:300])
+
+        # 2. Neither probe makes a mess of the login.
+        check("no shopt error at login",
+              "invalid shell option name" not in out
+              and "invalid option name" not in out,
+              "got %r" % startup[:300])
+        check("shopt -oq posix does not dump the option table at login",
+              "braceexpand" not in out and "interactive-comments" not in out,
+              "the whole set -o table hit the screen: %r" % startup[:300])
+        check("the ~/.bashrc posix branch is taken", "PROBE_POSIX=off" in out,
+              "got %r" % startup[:300])
+        check("progcomp answers instead of erroring",
+              "PROBE_PROGCOMP=off" in out, "got %r" % startup[:300])
+
+        # 3. PATH: the login chain does the job, unaided. This is the claim
+        #    the hand-rolled `case ":$PATH:"` block was compensating for.
+        path = ""
+        for line in out.splitlines():
+            if line.startswith("PATHIS="):
+                path = line[len("PATHIS="):]
+        check("~/.profile's ~/.local/bin reaches PATH",
+              os.path.join(home, ".local/bin") in path, "PATH=%r" % path)
+        check("~/.profile's ~/bin reaches PATH",
+              os.path.join(home, "bin") in path, "PATH=%r" % path)
+        check("the system entries survive", "/usr/bin" in path,
+              "PATH=%r" % path)
+        check("PATH has no duplicate ~/.local/bin",
+              path.split(":").count(os.path.join(home, ".local/bin")) == 1,
+              "PATH=%r" % path)
+
+        # 4. The seeded rc is sourced and its settings land.
+        check("~/.hellishrc reaches the session (EDITOR is set)",
+              "EDITORIS=vim" in out, "got %r" % out[-300:])
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/prompt_jobs_badge_test.py
+++ b/tests/prompt_jobs_badge_test.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Regression test: the built-in prompt's live badges -- issue #50.
+
+Reported as "the process tracker into the prompt disappeared". The
+process tracker is the background-jobs badge, " ⚙N", that the built-in
+two-row prompt shows on its info row while jobs exist; the duration badge
+"took N.Ns" sits right next to it and broke in exactly the same way.
+
+Root cause. prompt_normal() (src/infrastructure/prompt.c) refreshed three
+process-mirror globals -- anim_jobs(), anim_dur_ms(), anim_status() -- and
+only then rendered the built-in prompt. Those refreshes lived on the
+PS1-is-unset branch, AFTER the early `return ps1_animated(...)` taken when
+PS1 has a value:
+
+    ps1 = env_expand(state, "PS1");
+    if (ps1 && *ps1)
+        return (ps1_animated(state, ps1));   <-- taken from 2.7.0 on
+    ...
+    *anim_jobs() = state->job_table.count;   <-- never reached any more
+    render_prompt(...);
+
+That branch was dead code until 5b6d3d4 shipped a default PS1 of "\B" (so
+a virtualenv could restore it, issue #39). From that release on PS1 always
+has a value, the early return is always taken, and render_extras() -- which
+reads anim_jobs()/anim_dur_ms(), not the live job table -- rendered from
+mirrors frozen at zero. The badges silently vanished for every user who had
+not set a PS1 of their own.
+
+The mirrors are now refreshed before the PS1 branch, so every route to the
+built-in prompt sees the current process state.
+
+Three routes are covered, because they reach render_extras() differently:
+  1. PS1 unset      -- the historical built-in path
+  2. PS1='\B'       -- the shipped default, the one users actually run
+  3. PS1='...\J...' -- the \J escape, which reads the job table directly
+
+Usage: python3 prompt_jobs_badge_test.py /path/to/hellish
+"""
+import fcntl
+import os
+import pty
+import re
+import select
+import struct
+import sys
+import termios
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "build/bin/hellish")
+FAILS = []
+
+BASE_ENV = {
+    "HOME": os.environ.get("HOME", "/tmp"),
+    "PATH": os.environ["PATH"],
+    "TERM": "xterm-256color", "LANG": "C.UTF-8",
+    "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+    "HELLISH_NO_ANIM": "1", "ASAN_OPTIONS": "detect_leaks=0",
+}
+
+GEAR = "⚙"          # ⚙ -- the process tracker glyph
+ESC_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def session(cmds, ps1=None, cols=120, settle=1.4):
+    """Drive an interactive hellish on a pty; return the plain-text screen.
+
+    A wide pty on purpose: render_extras() DROPS the badges when the info
+    row lacks room for them plus the clock, so a narrow terminal would hide
+    the very thing under test and the regression would read as a pass.
+    """
+    env = dict(BASE_ENV)
+    if ps1 is not None:
+        env["PS1"] = ps1
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(env)
+        os.execv(SHELL, [SHELL])
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 24, cols, 0, 0))
+    time.sleep(0.8)
+    out = b""
+    for cmd in cmds:
+        os.write(fd, cmd)
+        end = time.time() + settle
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.1)
+            if r:
+                try:
+                    out += os.read(fd, 65536)
+                except OSError:
+                    break
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    return ESC_RE.sub("", out.decode(errors="replace"))
+
+
+def jobs_badge_case(label, ps1):
+    """A background job must raise ⚙1; reaping it must lower the badge."""
+    out = session([b"sleep 30 &\n", b"echo AFTER\n"], ps1=ps1)
+    check("%s: background job raises the ⚙ tracker" % label,
+          GEAR in out, "no gear on screen: %r" % out[-260:])
+    check("%s: the tracker counts the job (⚙1)" % label,
+          GEAR + "1" in out, "gear without its count: %r" % out[-260:])
+
+    # And it must come back DOWN -- a badge that never clears is just as
+    # wrong as one that never shows, and a stale mirror would keep it lit.
+    out = session([b"sleep 30 &\n", b"kill %1\n", b"wait\n", b"echo REAPED\n"],
+                  ps1=ps1)
+    tail = out.split("REAPED", 1)[-1]
+    check("%s: the tracker clears once no job is left" % label,
+          GEAR not in tail, "gear outlived its job: %r" % tail[:260])
+
+
+def main():
+    # The shipped configuration: PS1 unset in the environment, so the shell
+    # falls back to its own default. This is the exact case from the report.
+    jobs_badge_case("default prompt", None)
+
+    # The literal default value set_default_ps1() installs. Same renderer,
+    # reached through the PS1 branch instead of the fallback.
+    jobs_badge_case("PS1='\\B'", "\\B")
+
+    # \J in a user PS1 reads state->job_table directly and never regressed;
+    # it is here so a fix that "works" by breaking \J cannot pass.
+    out = session([b"sleep 30 &\n", b"echo AFTER\n"], ps1=r"[\J]> ")
+    check("\\J escape still renders the tracker", "[ " + GEAR + "1]" in out,
+          "got %r" % out[-260:])
+
+    # The duration badge shares the mirrors with the tracker and broke with
+    # it, so it is pinned here too: 2s is render_extras()'s threshold.
+    out = session([b"sleep 2.5\n", b"echo DONE\n"], ps1=None, settle=4.0)
+    check("default prompt: 'took N.Ns' returns after a slow command",
+          "took 2." in out, "no duration badge: %r" % out[-260:])
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/shopt_setopt_test.py
+++ b/tests/shopt_setopt_test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regression test: `shopt -o` addresses the set -o options -- issue #51.
+
+The report is a `make my_shell` login on Ubuntu 24 that printed errors.
+Two of them come from stock dotfiles probing shopt, and both are this
+builtin's fault.
+
+  1. ~/.bashrc (Ubuntu's skel copy, pulled in by ~/.profile because hellish
+     advertises BASH_VERSION) runs
+
+         if ! shopt -oq posix; then ... fi
+
+     to decide whether to load completions. builtin_shopt() dispatched
+     `-o` to list_set_options() and threw away the NAMES, the -q and the
+     -p: the login printed the entire 27-line option table, and returned 0
+     regardless of the setting, so the branch was decided by a coin flip.
+
+  2. /etc/profile.d/bash_completion.sh runs `shopt -q progcomp`. hellish
+     did not know the name, so every login opened with
+
+         hellish: shopt: progcomp: invalid shell option name
+
+     hellish has no `complete` builtin -- there is no programmable
+     completion to enable -- so progcomp is now a known option that is
+     OFF, which is the truthful answer AND the one that makes
+     bash_completion.sh correctly skip itself instead of feeding hellish a
+     2500-line bash script.
+
+Everything asserted below was read off bash 5.x first; each case carries
+the bash command that produced it. The one deliberate divergence is
+progcomp's default, and it is marked as such.
+
+Usage: python3 shopt_setopt_test.py /path/to/hellish
+"""
+import os
+import subprocess
+import sys
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "build/bin/hellish")
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def run(script):
+    """Run one -c script; return (stdout, stderr, status)."""
+    env = dict(os.environ)
+    env.update({"HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+                "ASAN_OPTIONS": "detect_leaks=0"})
+    p = subprocess.run([SHELL, "-c", script], capture_output=True, text=True,
+                       env=env, timeout=30)
+    return p.stdout, p.stderr, p.returncode
+
+
+def case(name, script, out=None, err="", rc=None, out_absent=None):
+    o, e, r = run(script)
+    if rc is not None:
+        check("%s: status %d" % (name, rc), r == rc, "got %d" % r)
+    if out is not None:
+        check("%s: stdout" % name, o == out, "got %r want %r" % (o, out))
+    if out_absent is not None:
+        check("%s: stdout free of %r" % (name, out_absent),
+              out_absent not in o, "got %r" % o[:200])
+    if err is not None:
+        check("%s: stderr" % name, (e == "") if err == "" else (err in e),
+              "got %r" % e[:200])
+
+
+def main():
+    # ── the two probes from the report ────────────────────────────────────
+    # bash: `shopt -oq posix` -> no output, status 1 (posix is off).
+    # The old code printed the whole table and returned 0.
+    case("shopt -oq posix", "shopt -oq posix", out="", rc=1)
+    # The table dump is the visible half of the bug: assert it explicitly,
+    # because an empty stdout check alone would not say WHY it must be empty.
+    case("shopt -oq posix does not dump the table", "shopt -oq posix",
+         out_absent="braceexpand", rc=1)
+
+    # bash: `shopt -q progcomp` -> silent, status 0 because bash HAS
+    # programmable completion. hellish has no `complete` builtin, so it
+    # answers the same question honestly: silent, status 1. What matters
+    # for the login is that it no longer ERRORS.
+    case("shopt -q progcomp is silent and off", "shopt -q progcomp",
+         out="", err="", rc=1)
+    o, e, r = run("shopt -q progcomp; echo rc=$?")
+    check("shopt -q progcomp prints no error at all",
+          "invalid" not in e and "invalid" not in o,
+          "stdout=%r stderr=%r" % (o[:120], e[:120]))
+
+    # ── `shopt -o` with a name, every modifier ────────────────────────────
+    # bash: `shopt -o posix` -> "posix          \toff", status 1.
+    case("shopt -o posix", "shopt -o posix", out="posix          \toff\n",
+         rc=1)
+    # bash: `shopt -op posix` -> "set +o posix", status 1.
+    case("shopt -op posix", "shopt -op posix", out="set +o posix\n", rc=1)
+    # bash: status follows the SETTING for the query forms.
+    case("shopt -oq xtrace, off", "shopt -oq xtrace", out="", rc=1)
+    case("shopt -oq xtrace, on", "set -x 2>/dev/null; shopt -oq xtrace",
+         rc=0, err=None)
+    # bash: -s/-u through -o really move the set -o option.
+    case("shopt -so noclobber sets it",
+         "shopt -so noclobber; shopt -oq noclobber; echo rc=$?",
+         out="rc=0\n", rc=0)
+    case("shopt -uo noclobber clears it",
+         "set -C; shopt -uo noclobber; shopt -oq noclobber; echo rc=$?",
+         out="rc=1\n", rc=0)
+    # bash: an unknown -o name is "invalid option name" (the -o form drops
+    # the word "shell" that the plain form uses), status 1.
+    case("shopt -o extglob rejects a non-set-o name", "shopt -o extglob",
+         out="", err="invalid option name", rc=1)
+    # bash: bare `shopt -o` still lists the whole set -o table, status 0.
+    o, e, r = run("shopt -o")
+    check("bare shopt -o still lists the table",
+          "braceexpand" in o and "xtrace" in o and r == 0,
+          "rc=%d out=%r" % (r, o[:160]))
+
+    # ── the plain shopt forms must not have moved ─────────────────────────
+    case("shopt -q histappend, off by default", "shopt -q histappend",
+         out="", rc=1)
+    case("shopt -s extglob then -q", "shopt -s extglob; shopt -q extglob",
+         out="", rc=0)
+    case("plain shopt name still prints on/off", "shopt -s dotglob; "
+         "shopt dotglob", out="dotglob             \ton\n", rc=0)
+    case("unknown plain name still errors like bash", "shopt notanoption",
+         out="", err="invalid shell option name", rc=1)
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tools/seed_hellishrc.sh
+++ b/tools/seed_hellishrc.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# ============================================================================
+# tools/seed_hellishrc.sh -- put hellishrc.example at ~/.hellishrc, once.
+#
+# Why this is its own file. The seeding used to live inline in
+# user-install.sh, which meant it only happened on the no-sudo route. The
+# sudo route -- `make my_shell`, install to /usr/bin and chsh -- installed a
+# binary and stopped, so a user who took it got a shell with no config at
+# all: no EDITOR, no aliases, no PS1, and no hint that a config file was
+# ever meant to exist. That is the first line of issue #51. One seeder,
+# called by both routes, is the only shape that cannot drift again.
+#
+# The one rule that matters: an EXISTING ~/.hellishrc is never touched. It
+# is the user's file, installers get re-run, and eating an edited config is
+# far worse than skipping a template.
+#
+#   tools/seed_hellishrc.sh                      seed $HOME/.hellishrc
+#   tools/seed_hellishrc.sh --home DIR           seed DIR/.hellishrc
+#   tools/seed_hellishrc.sh --example FILE       use FILE as the template
+#
+# Always exits 0 unless it was asked to do something impossible: a missing
+# template is a warning, because an install must not fail over a doc file.
+# ============================================================================
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET_HOME="${HOME:-}"
+EXAMPLE="$REPO_ROOT/hellishrc.example"
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--home) TARGET_HOME="${2:-}"; shift 2 ;;
+	--example) EXAMPLE="${2:-}"; shift 2 ;;
+	-h|--help) sed -n '3,20p' "$0"; exit 0 ;;
+	*) echo "seed_hellishrc: unknown argument: $1" >&2; exit 2 ;;
+	esac
+done
+
+if [ -z "$TARGET_HOME" ]; then
+	echo "seed_hellishrc: no \$HOME and no --home; nothing to seed" >&2
+	exit 2
+fi
+
+RC="$TARGET_HOME/.hellishrc"
+
+if [ -e "$RC" ]; then
+	printf '  \033[1;34mi\033[0m  %s already exists — left untouched\n' "$RC"
+	exit 0
+fi
+
+if [ ! -f "$EXAMPLE" ]; then
+	printf '  \033[1;33m!\033[0m  %s not found — skipping %s\n' \
+		"$EXAMPLE" "$RC" >&2
+	exit 0
+fi
+
+# Copy to a temp name in the same directory and rename, so an interrupted
+# copy can never leave a half-written rc that the next shell then sources.
+cp "$EXAMPLE" "$RC.new" || exit 1
+mv -f "$RC.new" "$RC" || exit 1
+printf '  \033[1;32m✓\033[0m  seeded %s from %s\n' "$RC" "$(basename "$EXAMPLE")"

--- a/user-install.sh
+++ b/user-install.sh
@@ -199,14 +199,10 @@ mv -f "$DEST.new" "$DEST"
 grn "installed $DEST"
 
 # ── 2. seed ~/.hellishrc ──────────────────────────────────────────────────
-if [ -e "$HOME/.hellishrc" ]; then
-	inf "~/.hellishrc already exists — left untouched"
-elif [ -f "$REPO_ROOT/hellishrc.example" ]; then
-	cp "$REPO_ROOT/hellishrc.example" "$HOME/.hellishrc"
-	grn "seeded ~/.hellishrc from hellishrc.example"
-else
-	warn "hellishrc.example not found — skipping ~/.hellishrc"
-fi
+# Delegated, not inlined. This is the copy `make my_shell` did not have, so
+# the sudo route installed a shell with no config at all (issue #51); one
+# seeder called by both routes is what keeps them from drifting again.
+"$REPO_ROOT/tools/seed_hellishrc.sh" --example "$REPO_ROOT/hellishrc.example"
 
 # ── 3. prove the binary works BEFORE anything execs it ────────────────────
 #

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -5,7 +5,7 @@ later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**. Released version: **2.7.2**.
+Branch to resume from: **`develop`**. Released version: **2.7.3**.
 
 The previous note on this file covered the issue-fixing session (#27, #32,
 #34, #42 and friends). All of those are closed; the tracker is empty. This


### PR DESCRIPTION
Ships **v2.7.3**: two issues reported from real machines, both on the path between installing hellish and getting a usable prompt.

| issue | what was wrong |
|---|---|
| #50 | The built-in prompt's process tracker (`⚙N`) and `took N.Ns` badge, gone since 2.7.0. The prompt's process-state mirrors were refreshed *below* an early return that 2.7.0's default `PS1="\B"` (shipped for the virtualenv fix, #39) made always-taken — so they stayed frozen at zero and both badges rendered as nothing. |
| #51 | `make my_shell` never seeded `~/.hellishrc` (the seeding lived only in `user-install.sh`). `shopt -o` discarded its names, `-q` and `-p`, so Ubuntu's stock `~/.bashrc` `if ! shopt -oq posix` dumped all 27 option lines at every login **and read the wrong status back**. `shopt -q progcomp` errored on every login from `/etc/profile.d/bash_completion.sh`. |

Patch, not minor: no new builtin, no new option, no interface added.

**Regression tests** — four new files, all auto-discovered by the pty suite:
`prompt_jobs_badge_test.py`, `shopt_setopt_test.py`, `login_chain_test.py`,
`hellishrc_seed_test.py`. Each fails on the pre-fix binary (5, 17, 3 and 2 checks
respectively).

**`develop` is 39/39 green** on `4f9ba65`, including the full platform matrix,
the hard corpus, allocator parity and the pty gates.

Closes #50
Closes #51
