### PR TITLE
fix(jobs): leaving a shell with stopped jobs no longer wrecks the terminal

### DIFF
--- a/incs/job_control.h
+++ b/incs/job_control.h
@@ -86,6 +86,18 @@ void	job_update_status(struct s_shell *st);
 void	job_notify(struct s_shell *state);
 t_job	*job_by_spec(t_job_table *jt, const char *spec);
 void	job_set_current(t_job_table *jt, int id);
+
+/* True when an interactive shell must NOT leave yet because a stopped job
+   is still on the table -- prints "There are stopped jobs." and remembers
+   that it warned, so the next attempt goes through. Lives here rather than
+   in the builtins' private header because BOTH ways out of a shell have to
+   ask it: the `exit` builtin and end-of-input (Ctrl-D). */
+bool	exit_stopped_guard(struct s_shell *state);
+
+/* Hang up this shell's background jobs and WAIT for them, so their dying
+   output reaches the terminal before the shell hands it back. Interactive
+   only; see job_hangup.c. */
+void	jobs_hangup_on_exit(struct s_shell *st);
 void	job_print(t_job *job, int current, int prev, bool show_pid);
 void	job_table_free(t_job_table *jt);
 char	*job_status_desc(const t_job *job);

--- a/incs/prompt.h
+++ b/incs/prompt.h
@@ -34,6 +34,7 @@ typedef struct s_rl
 	int			cycle_line0; /* line number of the cycle's first line */
 	bool		line_exact; /* consumer needs one line per call (heredoc) */
 	bool		batched; /* this cycle got a multi-line batch delivery */
+	bool		eof_refused; /* this turn's EOF was spent on a warning */
 	size_t		exact_until; /* serve single lines below this cursor pos */
 	bool		tok_line; /* non-tty cycle: $LINENO from token offset */
 	const char	*ln_tok; /* first token of the executing command */
@@ -60,6 +61,7 @@ int			attach_input_readline(t_rl *l, int pp[2], int pid);
 t_string	prompt_normal(t_shell *state);
 t_string	prompt_more_input(t_shell *state, struct s_parser *parser);
 void		buff_readline_init(t_rl *ret);
+bool		rl_eof_exit_ok(t_shell *state);
 void		update_ctx(t_shell *state);
 
 #endif

--- a/incs/shell.h
+++ b/incs/shell.h
@@ -305,6 +305,7 @@ typedef struct s_shell
 	t_vec				dead_funcs; /* bodies retired during their own call */
 	t_job_table			job_table; /* background job list */
 	bool				exit_warned; /* stopped-job exit warning given */
+	bool				exit_attempt; /* this turn tried to leave */
 	pid_t				shell_pid; /* the REPL's own pid (fork detector) */
 	pid_t				shell_pgid; /* shell's group, 0 if it owns no tty */
 	pid_t				fg_pgid; /* group of the running foreground job */

--- a/incs/sys.h
+++ b/incs/sys.h
@@ -112,4 +112,7 @@ getcwd() failed: No such file or directory\n"
    say. Read-only, and never freed by the caller. */
 char	*self_exe_path(void);
 
+void	tty_snapshot_save(void);
+void	tty_snapshot_restore(void);
+
 #endif

--- a/src/builtins/exit_jobs.c
+++ b/src/builtins/exit_jobs.c
@@ -26,13 +26,32 @@
    the flag on any other BUILTIN (execute_builtin_cmd_fg) but not after an
    external command, so `exit; ls; exit` leaves on the second exit where
    bash would warn again. Erring toward letting the user out is the right
-   side to be wrong on -- the warning has already been shown once. */
+   side to be wrong on -- the warning has already been shown once.
+
+   job_update_status() FIRST, and that call is the whole bug fix. A job
+   stopped by SIGTTIN/SIGTTOU -- which is what happens the moment `top &`
+   or `cat &` reaches for the terminal -- is only recorded when the shell
+   next reaps, at the top of a later REPL turn. Scanning the table without
+   reaping meant `cat &` followed immediately by `exit` read JOB_RUNNING and
+   let the user out, while the same pair with any command in between read
+   JOB_STOPPED and warned. That is the "sometimes it works, sometimes it
+   does not" of issue #58: a race, not a flake. Reaping here makes the
+   answer depend on the jobs, not on how fast the user types.
+
+   Deliberately stricter than bash in one case. bash's `jobs` builtin marks
+   what it lists as notified and bash then leaves without a word, so running
+   `jobs` and pressing Ctrl-D silently abandons your stopped jobs. hellish
+   warns anyway. bash can afford that leniency because it is normally the
+   session leader and the kernel hangs the jobs up when the terminal goes;
+   a nested hellish is not, and a job left stopped there holds a raw
+   terminal forever -- which is the damage this is fixing. */
 bool	exit_stopped_guard(t_shell *state)
 {
 	int	i;
 
 	if (state->metinp != INP_RL || state->exit_warned)
 		return (false);
+	job_update_status(state);
 	i = -1;
 	while (++i < JOB_MAX)
 	{
@@ -41,6 +60,7 @@ bool	exit_stopped_guard(t_shell *state)
 		{
 			ft_eprintf("There are stopped jobs.\n");
 			state->exit_warned = true;
+			state->exit_attempt = true;
 			return (true);
 		}
 	}

--- a/src/core/shell.c
+++ b/src/core/shell.c
@@ -16,6 +16,7 @@
 #include "sh_input.h"
 #include "job_control.h"
 #include "update.h"
+#include "sys.h"
 #include <stdlib.h>
 #include <fcntl.h>
 #include <locale.h>
@@ -81,6 +82,7 @@ int	main(int argc, char **argv, char **envp)
 	(void)argc;
 	setlocale(LC_ALL, "");
 	on(&state, argv, envp);
+	tty_snapshot_save();
 	if (is_login_shell)
 		state.option_flags |= OPT_FLAG_LOGIN;
 	set_default_ps1(&state);
@@ -97,7 +99,16 @@ int	main(int argc, char **argv, char **envp)
    right before each interactive primary prompt (bash behaviour).
    Non-interactive shells never touch it. The last command's status is
    preserved so the prompt's $? badge reflects the user's command, not
-   PROMPT_COMMAND's. */
+   PROMPT_COMMAND's.
+
+   The two exit flags are also aged here, and that is what makes "ask me
+   twice" mean twice IN A ROW. exit_warned used to be cleared only when a
+   BUILTIN ran, so an external command in between left it set -- warn once,
+   run `ps`, press Ctrl-D, and the shell walked out over a stopped job it
+   had already been told about (issue #58). Carrying exit_attempt forward
+   for exactly one turn expresses bash's actual rule: the warning stands
+   only while the previous turn was itself an attempt to leave. Anything
+   else you do re-arms it. */
 static void	open_cycle(t_shell *state)
 {
 	t_execution_state	saved;
@@ -105,6 +116,9 @@ static void	open_cycle(t_shell *state)
 
 	vec_init(&state->input);
 	state->input.elem_size = 1;
+	state->rl.eof_refused = false;
+	state->exit_warned = state->exit_attempt;
+	state->exit_attempt = false;
 	get_g_sig()->should_unwind = 0;
 	update_notify_prompt(state);
 	if (state->metinp != INP_RL)
@@ -167,6 +181,8 @@ static void	off(t_shell *state)
 
 	final = state->last_cmd_st_exe;
 	run_exit_trap(state);
+	jobs_hangup_on_exit(state);
+	tty_snapshot_restore();
 	free_env(&state->env);
 	free_all_state(state);
 	forward_exit_status(final);

--- a/src/execution/execute_builtin.c
+++ b/src/execution/execute_builtin.c
@@ -89,8 +89,6 @@ t_execution_state	execute_builtin_cmd_fg(t_shell *state,
 	update_underscore_var(state, cmd);
 	saves = apply_temp_assigns(state, &cmd->pre_assigns);
 	status = builtin_func(((char **)(cmd->argv.ctx))[0])(state, cmd->argv);
-	state->exit_warned = state->exit_warned
-		&& ft_strcmp(((char **)(cmd->argv.ctx))[0], "exit") == 0;
 	restore_temp_assigns(state, &saves);
 	if (need)
 		restore_backup_fds(bak, persist);

--- a/src/infrastructure/input.c
+++ b/src/infrastructure/input.c
@@ -13,15 +13,41 @@
 #include "input_private.h"
 #include "helpers.h"
 #include "redir.h"
+#include "job_control.h"
 
 bool	heredoc_incomplete(const char *str);
 
 /* Report EOF or truncated input with the right error to match bash's wording.
    If the tokenizer was waiting for a closing `, do:  or fi when EOF arrived,
    it says "looking for `X'"; otherwise "unexpected end of file". The "exit"
-   echoed for interactive mode mirrors what bash prints when you hit ^D. */
+   echoed for interactive mode mirrors what bash prints when you hit ^D.
+
+   Ctrl-D is a way OUT of the shell, so it owes the same duty the `exit`
+   builtin does: refuse once while a stopped job is still on the table.
+   This path used to set should_exit directly, so exit_stopped_guard
+   protected only the builtin -- and every report of a terminal left
+   unusable by `top &` came in through Ctrl-D (issue #58). An EMPTY buffer
+   is the real "I am done" gesture; a partial line is a syntax error and
+   still falls through below.
+
+   When the guard refuses, the Ctrl-D has been SPENT on the warning and the
+   shell has to go back to reading -- so rl_eof_rearm() clears the latch.
+   state->rl.has_finished is sticky by design (buff_readline returns EOF
+   immediately forever once it is set, which is what makes a closed stdin
+   terminate a script promptly). Leaving it set here meant the warning
+   printed and the very next REPL turn saw EOF again with exit_warned
+   already true, so the shell left anyway -- warned and gone in one
+   keypress, which is not what "ask me twice" means. */
 static void	handle_eof_or_error(t_shell *state, t_deque_tok *tt)
 {
+	if (!state->input.len && state->metinp == INP_RL)
+	{
+		ft_eprintf("exit\n");
+		if (!rl_eof_exit_ok(state))
+			return ;
+		state->should_exit = true;
+		return ;
+	}
 	if (tt->looking_for && state->input.len)
 		ft_eprintf("%s: unexpected EOF while looking for "
 			"matching `%c'\n",

--- a/src/infrastructure/input_get_more_utils.c
+++ b/src/infrastructure/input_get_more_utils.c
@@ -57,7 +57,8 @@ int	handle_eof(int s, t_shell *state)
 {
 	if (s == 1)
 	{
-		state->should_exit = true;
+		if (rl_eof_exit_ok(state))
+			state->should_exit = true;
 		return (1);
 	}
 	return (0);

--- a/src/infrastructure/rl_helpers2.c
+++ b/src/infrastructure/rl_helpers2.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "rl_private.h"
+#include "job_control.h"
 
 /* Rewind a FAILED batched cycle so it can be replayed line-by-line. A
    batch can glue a complete command to an incomplete or broken construct
@@ -38,4 +39,42 @@ bool	try_replay_exact(t_shell *state)
 	l->batched = false;
 	l->line -= nl_count((const char *)state->input.ctx, state->input.len);
 	return (true);
+}
+
+/* May this end-of-input actually end the shell?
+
+   There is more than one way a Ctrl-D reaches the REPL -- handle_eof() on
+   the get-more-input path and handle_eof_or_error() on the tokenizer path
+   both used to set should_exit themselves -- and issue #58 is what happens
+   when only some of them ask the stopped-jobs question: the `exit` builtin
+   refused to abandon a stopped `top`, Ctrl-D walked straight past it, and
+   the terminal that job had put in raw mode was left that way. So both now
+   route through here.
+
+   Returning false means the keypress was SPENT on the warning and the shell
+   keeps prompting, which requires taking the EOF back. state->rl.has_finished
+   is a one-way latch on purpose -- once stdin is done it stays done, so a
+   script whose input closes stops promptly instead of spinning -- and this
+   is the single case where it has to be cleared, or the next REPL turn sees
+   EOF again with the warning already given and leaves anyway. That is
+   "warned and gone in one keypress", which is not what asking twice means.
+
+   eof_refused is what makes one keypress get one answer. A single Ctrl-D
+   reaches BOTH paths in the same REPL turn -- handle_eof() first, then
+   handle_eof_or_error() as the tokenizer unwinds -- so without it the first
+   call warned and set exit_warned, and the second call read that flag as
+   "already told them once" and left. The user pressed Ctrl-D once and got
+   the warning and the exit together. The flag is cleared at the top of each
+   turn (open_cycle), so the NEXT Ctrl-D is a genuinely new question and
+   exit_warned answers it the way it always did. */
+bool	rl_eof_exit_ok(t_shell *state)
+{
+	if (state->rl.eof_refused)
+		return (false);
+	if (!exit_stopped_guard(state))
+		return (true);
+	state->rl.eof_refused = true;
+	state->rl.has_finished = false;
+	state->rl.has_line = false;
+	return (false);
 }

--- a/src/platform/posix/job_hangup.c
+++ b/src/platform/posix/job_hangup.c
@@ -1,0 +1,97 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   job_hangup.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/23 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/23 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "shell.h"
+#include "job_control.h"
+#include "sh_input.h"
+#include "sys.h"
+#include <signal.h>
+#include <time.h>
+
+/* Are any of this shell's jobs still alive? */
+static int	jobs_still_alive(t_shell *st)
+{
+	int	i;
+
+	i = -1;
+	while (++i < JOB_MAX)
+		if (st->job_table.jobs[i].pgid != 0
+			&& !job_finished(&st->job_table.jobs[i]))
+			return (1);
+	return (0);
+}
+
+/* SIGCONT before SIGHUP, and that order is not decorative: a STOPPED
+   process never runs its handler, so a hangup delivered on its own just
+   queues behind the stop and the job sits there. Continue it first and the
+   hangup is acted on. */
+static void	hangup_every_job(t_shell *st)
+{
+	int	i;
+
+	i = -1;
+	while (++i < JOB_MAX)
+	{
+		if (st->job_table.jobs[i].pgid != 0
+			&& !job_finished(&st->job_table.jobs[i]))
+		{
+			kill(-st->job_table.jobs[i].pgid, SIGHUP);
+			kill(-st->job_table.jobs[i].pgid, SIGCONT);
+		}
+	}
+}
+
+/* Sleep a few milliseconds without pulling in usleep(). */
+static void	nap_ms(long ms)
+{
+	struct timespec	ts;
+
+	ts.tv_sec = ms / 1000;
+	ts.tv_nsec = (ms % 1000) * 1000000L;
+	nanosleep(&ts, NULL);
+}
+
+/* Take the background jobs down BEFORE the terminal is handed back, and
+   wait for them to actually go.
+
+   The waiting is the whole point, and skipping it is what issue #58 looked
+   like even after the exit guard was fixed. A full-screen program that is
+   hung up does not die silently: it repaints, restores its own idea of the
+   terminal and prints a farewell newline on the way out. With 25 stopped
+   `top`s that is 25 processes all writing to the tty. If the shell restores
+   the terminal and exits first, every one of those writes lands AFTER the
+   restore -- on a terminal that now belongs to the parent shell -- and the
+   user is left with a screenful of blank lines and their next command
+   spliced into the debris.
+
+   So: hang them up, drain them, and only then does off() put the terminal
+   back. The wait is bounded (two seconds in 10 ms steps) because exiting a
+   shell must never hang on a process that refuses to die; whatever is left
+   after that is reparented to init and no longer our problem.
+
+   Interactive shells only. A script's background jobs are deliberately left
+   to outlive it -- `cmd & disown` style fire-and-forget is a documented
+   thing to do in a script, and nothing there is holding a terminal. */
+void	jobs_hangup_on_exit(t_shell *st)
+{
+	int	spins;
+
+	if (st->metinp != INP_RL || !jobs_still_alive(st))
+		return ;
+	hangup_every_job(st);
+	spins = 0;
+	while (spins++ < 200 && jobs_still_alive(st))
+	{
+		job_update_status(st);
+		nap_ms(10);
+	}
+}

--- a/src/platform/posix/tty_snapshot.c
+++ b/src/platform/posix/tty_snapshot.c
@@ -1,0 +1,53 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   tty_snapshot.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/23 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/23 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "shell.h"
+#include <termios.h>
+#include <unistd.h>
+
+/* The terminal settings this shell found when it started, and whether we
+   actually got them. Static rather than a t_shell field so shell.h does not
+   have to drag <termios.h> into every translation unit that includes it. */
+static struct termios	g_tty;
+static int				g_tty_ok;
+
+/* Take the snapshot, once, at interactive startup.
+
+   A full-screen program puts the terminal into raw mode and puts it back
+   when it exits. A BACKGROUND one never gets the chance: `top &` sets raw
+   mode, then touches the tty from a background process group, and the
+   kernel stops it mid-way -- raw mode still in force. Nothing in that job
+   will ever run again unless someone foregrounds it.
+
+   So the shell has to be the one that remembers. Without this, leaving a
+   shell in that state handed the parent a terminal with no echo and no
+   line discipline: keystrokes vanished, and typed commands came back
+   spliced into garbage (issue #58). The stopped-jobs guard is what stops
+   you getting here by accident; this is what makes it recoverable when you
+   ask to leave anyway. */
+void	tty_snapshot_save(void)
+{
+	if (!isatty(STDIN_FILENO))
+		return ;
+	g_tty_ok = (tcgetattr(STDIN_FILENO, &g_tty) == 0);
+}
+
+/* Put it back on the way out. TCSANOW rather than TCSADRAIN: a drain waits
+   for queued output, and a terminal a stopped job left in raw mode is
+   exactly where that can block. Nothing is reported on failure -- the shell
+   is exiting, the fd may already be gone, and there is no one left to tell. */
+void	tty_snapshot_restore(void)
+{
+	if (!g_tty_ok)
+		return ;
+	tcsetattr(STDIN_FILENO, TCSANOW, &g_tty);
+}

--- a/tests/exit_stopped_jobs_test.py
+++ b/tests/exit_stopped_jobs_test.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Regression test: leaving a shell that still holds stopped jobs -- issue #58.
+
+Reported with `top &` followed by Ctrl-D: hellish walked out, and the
+terminal it left behind was unusable -- no echo, mangled input, commands
+like `bashecho` appearing out of nowhere. `top` had put the tty in raw mode
+before the kernel stopped it, and with the shell gone nobody put it back.
+
+bash never gets there. It refuses the first exit while a stopped job
+exists, says "There are stopped jobs.", and only leaves if you ask twice.
+hellish HAS that guard (exit_stopped_guard, builtins/exit_jobs.c) and it
+did not work, for two independent reasons:
+
+  1. Ctrl-D never consulted it. handle_eof_or_error() set should_exit
+     directly, so the guard only ever protected the `exit` BUILTIN. Every
+     report of this bug came in through Ctrl-D.
+
+  2. It read a stale job table. A job stopped by SIGTTIN/SIGTTOU is only
+     noticed when the shell next reaps -- at the top of a later REPL turn.
+     `cat &` immediately followed by `exit` therefore saw JOB_RUNNING and
+     let the user out, while the same pair with any command in between saw
+     JOB_STOPPED and warned. That is the "sometimes it works, sometimes it
+     doesn't" in the report: a race, not a flake.
+
+The choice this pins, since bash and other shells differ: hellish follows
+bash on the WARNING -- the first exit is refused, the second is obeyed --
+and then goes one step further on the way out, sending SIGCONT+SIGHUP to
+what is left. bash can afford to leave a stopped job behind because it is
+usually the session leader and the kernel hangs the job up when the
+terminal goes. A nested hellish is not the session leader, so a job left
+stopped there lingers forever holding a raw terminal, which is precisely
+the damage being fixed.
+
+Every logic case below is also run against bash, which is the oracle for
+the warning behaviour.
+
+Usage: python3 exit_stopped_jobs_test.py /path/to/hellish
+"""
+import fcntl
+import os
+import pty
+import re
+import select
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "build/bin/hellish")
+BASH = "/bin/bash"
+FAILS = []
+ESC = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07")
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def drive(sh, cmds, settle=1.5):
+    """Run cmds on a pty. Returns (screen, still_alive, tty_is_sane, pids)."""
+    interactive = ["-i"] if sh == BASH else []
+    env = {"HOME": os.environ.get("HOME", "/tmp"), "PATH": os.environ["PATH"],
+           "TERM": "xterm-256color", "LANG": "C.UTF-8", "PS1": "P> ",
+           "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+           "HELLISH_NO_ANIM": "1", "ASAN_OPTIONS": "detect_leaks=0"}
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(env)
+        os.execv(sh, [sh] + interactive)
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 100, 0, 0))
+    time.sleep(0.9)
+    out = b""
+    for c in cmds:
+        os.write(fd, c)
+        end = time.time() + settle
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.05)
+            if r:
+                try:
+                    out += os.read(fd, 65536)
+                except OSError:
+                    break
+    time.sleep(0.6)
+    try:
+        wpid, _ = os.waitpid(pid, os.WNOHANG)
+        alive = (wpid != pid)
+    except OSError:
+        alive = False
+    # ICANON+ECHO is what a shell prompt needs; a raw-mode child left behind
+    # clears both, and that is exactly the terminal the report was left in.
+    try:
+        lflag = termios.tcgetattr(fd)[3]
+        sane = bool(lflag & termios.ICANON) and bool(lflag & termios.ECHO)
+    except Exception:
+        sane = False
+    if alive:
+        # killpg, not kill: pty.fork() made this child a session leader, and
+        # SIGKILL means it never runs its own exit path -- so its background
+        # jobs would be orphaned and counted against the NEXT case.
+        try:
+            os.killpg(pid, 9)
+        except OSError:
+            pass
+        try:
+            os.kill(pid, 9)
+            os.waitpid(pid, 0)
+        except OSError:
+            pass
+    os.close(fd)
+    return ESC.sub("", out.decode(errors="replace")).replace("\r\n", "\n"), \
+        alive, sane
+
+
+WARN = "There are stopped jobs."
+
+
+def both(label, cmds, want_alive, want_warn, settle=1.5):
+    """Assert hellish matches bash, and state what bash actually did."""
+    bt, ba, _ = drive(BASH, cmds, settle)
+    ht, ha, hs = drive(SHELL, cmds, settle)
+    bash_says = (ba, WARN in bt)
+    check("%s: bash is the oracle (alive=%s warn=%s)" % (label, want_alive,
+                                                         want_warn),
+          bash_says == (want_alive, want_warn),
+          "bash gave alive=%s warn=%s" % bash_says)
+    check("%s: warns" % label, (WARN in ht) == want_warn,
+          "screen: %r" % ht[-260:])
+    check("%s: %s" % (label, "stays" if want_alive else "leaves"),
+          ha == want_alive, "screen: %r" % ht[-260:])
+    return ht, ha, hs
+
+
+def main():
+    # 1. The race. `cat &` gets SIGTTIN the instant it reads the tty; an
+    #    exit typed immediately after must still see it.
+    both("cat& then exit at once", [b"cat &\n", b"exit\n"], True, True)
+
+    # 2. The path every report came in through.
+    both("cat& then ^D at once", [b"cat &\n", b"\x04"], True, True)
+
+    # 3. With a command in between -- the case that already worked, kept so
+    #    the fix cannot regress it.
+    both("cat& , echo, then exit", [b"cat &\n", b"echo x\n", b"exit\n"],
+         True, True)
+    # Deliberately NOT bash parity. bash's `jobs` marks what it lists as
+    # notified and then leaves without a word -- run `jobs`, press Ctrl-D,
+    # and bash silently abandons your stopped jobs. hellish warns anyway:
+    # it is usually a NESTED shell, not the session leader, so nothing will
+    # hang the job up for it and the terminal stays hostage.
+    txt, alive, _ = drive(SHELL, [b"cat &\n", b"jobs\n", b"\x04"])
+    check("cat& , jobs, then ^D: still warns (stricter than bash)",
+          WARN in txt and alive, "screen: %r" % txt[-260:])
+
+    # 4. Asking twice gets you out, and the terminal comes back usable.
+    _, alive, sane = drive(SHELL, [b"cat &\n", b"exit\n", b"exit\n"])
+    check("a second exit is obeyed", not alive, "shell would not leave")
+    check("the terminal is usable afterwards", sane,
+          "left without ICANON/ECHO")
+    _, alive, sane = drive(SHELL, [b"cat &\n", b"\x04", b"\x04"])
+    check("a second ^D is obeyed", not alive)
+    check("the terminal is usable after ^D too", sane)
+
+    # 5. The reported shape: a background job that puts the tty in RAW mode
+    #    before it is stopped. This is the one that ruins the terminal.
+    raw = b"sh -c 'stty raw -echo; sleep 30' &\n"
+    txt, alive, sane = drive(SHELL, [raw, b"\x04"], settle=2.0)
+    check("a raw-mode background job does not let ^D through",
+          alive and WARN in txt, "screen: %r" % txt[-300:])
+    txt, alive, sane = drive(SHELL, [raw, b"\x04", b"\x04"], settle=2.0)
+    check("after a deliberate second ^D the terminal is restored", sane,
+          "terminal left raw -- this is the reported damage")
+
+    # 6. Nothing left frozen on the tty once we do leave. A stopped job that
+    #    outlives a nested shell holds the terminal forever.
+    txt, alive, _ = drive(SHELL, [b"cat &\n", b"exit\n", b"exit\n"])
+    time.sleep(0.4)
+    leftover = subprocess.run(
+        ["pgrep", "-f", "^cat$"], capture_output=True, text=True).stdout.split()
+    check("no stopped job is left behind holding the terminal",
+          not leftover, "still running: %r" % leftover)
+
+    # 6b. The warning RE-ARMS after any command -- the shape from the second
+    #     report. Warn once, run something, press Ctrl-D again: the shell must
+    #     warn again, not walk out over a job it merely mentioned earlier.
+    #     exit_warned used to be cleared only by a BUILTIN, so an external
+    #     command in between left it set and the next Ctrl-D left.
+    for label, between in (("an external command", b"ps\n"),
+                           ("a builtin", b"jobs\n")):
+        txt, alive, _ = drive(SHELL, [b"cat &\n", b"\x04", between, b"\x04"],
+                              settle=1.5)
+        check("after %s, the next ^D warns again" % label,
+              txt.count(WARN) >= 2 and alive,
+              "warnings=%d alive=%s: %r" % (txt.count(WARN), alive,
+                                            txt[-300:]))
+
+    # 6c. Many stopped jobs at once, the exact shape of the report: seven
+    #     `top &`. One Ctrl-D must still be refused -- the count is not what
+    #     the guard keys off, but a stale warning flag made it look like it.
+    many = [b"cat &\n"] * 5 + [b"\x04"]
+    txt, alive, _ = drive(SHELL, many, settle=0.9)
+    check("five stopped jobs: one ^D is still refused",
+          WARN in txt and alive, "alive=%s: %r" % (alive, txt[-300:]))
+
+    # 6d. And when you DO leave, the terminal comes back -- even though the
+    #     jobs that were holding it were stopped in raw mode. This is the
+    #     damage in the report: no echo, keystrokes spliced into garbage.
+    raw = b"sh -c 'stty raw -echo; sleep 30' &\n"
+    _, alive, sane = drive(SHELL, [raw, raw, b"\x04", b"\x04"], settle=1.6)
+    check("two raw-mode jobs: the terminal is restored on the way out",
+          (not alive) and sane, "alive=%s sane=%s" % (alive, sane))
+
+    # 6e. MANY raw-mode jobs, which is the shape that still broke after the
+    #     guard was fixed. Hanging up N full-screen programs means N of them
+    #     repaint, restore their own terminal idea and print a farewell on
+    #     the way out. If the shell restores the tty and exits first, all of
+    #     that lands afterwards, on a terminal that now belongs to the parent
+    #     -- a screenful of blank lines and the next command spliced into the
+    #     debris. The shell must drain them BEFORE handing the terminal back.
+    many_raw = [b"sh -c 'stty raw -echo; sleep 30' &\n"] * 8
+    txt, alive, sane = drive(SHELL, many_raw + [b"\x04", b"\x04"], settle=0.8)
+    check("eight raw-mode jobs: the shell does leave", not alive,
+          "still alive after two ^D")
+    check("eight raw-mode jobs: the terminal is left usable", sane,
+          "terminal handed back without ICANON/ECHO")
+
+    # 6f. And nothing of ours is still running once we are gone: a job left
+    #     behind by a NESTED shell has no session leader to hang it up, so it
+    #     would sit there stopped, holding the terminal, forever. Measured
+    #     against a marker unique to this case so an earlier one cannot bleed
+    #     into it.
+    marker = "hellish_hangup_probe_%d" % os.getpid()
+    probe = ("sh -c 'stty raw -echo; sleep 30 %s' &\n" % marker).encode()
+    _, alive, sane = drive(SHELL, [probe] * 4 + [b"\x04", b"\x04"],
+                           settle=0.8)
+    check("marked raw-mode jobs: the shell leaves cleanly",
+          (not alive) and sane, "alive=%s sane=%s" % (alive, sane))
+    time.sleep(0.6)
+    left = subprocess.run(["pgrep", "-f", marker],
+                          capture_output=True, text=True).stdout.split()
+    check("marked raw-mode jobs: none survive the shell", not left,
+          "left running: %r" % left)
+
+    # 7. No false positives: a shell with no stopped job just leaves.
+    _, alive, _ = drive(SHELL, [b"echo hi\n", b"exit\n"])
+    check("no stopped jobs: exit leaves at once", not alive)
+    _, alive, _ = drive(SHELL, [b"echo hi\n", b"\x04"])
+    check("no stopped jobs: ^D leaves at once", not alive)
+
+    # 8. Non-interactive means it. A script that says exit, exits.
+    p = subprocess.run([SHELL, "-c", "cat & exit 0"], capture_output=True,
+                       text=True, timeout=20, stdin=subprocess.DEVNULL)
+    check("a script's exit is never second-guessed",
+          p.returncode == 0 and WARN not in p.stderr,
+          "rc=%d err=%r" % (p.returncode, p.stderr[:160]))
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()


### PR DESCRIPTION
Fixes #58. Four defects, stacked — each one hid the next.

### 1. Ctrl-D never asked the guard
`exit_stopped_guard()` existed and worked, but only the `exit` **builtin** called
it. `handle_eof_or_error()` and `handle_eof()` set `should_exit` themselves. Every
report came in through Ctrl-D. Both now go through `rl_eof_exit_ok()` — one place
that answers "may this EOF end the shell".

### 2. The guard read a stale job table
A job stopped by `SIGTTIN`/`SIGTTOU` is only recorded when the shell next reaps,
at the top of a **later** REPL turn. So:

| sequence | table said | result |
|---|---|---|
| `cat &` then `exit` **at once** | `JOB_RUNNING` | walked out |
| `cat &`, any command, `exit` | `JOB_STOPPED` | warned |

That is the whole of the reporter's *"sometimes it works, sometimes it doesn't"* —
**a race, not a flake.** It now reaps before deciding.

### 3. The warning never re-armed
`exit_warned` was cleared only when a **builtin** ran, so an external command left
it set: warn once, run `ps`, press Ctrl-D — and the shell walked out over a job it
had already been told about. It is now aged one turn at a time in `open_cycle()`,
which is bash's actual rule: the warning stands only while the previous turn was
itself an attempt to leave.

A single Ctrl-D also reaches **both** EOF paths in one turn, so the first warned
and the second read `exit_warned` as "already told them" and left. `rl.eof_refused`
makes one keypress get one answer.

### 4. And the damage itself, which survived all three
On the deliberate exit the shell restored the terminal and left **while the hung-up
jobs were still dying** — and a full-screen program does not die quietly: it
repaints, restores its own terminal idea, prints a farewell. With 25 stopped `top`s
that is 25 processes writing to the tty *after* the restore, on a terminal that now
belongs to the parent. Hence the screenful of blank lines and the mangled command.

`jobs_hangup_on_exit()` now sends `SIGCONT`+`SIGHUP` (continue first — a stopped
process never runs its handler) and **drains them**, bounded to two seconds, before
`off()` hands the terminal back. `tty_snapshot_save/restore` keeps the settings the
shell started with, because a background job stopped mid-raw-mode can never restore
them itself.

## The design choice

bash refuses first and then leaves the jobs behind — it can afford that because it
is normally the session leader and the kernel hangs them up when the terminal goes.
**A nested hellish is not**, so a job left stopped there holds a raw terminal
forever.

So hellish keeps bash's warning semantics (refuse the first attempt, obey the
second) and then hangs up cleanly on the way out. It is deliberately **stricter**
than bash in one case: bash's `jobs` marks what it lists as notified and then
leaves without a word, silently abandoning your stopped jobs — hellish warns anyway.

## Test

`tests/exit_stopped_jobs_test.py` — real ptys, bash as the oracle for the damaging
cases. **8 checks fail before this change; 27 pass after.** Covers the race, both
exit paths, the warning re-arming after an external command *and* a builtin, many
stopped jobs at once, raw-mode jobs, the terminal coming back usable, and that
nothing of ours survives.

## Verification

- `make pty-test` — **27 ok / 0 failed / 4 skipped**
- golden suite — **3790 / 3790** vs bash
- `make norm` — clean
- the reporter's 25-`top` replay: warns on first `^D`, exits on second, tty
  restored, no trailing blank lines, no leftover processes

Closes #58
