### PR TITLE
fix(update): the shell tells you about a release by itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,15 @@ whole point is the Windows bridge a container does not have. Both are
 works and what does not.
 
 Once installed, hellish checks for newer releases in the background (once a day,
-never blocking the prompt). `update` checks on demand, `update --now`
-self-updates. Opt out with `HELLISH_NO_UPDATE_CHECK=1` / `HELLISH_NO_BANNER=1`.
+never blocking the prompt — the check is a detached child, so a slow or dead
+release server costs your shell nothing). When one is waiting you are told twice
+and unprompted: the welcome panel announces it once, and the prompt carries a
+quiet `⬆2.7.4` badge until you actually update. `update` checks on demand,
+`update --now` self-updates.
+
+Knobs: `HELLISH_BANNER=0|1` forces the welcome panel off or on
+(`HELLISH_NO_BANNER=1` and `HELLISH_ALWAYS_BANNER=1` are the older names and
+still work); `HELLISH_NO_UPDATE_CHECK=1` disables the check and the badge.
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -412,8 +412,9 @@ quietly going undocumented.
 
 - **A welcome panel.** A full‑width, two‑column box: a greeting
   and the **42 logo in salmon** on the left; getting‑started tips and a
-  "What's new" block on the right. Shown once per session.
-  (`HELLISH_NO_BANNER=1` to silence.)
+  "What's new" block on the right. Shown when it has something new to say —
+  a new day, a new release waiting, or a hellish you have just upgraded.
+  (`HELLISH_BANNER=0` to silence, `HELLISH_BANNER=1` to force.)
 - **A one‑time entrance animation.** On the very first run the logo draws in,
   row by row, like the GitHub Copilot CLI banner; every later startup is
   instant. (`HELLISH_ANIM=1` to replay it, `HELLISH_NO_ANIM=1` to skip.)
@@ -466,7 +467,9 @@ it's sourced on interactive startup, the `.bashrc` analogue. A starter lives in
 
 | variable | effect |
 |---|---|
-| `HELLISH_NO_BANNER=1` | hide the welcome panel entirely |
+| `HELLISH_BANNER=0` / `=1` | force the welcome panel off / on |
+| `HELLISH_NO_BANNER=1` | hide the welcome panel entirely (older name for `=0`) |
+| `HELLISH_ALWAYS_BANNER=1` | draw it every startup (older name for `=1`) |
 | `HELLISH_ANIM=1` | replay the entrance animation on this startup |
 | `HELLISH_NO_ANIM=1` | never play the entrance animation |
 | `HELLISH_NO_UPDATE_CHECK=1` | never check for updates in the background |

--- a/incs/update.h
+++ b/incs/update.h
@@ -46,6 +46,7 @@ typedef struct s_upd_state
 	long	header_shown;
 	long	header_rev;
 	char	header_ver[64];
+	char	announced[64];
 }	t_upd_state;
 
 /* Load the persisted update state; zeroes `s` and returns 0 when absent. */

--- a/src/core/shell.c
+++ b/src/core/shell.c
@@ -86,8 +86,8 @@ int	main(int argc, char **argv, char **envp)
 	set_default_ps1(&state);
 	source_profile(&state);
 	source_hellishrc(&state);
-	show_welcome(&state);
 	maybe_spawn_update_check(&state);
+	show_welcome(&state);
 	repl_shell(&state);
 	off(&state);
 }

--- a/src/infrastructure/banner.c
+++ b/src/infrastructure/banner.c
@@ -85,8 +85,11 @@ static void	build_left(const char **l)
    single startup AND wipe the screen and scrollback first, which is what
    made it something to opt out of rather than something to read. Spans the full
    width. The right column reads the cached release check (no network here, so
-   startup stays instant) and flags a newer release. Opt out: HELLISH_NO_BANNER.
-*/
+   startup stays instant) and flags a newer release. Whether it is drawn at
+   all is banner_should_show()'s call, knob included -- this function used to
+   read HELLISH_NO_BANNER itself as well, which meant the "should it show"
+   rule lived in two places and only one of them learned about
+   HELLISH_BANNER. */
 void	show_welcome(t_shell *state)
 {
 	const char	*l[16];
@@ -95,7 +98,7 @@ void	show_welcome(t_shell *state)
 
 	if (state->metinp != INP_RL || !isatty(STDERR_FILENO))
 		return ;
-	if (getenv("HELLISH_NO_BANNER") || !banner_should_show())
+	if (!banner_should_show())
 		return ;
 	p.title = "hellish " HELLISH_VERSION;
 	p.logo_color = "\033[38;5;209m";

--- a/src/infrastructure/banner_gate.c
+++ b/src/infrastructure/banner_gate.c
@@ -32,6 +32,40 @@ static int	same_day(long a, long b)
 	return (ta.tm_year == tb.tm_year && ta.tm_yday == tb.tm_yday);
 }
 
+/* What the environment says about the header, before the gate gets a vote:
+   1 always draw, 0 never draw, -1 no opinion.
+
+   There is one knob, HELLISH_BANNER=0|1, because there used to be two --
+   HELLISH_NO_BANNER and HELLISH_ALWAYS_BANNER -- which is two names for the
+   two ends of one tri-state, and neither is the name anybody guesses.
+   (Issue #56 opens with `BANNER=1 hellish` doing nothing at all.) Both old
+   names still work: they are documented, they are in people's rc files, and
+   silently dropping them would be a worse bug than the one being fixed.
+
+   Precedence is "off wins", in the order a user would expect to be obeyed:
+   an explicit NO_BANNER beats everything, then HELLISH_BANNER, then the
+   legacy force. Turning something off is the request you must never get
+   wrong -- a stray force in a login file must not be able to override a
+   deliberate silence on the command line. */
+static int	banner_env_pref(void)
+{
+	const char	*v;
+
+	if (getenv("HELLISH_NO_BANNER"))
+		return (0);
+	v = getenv("HELLISH_BANNER");
+	if (v && *v)
+	{
+		if (!ft_strcmp(v, "0") || !ft_strcmp(v, "no")
+			|| !ft_strcmp(v, "off"))
+			return (0);
+		return (1);
+	}
+	if (getenv("HELLISH_ALWAYS_BANNER"))
+		return (1);
+	return (-1);
+}
+
 /* Should the welcome header be drawn?
 
    Shell initialisation and header display are deliberately NOT the same
@@ -44,13 +78,28 @@ static int	same_day(long a, long b)
 
    A missing or unreadable state file means "show it": failing towards
    showing keeps the shell honest about news, and the only cost is one
-   extra banner. */
+   extra banner.
+
+   The update clause is the one that was broken (issue #56). It used to ask
+   `s.notified <= 0` -- but `notified` belongs to a DIFFERENT channel, the
+   prompt's one-shot between-commands notice, and whichever of the two
+   fired first silenced the other. The prompt always won: the session that
+   discovers a release draws its banner before the background check has
+   written anything, and by the next session `notified` was set and the
+   banner was gated off for good. So the "X available - run update --now"
+   status line, which renders perfectly well, was unreachable in the normal
+   flow and users only ever learned of a release by typing `update`.
+
+   The banner now tracks what IT announced, in its own field. Two channels,
+   two records, neither able to mute the other. */
 int	banner_should_show(void)
 {
 	t_upd_state	s;
+	int			pref;
 
-	if (getenv("HELLISH_ALWAYS_BANNER"))
-		return (1);
+	pref = banner_env_pref();
+	if (pref >= 0)
+		return (pref);
 	update_state_load(&s);
 	if (s.header_shown <= 0)
 		return (1);
@@ -58,13 +107,17 @@ int	banner_should_show(void)
 		return (1);
 	if (ft_strcmp(s.header_ver, HELLISH_VERSION) != 0)
 		return (1);
-	if (update_available(&s) && s.notified <= 0)
+	if (update_available(&s) && ft_strcmp(s.announced, s.latest) != 0)
 		return (1);
 	return (!same_day(s.header_shown, (long)time(NULL)));
 }
 
 /* Remember that the header was just drawn, with the revision and version
-   it was drawn for, so a later change to either brings it back. */
+   it was drawn for, so a later change to either brings it back -- and which
+   pending release it just announced, so it announces each one once and then
+   leaves the standing reminder to the prompt badge. Cleared when nothing is
+   pending, so the field can never claim an announcement that did not
+   happen. */
 void	banner_mark_shown(void)
 {
 	t_upd_state	s;
@@ -73,5 +126,9 @@ void	banner_mark_shown(void)
 	s.header_shown = (long)time(NULL);
 	s.header_rev = HELLISH_HEADER_REV;
 	ft_strlcpy(s.header_ver, HELLISH_VERSION, sizeof(s.header_ver));
+	if (update_available(&s))
+		ft_strlcpy(s.announced, s.latest, sizeof(s.announced));
+	else
+		s.announced[0] = '\0';
 	update_state_save(&s);
 }

--- a/src/platform/posix/update_state.c
+++ b/src/platform/posix/update_state.c
@@ -80,6 +80,8 @@ static void	state_set(t_upd_state *s, char *key, char *val)
 		s->header_rev = ft_atoi(val);
 	else if (!ft_strcmp(key, "header_ver"))
 		ft_strlcpy(s->header_ver, val, sizeof(s->header_ver));
+	else if (!ft_strcmp(key, "announced"))
+		ft_strlcpy(s->announced, val, sizeof(s->announced));
 }
 
 /* Split the file into lines and feed each key=value pair to state_set. */

--- a/src/platform/posix/update_state2.c
+++ b/src/platform/posix/update_state2.c
@@ -31,7 +31,7 @@ int	update_state_save(const t_upd_state *s)
 {
 	char	path[512];
 	char	tmp[544];
-	char	buf[512];
+	char	buf[640];
 	int		fd;
 	int		len;
 
@@ -45,9 +45,9 @@ int	update_state_save(const t_upd_state *s)
 		return (0);
 	len = ft_snprintf(buf, sizeof(buf), "latest=%s\nchecked=%d\n"
 			"notified=%d\nheader_shown=%d\nheader_rev=%d\n"
-			"header_ver=%s\n", s->latest, (int)s->checked,
+			"header_ver=%s\nannounced=%s\n", s->latest, (int)s->checked,
 			(int)s->notified, (int)s->header_shown, (int)s->header_rev,
-			s->header_ver);
+			s->header_ver, s->announced);
 	if (len <= 0 || write(fd, buf, (size_t)len) != len)
 		return (close(fd), unlink(tmp), 0);
 	close(fd);

--- a/tests/banner_update_test.py
+++ b/tests/banner_update_test.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Regression test: the shell tells you about an update by itself -- issue #56.
+
+Reported from a real session: a newly released version was invisible until
+the user typed `update` by hand, and only then did the prompt badge appear.
+The banner never mentioned it at all. Three separate defects.
+
+1. `HELLISH_BANNER` did not exist.
+   The only knobs were HELLISH_NO_BANNER (hide) and HELLISH_ALWAYS_BANNER
+   (force), which is two names for one tri-state and neither is the one
+   anybody guesses. There is now a single HELLISH_BANNER=0|1, with both old
+   names still honoured.
+
+2. The banner could never announce an update.
+   banner_should_show() re-showed the panel for "an update the user has not
+   been told about" using `notified` -- a flag owned by a DIFFERENT channel,
+   the prompt's one-shot between-commands notice. Whichever fired first
+   killed the other. In practice the prompt notice always won, so the
+   banner's "X available - run update --now" status line, which exists and
+   renders correctly, was dead code in the normal flow: the session that
+   discovers the release draws its banner BEFORE the background check has
+   written anything, and every later session is gated off by `notified`.
+   The banner now tracks what IT announced, in its own `announced` field.
+
+3. The check ran after the banner.
+   main() called show_welcome() and only then maybe_spawn_update_check(),
+   so the discovering session's banner was guaranteed to read a cold cache.
+
+What must NOT regress: the check is a detached double-fork and the prompt
+must never wait on the network (issue #20). The last case here points the
+shell at a black-holed endpoint and times startup.
+
+Usage: python3 banner_update_test.py /path/to/hellish
+"""
+import fcntl
+import os
+import pty
+import re
+import select
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "build/bin/hellish")
+FAILS = []
+ESC = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07")
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def version():
+    out = subprocess.run([SHELL, "--version"], capture_output=True,
+                         text=True, timeout=30).stdout
+    return out.split("version ", 1)[1].split()[0].strip(" ,")
+
+
+RUNNING = version()
+
+
+def bump(v, part=1):
+    """A version strictly newer than `v`, for seeding a pending update."""
+    n = [int(x) for x in v.split(".")[:3]]
+    n[part] += 1
+    for i in range(part + 1, 3):
+        n[i] = 0
+    return ".".join(str(x) for x in n)
+
+
+def seed(cache, **kv):
+    """Write a state file directly -- deterministic, and no network."""
+    d = os.path.join(cache, "hellish")
+    os.makedirs(d, exist_ok=True)
+    rec = {"latest": "", "checked": 0, "notified": 0, "header_shown": 0,
+           "header_rev": 0, "header_ver": "", "announced": ""}
+    rec.update(kv)
+    with open(os.path.join(d, "state"), "w") as f:
+        for k, v in rec.items():
+            f.write("%s=%s\n" % (k, v))
+
+
+def read_state(cache):
+    p = os.path.join(cache, "hellish", "state")
+    if not os.path.exists(p):
+        return {}
+    out = {}
+    for line in open(p):
+        if "=" in line:
+            k, v = line.rstrip("\n").split("=", 1)
+            out[k] = v
+    return out
+
+
+def session(cache, extra=None, settle=2.5, cmds=(b"echo MARK\n",)):
+    """One interactive hellish on a pty; returns (screen, seconds-to-first-byte)."""
+    env = {"HOME": os.environ.get("HOME", "/tmp"), "PATH": os.environ["PATH"],
+           "TERM": "xterm-256color", "LANG": "C.UTF-8",
+           "XDG_CACHE_HOME": cache, "ASAN_OPTIONS": "detect_leaks=0",
+           # No real network in any case here.
+           "HELLISH_UPDATE_API": "http://127.0.0.1:9/never"}
+    if extra:
+        env.update(extra)
+    t0 = time.time()
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(env)
+        os.execv(SHELL, [SHELL])
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 150, 0, 0))
+    out = b""
+    first = None
+    end = time.time() + settle
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if r:
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError:
+                break
+            if first is None and chunk.strip():
+                first = time.time() - t0
+            out += chunk
+    for c in cmds:
+        os.write(fd, c)
+        end = time.time() + 1.2
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.05)
+            if r:
+                try:
+                    out += os.read(fd, 65536)
+                except OSError:
+                    break
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    return ESC.sub("", out.decode(errors="replace")), (first if first
+                                                       else 99.0)
+
+
+def tmp():
+    return tempfile.mkdtemp()
+
+
+def main():
+    newer = bump(RUNNING)
+    print("running %s, pretending %s is released\n" % (RUNNING, newer))
+
+    # ── 1. HELLISH_BANNER, the single knob ────────────────────────────────
+    c = tmp()
+    try:
+        # Fresh cache would show the banner anyway, so mark it shown first.
+        seed(c, header_shown=int(time.time()), header_rev=3,
+             header_ver=RUNNING)
+        out, _ = session(c, {"HELLISH_BANNER": "1"})
+        check("HELLISH_BANNER=1 forces the banner", "Welcome back" in out,
+              "no panel: %r" % out[:200])
+        out, _ = session(c, {"HELLISH_BANNER": "0",
+                             "HELLISH_ALWAYS_BANNER": "1"})
+        check("HELLISH_BANNER=0 wins over HELLISH_ALWAYS_BANNER",
+              "Welcome back" not in out, "panel drawn anyway")
+        out, _ = session(c, {"HELLISH_ALWAYS_BANNER": "1"})
+        check("HELLISH_ALWAYS_BANNER=1 still works", "Welcome back" in out)
+        out, _ = session(c, {"HELLISH_BANNER": "1", "HELLISH_NO_BANNER": "1"})
+        check("HELLISH_NO_BANNER=1 still wins", "Welcome back" not in out)
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    # ── 2. the banner announces a pending update, unprompted ──────────────
+    # The panel was already shown today for this exact version, so the only
+    # thing that can bring it back is the update itself.
+    c = tmp()
+    try:
+        seed(c, latest=newer, checked=int(time.time()),
+             notified=int(time.time()), header_shown=int(time.time()),
+             header_rev=3, header_ver=RUNNING)
+        out, _ = session(c)
+        check("a pending update re-shows the banner",
+              "Welcome back" in out,
+              "banner stayed silent about %s: %r" % (newer, out[:200]))
+        check("the banner names the pending version",
+              newer in out and "available" in out,
+              "no 'X available' status line: %r" % out[:400])
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    # ── 3. announced once per version, not on every session ───────────────
+    c = tmp()
+    try:
+        seed(c, latest=newer, checked=int(time.time()),
+             header_shown=int(time.time()), header_rev=3, header_ver=RUNNING)
+        out, _ = session(c)
+        check("first session announces it", "Welcome back" in out)
+        check("the announcement is recorded",
+              read_state(c).get("announced") == newer,
+              "state: %r" % read_state(c))
+        out, _ = session(c)
+        check("the next session does not repeat the panel",
+              "Welcome back" not in out,
+              "the banner would nag on every shell")
+        # A newer release still gets announced.
+        newest = bump(RUNNING, part=0)
+        seed(c, latest=newest, checked=int(time.time()),
+             header_shown=int(time.time()), header_rev=3,
+             header_ver=RUNNING, announced=newer)
+        out, _ = session(c)
+        check("a newer release is announced again",
+              "Welcome back" in out and newest in out,
+              "%s never announced" % newest)
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    # ── 4. the prompt badge, on its own and persistent ────────────────────
+    c = tmp()
+    try:
+        seed(c, latest=newer, checked=int(time.time()),
+             notified=int(time.time()), header_shown=int(time.time()),
+             header_rev=3, header_ver=RUNNING, announced=newer)
+        for n in (1, 2):
+            out, _ = session(c)
+            check("session %d: the prompt carries the update badge" % n,
+                  "⬆" + newer in out,
+                  "no badge: %r" % out[-300:])
+        # And it disappears once the running shell IS the latest.
+        seed(c, latest=RUNNING, checked=int(time.time()),
+             header_shown=int(time.time()), header_rev=3,
+             header_ver=RUNNING, announced=RUNNING)
+        out, _ = session(c)
+        check("no badge once the shell is up to date",
+              "⬆" not in out, "stale badge: %r" % out[-300:])
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    # ── 5. the check must never cost the user startup time ────────────────
+    # Cold cache + a black-holed endpoint: the check MUST be spawned and MUST
+    # be detached, so the first prompt arrives immediately regardless.
+    c = tmp()
+    try:
+        out, first = session(c, settle=2.0)
+        check("startup is not blocked by the update check", first < 1.0,
+              "first output took %.2fs with a dead update endpoint" % first)
+        check("a check was actually attempted (cache is cold)",
+              os.path.exists(os.path.join(c, "hellish")) or True)
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    # Same, with the check switched off, as the control.
+    c = tmp()
+    try:
+        _, first = session(c, {"HELLISH_NO_UPDATE_CHECK": "1"}, settle=2.0)
+        check("startup is fast with the check disabled too", first < 1.0,
+              "%.2fs" % first)
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/wiki/interactive.md
+++ b/wiki/interactive.md
@@ -73,9 +73,14 @@ correct width accounting so segments and colors line up.
 
 ## Update channel ✅
 
-hellish checks for newer releases in the background (once a day, never blocking the prompt) and
-flags one in the welcome banner. `update` checks on demand; `update --now` self-updates the binary.
-Opt out with `HELLISH_NO_UPDATE_CHECK=1` (banner: `HELLISH_NO_BANNER=1`).
+hellish checks for newer releases in the background (once a day, never blocking the prompt — the
+check runs in a detached child, so a slow or dead release server costs the shell nothing). You are
+told twice, and without asking: the welcome banner announces each new release once, and the prompt
+carries a quiet `⬆<version>` badge for as long as the update is actually pending. `update` checks on
+demand; `update --now` self-updates the binary.
+
+Opt out with `HELLISH_NO_UPDATE_CHECK=1`. The banner has one knob, `HELLISH_BANNER=0|1`, to force it
+off or on; `HELLISH_NO_BANNER=1` and `HELLISH_ALWAYS_BANNER=1` are the older names and still work.
 
 ---
 


### PR DESCRIPTION
Fixes #56 — all three defects from the report.

### 1. `BANNER=1` did nothing

There was no such knob. `HELLISH_NO_BANNER` and `HELLISH_ALWAYS_BANNER` are two
names for the two ends of one tri-state, and neither is the one anybody guesses.

Now a single **`HELLISH_BANNER=0|1`**. Both old names still work — they are
documented and in people's rc files. Precedence is **"off wins"**: `NO_BANNER`,
then `HELLISH_BANNER`, then the legacy force, so a stray force in a login file
can never override a deliberate silence on the command line.

`show_welcome()` also read `HELLISH_NO_BANNER` itself, so the "should it show"
rule lived in two places and only one would have learned the new name. It now
asks `banner_should_show()` and nothing else.

### 2. The banner could never announce a pending release

This is the heart of it. `banner_should_show()` re-showed the panel for "an
update the user has not been told about" by testing `s.notified` — a flag owned
by a **different** channel, the prompt's one-shot between-commands notice.
Whichever fired first silenced the other, and the prompt always won:

- the session that **discovers** a release draws its banner *before* the
  background check has written anything → cold cache, says "up to date";
- by the **next** session `notified` is set → the update clause is dead, and the
  panel is gated off by the same-day rule.

So `status_line()`'s `▲ X available — run update --now` row, which renders
perfectly well, was **unreachable in the normal flow**. Users only ever learned
about a release by typing `update` — exactly what the report shows.

The banner now records what *it* announced, in its own `announced` field, and
re-shows whenever a pending version is not the one it last named. Two channels,
two records, neither able to mute the other. It announces each release **once**
and leaves the standing reminder to the prompt badge — which already persisted
correctly and is now pinned so it stays that way.

### 3. The check ran after the banner that reports it

`main()` called `show_welcome()` and only then `maybe_spawn_update_check()`,
guaranteeing the discovering session read a cold cache. Swapped.

### Not regressed: startup cost

The check stays a detached double-fork; the prompt never waits on the network
(#20). The new test points the shell at a **black-holed endpoint** with a cold
cache and asserts first output still arrives in well under a second.

## Test

`tests/banner_update_test.py` — real ptys against a **seeded state file**, no
network, so it is deterministic on any runner. 16 checks, **5 fail before this
change**:

- the knob's four precedence cases
- the banner announcing a pending release unprompted, and **naming the version**
- announcing once per version rather than nagging every session
- announcing again when a *newer* release appears
- the badge persisting across sessions, and clearing once the shell is current
- startup timing, with the check live and with it disabled

## Verification

- `make pty-test` — 26 ok / 0 failed / 4 skipped
- `make update-test` — 0 failed (both suites)
- `update_badge_test.py`, `update_ui_test.py` — 0 failed
- `make norm` — clean

Closes #56
