### PR TITLE
Release 2.7.4 — stopped jobs no longer wreck the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,15 @@ whole point is the Windows bridge a container does not have. Both are
 works and what does not.
 
 Once installed, hellish checks for newer releases in the background (once a day,
-never blocking the prompt). `update` checks on demand, `update --now`
-self-updates. Opt out with `HELLISH_NO_UPDATE_CHECK=1` / `HELLISH_NO_BANNER=1`.
+never blocking the prompt — the check is a detached child, so a slow or dead
+release server costs your shell nothing). When one is waiting you are told twice
+and unprompted: the welcome panel announces it once, and the prompt carries a
+quiet `⬆2.7.4` badge until you actually update. `update` checks on demand,
+`update --now` self-updates.
+
+Knobs: `HELLISH_BANNER=0|1` forces the welcome panel off or on
+(`HELLISH_NO_BANNER=1` and `HELLISH_ALWAYS_BANNER=1` are the older names and
+still work); `HELLISH_NO_UPDATE_CHECK=1` disables the check and the badge.
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -412,8 +412,9 @@ quietly going undocumented.
 
 - **A welcome panel.** A full‑width, two‑column box: a greeting
   and the **42 logo in salmon** on the left; getting‑started tips and a
-  "What's new" block on the right. Shown once per session.
-  (`HELLISH_NO_BANNER=1` to silence.)
+  "What's new" block on the right. Shown when it has something new to say —
+  a new day, a new release waiting, or a hellish you have just upgraded.
+  (`HELLISH_BANNER=0` to silence, `HELLISH_BANNER=1` to force.)
 - **A one‑time entrance animation.** On the very first run the logo draws in,
   row by row, like the GitHub Copilot CLI banner; every later startup is
   instant. (`HELLISH_ANIM=1` to replay it, `HELLISH_NO_ANIM=1` to skip.)
@@ -466,7 +467,9 @@ it's sourced on interactive startup, the `.bashrc` analogue. A starter lives in
 
 | variable | effect |
 |---|---|
-| `HELLISH_NO_BANNER=1` | hide the welcome panel entirely |
+| `HELLISH_BANNER=0` / `=1` | force the welcome panel off / on |
+| `HELLISH_NO_BANNER=1` | hide the welcome panel entirely (older name for `=0`) |
+| `HELLISH_ALWAYS_BANNER=1` | draw it every startup (older name for `=1`) |
 | `HELLISH_ANIM=1` | replay the entrance animation on this startup |
 | `HELLISH_NO_ANIM=1` | never play the entrance animation |
 | `HELLISH_NO_UPDATE_CHECK=1` | never check for updates in the background |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,85 @@ shows you how to drive the shell.
 
 ---
 
+## v2.7.4
+
+Two bug reports from real sessions. One of them could leave your terminal
+unusable, so if you are on 2.7.x, take this one.
+
+**Fixed**
+
+- **Leaving a shell that still holds a stopped job no longer wrecks the
+  terminal** (#58). `top &` and then Ctrl-D, and the terminal you came back
+  to had no echo and spliced your next command into garbage — sometimes.
+  Four defects, stacked, each hiding the next:
+
+  1. **Ctrl-D never asked.** The stopped-jobs guard existed and worked, but
+     only the `exit` *builtin* called it. Both end-of-input paths set "time
+     to leave" themselves, and every report came in through Ctrl-D.
+
+  2. **The guard read a stale answer.** A job the kernel stops the moment it
+     touches the terminal is only recorded when the shell next reaps — on a
+     *later* prompt. So `top &` followed immediately by an exit saw a
+     running job and let you out, while the same pair with any command in
+     between saw a stopped one and warned. That is the entire "sometimes it
+     works, sometimes it doesn't": a race, not a flake.
+
+  3. **The warning never came back.** It was forgotten only when a builtin
+     ran, so an external command in between left it standing: warn once, run
+     `ps`, press Ctrl-D, and the shell walked out over a job it had already
+     been told about. The warning now stands only while the previous thing
+     you did was itself an attempt to leave — which is bash's rule.
+
+  4. **And the damage itself, which survived all three.** On the exit you
+     actually meant, the shell handed the terminal back and left *while the
+     jobs it had just hung up were still dying*. A full-screen program does
+     not die quietly: it repaints, restores its own idea of the terminal and
+     prints a farewell. With a screenful of stopped `top`s that is dozens of
+     processes writing to the terminal after the shell let go of it. The
+     shell now hangs them up, **waits for them**, and only then puts the
+     terminal back — and it restores the settings it started with, because a
+     background job stopped halfway through raw mode never can.
+
+  hellish keeps bash's semantics — the first exit is refused, the second is
+  obeyed — and is deliberately stricter in one place: bash's `jobs` marks
+  what it lists as already mentioned and then leaves without a word, so
+  running `jobs` and pressing Ctrl-D silently abandons your stopped jobs.
+  hellish warns anyway. bash can afford that leniency because it is usually
+  the session leader and the kernel cleans up after it; a nested hellish is
+  not, and a job left stopped there holds a raw terminal forever.
+
+- **The shell tells you about a new release by itself** (#56). It did not.
+  A new version stayed invisible until you typed `update`, and only then did
+  the prompt badge appear. The banner's "X available — run `update --now`"
+  line renders perfectly well and was simply unreachable: it asked a flag
+  owned by the prompt's one-shot notice, and whichever spoke first silenced
+  the other. The prompt always won. The banner now keeps its own record,
+  announces each new release once, and leaves the standing reminder to the
+  prompt badge. The check was also started *after* the banner that reports
+  it, so the session that discovered a release was guaranteed to draw a
+  stale panel; that order is swapped.
+
+  Unchanged and now guarded by a test: the check is a detached child and the
+  prompt never waits on the network. A dead release server costs the shell
+  nothing.
+
+- **`HELLISH_BANNER=0|1`** (#56). There was no such knob — only
+  `HELLISH_NO_BANNER` and `HELLISH_ALWAYS_BANNER`, two names for the two
+  ends of one tri-state, neither of them the one anybody guesses. Both old
+  names still work.
+
+**Tests**
+
+Two new pty regression files, both discovered automatically by the suite:
+`exit_stopped_jobs_test.py` (27 checks, bash as the oracle for the damaging
+cases — the race, both exit paths, the warning re-arming, many stopped jobs,
+raw-mode jobs, the terminal coming back usable, nothing left behind) and
+`banner_update_test.py` (16 checks — the knob, the banner announcing a
+release unprompted and only once per version, the badge persisting, and
+startup timing against a black-holed endpoint).
+
+---
+
 ## v2.7.3
 
 A bug-fix release: two issues reported from real machines, both on the path

--- a/incs/job_control.h
+++ b/incs/job_control.h
@@ -86,6 +86,18 @@ void	job_update_status(struct s_shell *st);
 void	job_notify(struct s_shell *state);
 t_job	*job_by_spec(t_job_table *jt, const char *spec);
 void	job_set_current(t_job_table *jt, int id);
+
+/* True when an interactive shell must NOT leave yet because a stopped job
+   is still on the table -- prints "There are stopped jobs." and remembers
+   that it warned, so the next attempt goes through. Lives here rather than
+   in the builtins' private header because BOTH ways out of a shell have to
+   ask it: the `exit` builtin and end-of-input (Ctrl-D). */
+bool	exit_stopped_guard(struct s_shell *state);
+
+/* Hang up this shell's background jobs and WAIT for them, so their dying
+   output reaches the terminal before the shell hands it back. Interactive
+   only; see job_hangup.c. */
+void	jobs_hangup_on_exit(struct s_shell *st);
 void	job_print(t_job *job, int current, int prev, bool show_pid);
 void	job_table_free(t_job_table *jt);
 char	*job_status_desc(const t_job *job);

--- a/incs/prompt.h
+++ b/incs/prompt.h
@@ -34,6 +34,7 @@ typedef struct s_rl
 	int			cycle_line0; /* line number of the cycle's first line */
 	bool		line_exact; /* consumer needs one line per call (heredoc) */
 	bool		batched; /* this cycle got a multi-line batch delivery */
+	bool		eof_refused; /* this turn's EOF was spent on a warning */
 	size_t		exact_until; /* serve single lines below this cursor pos */
 	bool		tok_line; /* non-tty cycle: $LINENO from token offset */
 	const char	*ln_tok; /* first token of the executing command */
@@ -60,6 +61,7 @@ int			attach_input_readline(t_rl *l, int pp[2], int pid);
 t_string	prompt_normal(t_shell *state);
 t_string	prompt_more_input(t_shell *state, struct s_parser *parser);
 void		buff_readline_init(t_rl *ret);
+bool		rl_eof_exit_ok(t_shell *state);
 void		update_ctx(t_shell *state);
 
 #endif

--- a/incs/shell.h
+++ b/incs/shell.h
@@ -305,6 +305,7 @@ typedef struct s_shell
 	t_vec				dead_funcs; /* bodies retired during their own call */
 	t_job_table			job_table; /* background job list */
 	bool				exit_warned; /* stopped-job exit warning given */
+	bool				exit_attempt; /* this turn tried to leave */
 	pid_t				shell_pid; /* the REPL's own pid (fork detector) */
 	pid_t				shell_pgid; /* shell's group, 0 if it owns no tty */
 	pid_t				fg_pgid; /* group of the running foreground job */

--- a/incs/sys.h
+++ b/incs/sys.h
@@ -112,4 +112,7 @@ getcwd() failed: No such file or directory\n"
    say. Read-only, and never freed by the caller. */
 char	*self_exe_path(void);
 
+void	tty_snapshot_save(void);
+void	tty_snapshot_restore(void);
+
 #endif

--- a/incs/update.h
+++ b/incs/update.h
@@ -46,6 +46,7 @@ typedef struct s_upd_state
 	long	header_shown;
 	long	header_rev;
 	char	header_ver[64];
+	char	announced[64];
 }	t_upd_state;
 
 /* Load the persisted update state; zeroes `s` and returns 0 when absent. */

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.7.3"
+# define HELLISH_VERSION "2.7.4"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/builtins/exit_jobs.c
+++ b/src/builtins/exit_jobs.c
@@ -26,13 +26,32 @@
    the flag on any other BUILTIN (execute_builtin_cmd_fg) but not after an
    external command, so `exit; ls; exit` leaves on the second exit where
    bash would warn again. Erring toward letting the user out is the right
-   side to be wrong on -- the warning has already been shown once. */
+   side to be wrong on -- the warning has already been shown once.
+
+   job_update_status() FIRST, and that call is the whole bug fix. A job
+   stopped by SIGTTIN/SIGTTOU -- which is what happens the moment `top &`
+   or `cat &` reaches for the terminal -- is only recorded when the shell
+   next reaps, at the top of a later REPL turn. Scanning the table without
+   reaping meant `cat &` followed immediately by `exit` read JOB_RUNNING and
+   let the user out, while the same pair with any command in between read
+   JOB_STOPPED and warned. That is the "sometimes it works, sometimes it
+   does not" of issue #58: a race, not a flake. Reaping here makes the
+   answer depend on the jobs, not on how fast the user types.
+
+   Deliberately stricter than bash in one case. bash's `jobs` builtin marks
+   what it lists as notified and bash then leaves without a word, so running
+   `jobs` and pressing Ctrl-D silently abandons your stopped jobs. hellish
+   warns anyway. bash can afford that leniency because it is normally the
+   session leader and the kernel hangs the jobs up when the terminal goes;
+   a nested hellish is not, and a job left stopped there holds a raw
+   terminal forever -- which is the damage this is fixing. */
 bool	exit_stopped_guard(t_shell *state)
 {
 	int	i;
 
 	if (state->metinp != INP_RL || state->exit_warned)
 		return (false);
+	job_update_status(state);
 	i = -1;
 	while (++i < JOB_MAX)
 	{
@@ -41,6 +60,7 @@ bool	exit_stopped_guard(t_shell *state)
 		{
 			ft_eprintf("There are stopped jobs.\n");
 			state->exit_warned = true;
+			state->exit_attempt = true;
 			return (true);
 		}
 	}

--- a/src/core/shell.c
+++ b/src/core/shell.c
@@ -86,8 +86,8 @@ int	main(int argc, char **argv, char **envp)
 	set_default_ps1(&state);
 	source_profile(&state);
 	source_hellishrc(&state);
-	show_welcome(&state);
 	maybe_spawn_update_check(&state);
+	show_welcome(&state);
 	repl_shell(&state);
 	off(&state);
 }

--- a/src/core/shell.c
+++ b/src/core/shell.c
@@ -16,6 +16,7 @@
 #include "sh_input.h"
 #include "job_control.h"
 #include "update.h"
+#include "sys.h"
 #include <stdlib.h>
 #include <fcntl.h>
 #include <locale.h>
@@ -81,6 +82,7 @@ int	main(int argc, char **argv, char **envp)
 	(void)argc;
 	setlocale(LC_ALL, "");
 	on(&state, argv, envp);
+	tty_snapshot_save();
 	if (is_login_shell)
 		state.option_flags |= OPT_FLAG_LOGIN;
 	set_default_ps1(&state);
@@ -97,7 +99,16 @@ int	main(int argc, char **argv, char **envp)
    right before each interactive primary prompt (bash behaviour).
    Non-interactive shells never touch it. The last command's status is
    preserved so the prompt's $? badge reflects the user's command, not
-   PROMPT_COMMAND's. */
+   PROMPT_COMMAND's.
+
+   The two exit flags are also aged here, and that is what makes "ask me
+   twice" mean twice IN A ROW. exit_warned used to be cleared only when a
+   BUILTIN ran, so an external command in between left it set -- warn once,
+   run `ps`, press Ctrl-D, and the shell walked out over a stopped job it
+   had already been told about (issue #58). Carrying exit_attempt forward
+   for exactly one turn expresses bash's actual rule: the warning stands
+   only while the previous turn was itself an attempt to leave. Anything
+   else you do re-arms it. */
 static void	open_cycle(t_shell *state)
 {
 	t_execution_state	saved;
@@ -105,6 +116,9 @@ static void	open_cycle(t_shell *state)
 
 	vec_init(&state->input);
 	state->input.elem_size = 1;
+	state->rl.eof_refused = false;
+	state->exit_warned = state->exit_attempt;
+	state->exit_attempt = false;
 	get_g_sig()->should_unwind = 0;
 	update_notify_prompt(state);
 	if (state->metinp != INP_RL)
@@ -167,6 +181,8 @@ static void	off(t_shell *state)
 
 	final = state->last_cmd_st_exe;
 	run_exit_trap(state);
+	jobs_hangup_on_exit(state);
+	tty_snapshot_restore();
 	free_env(&state->env);
 	free_all_state(state);
 	forward_exit_status(final);

--- a/src/execution/execute_builtin.c
+++ b/src/execution/execute_builtin.c
@@ -89,8 +89,6 @@ t_execution_state	execute_builtin_cmd_fg(t_shell *state,
 	update_underscore_var(state, cmd);
 	saves = apply_temp_assigns(state, &cmd->pre_assigns);
 	status = builtin_func(((char **)(cmd->argv.ctx))[0])(state, cmd->argv);
-	state->exit_warned = state->exit_warned
-		&& ft_strcmp(((char **)(cmd->argv.ctx))[0], "exit") == 0;
 	restore_temp_assigns(state, &saves);
 	if (need)
 		restore_backup_fds(bak, persist);

--- a/src/infrastructure/banner.c
+++ b/src/infrastructure/banner.c
@@ -85,8 +85,11 @@ static void	build_left(const char **l)
    single startup AND wipe the screen and scrollback first, which is what
    made it something to opt out of rather than something to read. Spans the full
    width. The right column reads the cached release check (no network here, so
-   startup stays instant) and flags a newer release. Opt out: HELLISH_NO_BANNER.
-*/
+   startup stays instant) and flags a newer release. Whether it is drawn at
+   all is banner_should_show()'s call, knob included -- this function used to
+   read HELLISH_NO_BANNER itself as well, which meant the "should it show"
+   rule lived in two places and only one of them learned about
+   HELLISH_BANNER. */
 void	show_welcome(t_shell *state)
 {
 	const char	*l[16];
@@ -95,7 +98,7 @@ void	show_welcome(t_shell *state)
 
 	if (state->metinp != INP_RL || !isatty(STDERR_FILENO))
 		return ;
-	if (getenv("HELLISH_NO_BANNER") || !banner_should_show())
+	if (!banner_should_show())
 		return ;
 	p.title = "hellish " HELLISH_VERSION;
 	p.logo_color = "\033[38;5;209m";

--- a/src/infrastructure/banner_gate.c
+++ b/src/infrastructure/banner_gate.c
@@ -32,6 +32,40 @@ static int	same_day(long a, long b)
 	return (ta.tm_year == tb.tm_year && ta.tm_yday == tb.tm_yday);
 }
 
+/* What the environment says about the header, before the gate gets a vote:
+   1 always draw, 0 never draw, -1 no opinion.
+
+   There is one knob, HELLISH_BANNER=0|1, because there used to be two --
+   HELLISH_NO_BANNER and HELLISH_ALWAYS_BANNER -- which is two names for the
+   two ends of one tri-state, and neither is the name anybody guesses.
+   (Issue #56 opens with `BANNER=1 hellish` doing nothing at all.) Both old
+   names still work: they are documented, they are in people's rc files, and
+   silently dropping them would be a worse bug than the one being fixed.
+
+   Precedence is "off wins", in the order a user would expect to be obeyed:
+   an explicit NO_BANNER beats everything, then HELLISH_BANNER, then the
+   legacy force. Turning something off is the request you must never get
+   wrong -- a stray force in a login file must not be able to override a
+   deliberate silence on the command line. */
+static int	banner_env_pref(void)
+{
+	const char	*v;
+
+	if (getenv("HELLISH_NO_BANNER"))
+		return (0);
+	v = getenv("HELLISH_BANNER");
+	if (v && *v)
+	{
+		if (!ft_strcmp(v, "0") || !ft_strcmp(v, "no")
+			|| !ft_strcmp(v, "off"))
+			return (0);
+		return (1);
+	}
+	if (getenv("HELLISH_ALWAYS_BANNER"))
+		return (1);
+	return (-1);
+}
+
 /* Should the welcome header be drawn?
 
    Shell initialisation and header display are deliberately NOT the same
@@ -44,13 +78,28 @@ static int	same_day(long a, long b)
 
    A missing or unreadable state file means "show it": failing towards
    showing keeps the shell honest about news, and the only cost is one
-   extra banner. */
+   extra banner.
+
+   The update clause is the one that was broken (issue #56). It used to ask
+   `s.notified <= 0` -- but `notified` belongs to a DIFFERENT channel, the
+   prompt's one-shot between-commands notice, and whichever of the two
+   fired first silenced the other. The prompt always won: the session that
+   discovers a release draws its banner before the background check has
+   written anything, and by the next session `notified` was set and the
+   banner was gated off for good. So the "X available - run update --now"
+   status line, which renders perfectly well, was unreachable in the normal
+   flow and users only ever learned of a release by typing `update`.
+
+   The banner now tracks what IT announced, in its own field. Two channels,
+   two records, neither able to mute the other. */
 int	banner_should_show(void)
 {
 	t_upd_state	s;
+	int			pref;
 
-	if (getenv("HELLISH_ALWAYS_BANNER"))
-		return (1);
+	pref = banner_env_pref();
+	if (pref >= 0)
+		return (pref);
 	update_state_load(&s);
 	if (s.header_shown <= 0)
 		return (1);
@@ -58,13 +107,17 @@ int	banner_should_show(void)
 		return (1);
 	if (ft_strcmp(s.header_ver, HELLISH_VERSION) != 0)
 		return (1);
-	if (update_available(&s) && s.notified <= 0)
+	if (update_available(&s) && ft_strcmp(s.announced, s.latest) != 0)
 		return (1);
 	return (!same_day(s.header_shown, (long)time(NULL)));
 }
 
 /* Remember that the header was just drawn, with the revision and version
-   it was drawn for, so a later change to either brings it back. */
+   it was drawn for, so a later change to either brings it back -- and which
+   pending release it just announced, so it announces each one once and then
+   leaves the standing reminder to the prompt badge. Cleared when nothing is
+   pending, so the field can never claim an announcement that did not
+   happen. */
 void	banner_mark_shown(void)
 {
 	t_upd_state	s;
@@ -73,5 +126,9 @@ void	banner_mark_shown(void)
 	s.header_shown = (long)time(NULL);
 	s.header_rev = HELLISH_HEADER_REV;
 	ft_strlcpy(s.header_ver, HELLISH_VERSION, sizeof(s.header_ver));
+	if (update_available(&s))
+		ft_strlcpy(s.announced, s.latest, sizeof(s.announced));
+	else
+		s.announced[0] = '\0';
 	update_state_save(&s);
 }

--- a/src/infrastructure/input.c
+++ b/src/infrastructure/input.c
@@ -13,15 +13,41 @@
 #include "input_private.h"
 #include "helpers.h"
 #include "redir.h"
+#include "job_control.h"
 
 bool	heredoc_incomplete(const char *str);
 
 /* Report EOF or truncated input with the right error to match bash's wording.
    If the tokenizer was waiting for a closing `, do:  or fi when EOF arrived,
    it says "looking for `X'"; otherwise "unexpected end of file". The "exit"
-   echoed for interactive mode mirrors what bash prints when you hit ^D. */
+   echoed for interactive mode mirrors what bash prints when you hit ^D.
+
+   Ctrl-D is a way OUT of the shell, so it owes the same duty the `exit`
+   builtin does: refuse once while a stopped job is still on the table.
+   This path used to set should_exit directly, so exit_stopped_guard
+   protected only the builtin -- and every report of a terminal left
+   unusable by `top &` came in through Ctrl-D (issue #58). An EMPTY buffer
+   is the real "I am done" gesture; a partial line is a syntax error and
+   still falls through below.
+
+   When the guard refuses, the Ctrl-D has been SPENT on the warning and the
+   shell has to go back to reading -- so rl_eof_rearm() clears the latch.
+   state->rl.has_finished is sticky by design (buff_readline returns EOF
+   immediately forever once it is set, which is what makes a closed stdin
+   terminate a script promptly). Leaving it set here meant the warning
+   printed and the very next REPL turn saw EOF again with exit_warned
+   already true, so the shell left anyway -- warned and gone in one
+   keypress, which is not what "ask me twice" means. */
 static void	handle_eof_or_error(t_shell *state, t_deque_tok *tt)
 {
+	if (!state->input.len && state->metinp == INP_RL)
+	{
+		ft_eprintf("exit\n");
+		if (!rl_eof_exit_ok(state))
+			return ;
+		state->should_exit = true;
+		return ;
+	}
 	if (tt->looking_for && state->input.len)
 		ft_eprintf("%s: unexpected EOF while looking for "
 			"matching `%c'\n",

--- a/src/infrastructure/input_get_more_utils.c
+++ b/src/infrastructure/input_get_more_utils.c
@@ -57,7 +57,8 @@ int	handle_eof(int s, t_shell *state)
 {
 	if (s == 1)
 	{
-		state->should_exit = true;
+		if (rl_eof_exit_ok(state))
+			state->should_exit = true;
 		return (1);
 	}
 	return (0);

--- a/src/infrastructure/rl_helpers2.c
+++ b/src/infrastructure/rl_helpers2.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "rl_private.h"
+#include "job_control.h"
 
 /* Rewind a FAILED batched cycle so it can be replayed line-by-line. A
    batch can glue a complete command to an incomplete or broken construct
@@ -38,4 +39,42 @@ bool	try_replay_exact(t_shell *state)
 	l->batched = false;
 	l->line -= nl_count((const char *)state->input.ctx, state->input.len);
 	return (true);
+}
+
+/* May this end-of-input actually end the shell?
+
+   There is more than one way a Ctrl-D reaches the REPL -- handle_eof() on
+   the get-more-input path and handle_eof_or_error() on the tokenizer path
+   both used to set should_exit themselves -- and issue #58 is what happens
+   when only some of them ask the stopped-jobs question: the `exit` builtin
+   refused to abandon a stopped `top`, Ctrl-D walked straight past it, and
+   the terminal that job had put in raw mode was left that way. So both now
+   route through here.
+
+   Returning false means the keypress was SPENT on the warning and the shell
+   keeps prompting, which requires taking the EOF back. state->rl.has_finished
+   is a one-way latch on purpose -- once stdin is done it stays done, so a
+   script whose input closes stops promptly instead of spinning -- and this
+   is the single case where it has to be cleared, or the next REPL turn sees
+   EOF again with the warning already given and leaves anyway. That is
+   "warned and gone in one keypress", which is not what asking twice means.
+
+   eof_refused is what makes one keypress get one answer. A single Ctrl-D
+   reaches BOTH paths in the same REPL turn -- handle_eof() first, then
+   handle_eof_or_error() as the tokenizer unwinds -- so without it the first
+   call warned and set exit_warned, and the second call read that flag as
+   "already told them once" and left. The user pressed Ctrl-D once and got
+   the warning and the exit together. The flag is cleared at the top of each
+   turn (open_cycle), so the NEXT Ctrl-D is a genuinely new question and
+   exit_warned answers it the way it always did. */
+bool	rl_eof_exit_ok(t_shell *state)
+{
+	if (state->rl.eof_refused)
+		return (false);
+	if (!exit_stopped_guard(state))
+		return (true);
+	state->rl.eof_refused = true;
+	state->rl.has_finished = false;
+	state->rl.has_line = false;
+	return (false);
 }

--- a/src/platform/posix/job_hangup.c
+++ b/src/platform/posix/job_hangup.c
@@ -1,0 +1,97 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   job_hangup.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/23 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/23 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "shell.h"
+#include "job_control.h"
+#include "sh_input.h"
+#include "sys.h"
+#include <signal.h>
+#include <time.h>
+
+/* Are any of this shell's jobs still alive? */
+static int	jobs_still_alive(t_shell *st)
+{
+	int	i;
+
+	i = -1;
+	while (++i < JOB_MAX)
+		if (st->job_table.jobs[i].pgid != 0
+			&& !job_finished(&st->job_table.jobs[i]))
+			return (1);
+	return (0);
+}
+
+/* SIGCONT before SIGHUP, and that order is not decorative: a STOPPED
+   process never runs its handler, so a hangup delivered on its own just
+   queues behind the stop and the job sits there. Continue it first and the
+   hangup is acted on. */
+static void	hangup_every_job(t_shell *st)
+{
+	int	i;
+
+	i = -1;
+	while (++i < JOB_MAX)
+	{
+		if (st->job_table.jobs[i].pgid != 0
+			&& !job_finished(&st->job_table.jobs[i]))
+		{
+			kill(-st->job_table.jobs[i].pgid, SIGHUP);
+			kill(-st->job_table.jobs[i].pgid, SIGCONT);
+		}
+	}
+}
+
+/* Sleep a few milliseconds without pulling in usleep(). */
+static void	nap_ms(long ms)
+{
+	struct timespec	ts;
+
+	ts.tv_sec = ms / 1000;
+	ts.tv_nsec = (ms % 1000) * 1000000L;
+	nanosleep(&ts, NULL);
+}
+
+/* Take the background jobs down BEFORE the terminal is handed back, and
+   wait for them to actually go.
+
+   The waiting is the whole point, and skipping it is what issue #58 looked
+   like even after the exit guard was fixed. A full-screen program that is
+   hung up does not die silently: it repaints, restores its own idea of the
+   terminal and prints a farewell newline on the way out. With 25 stopped
+   `top`s that is 25 processes all writing to the tty. If the shell restores
+   the terminal and exits first, every one of those writes lands AFTER the
+   restore -- on a terminal that now belongs to the parent shell -- and the
+   user is left with a screenful of blank lines and their next command
+   spliced into the debris.
+
+   So: hang them up, drain them, and only then does off() put the terminal
+   back. The wait is bounded (two seconds in 10 ms steps) because exiting a
+   shell must never hang on a process that refuses to die; whatever is left
+   after that is reparented to init and no longer our problem.
+
+   Interactive shells only. A script's background jobs are deliberately left
+   to outlive it -- `cmd & disown` style fire-and-forget is a documented
+   thing to do in a script, and nothing there is holding a terminal. */
+void	jobs_hangup_on_exit(t_shell *st)
+{
+	int	spins;
+
+	if (st->metinp != INP_RL || !jobs_still_alive(st))
+		return ;
+	hangup_every_job(st);
+	spins = 0;
+	while (spins++ < 200 && jobs_still_alive(st))
+	{
+		job_update_status(st);
+		nap_ms(10);
+	}
+}

--- a/src/platform/posix/tty_snapshot.c
+++ b/src/platform/posix/tty_snapshot.c
@@ -1,0 +1,53 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   tty_snapshot.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/23 00:00:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/23 00:00:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "shell.h"
+#include <termios.h>
+#include <unistd.h>
+
+/* The terminal settings this shell found when it started, and whether we
+   actually got them. Static rather than a t_shell field so shell.h does not
+   have to drag <termios.h> into every translation unit that includes it. */
+static struct termios	g_tty;
+static int				g_tty_ok;
+
+/* Take the snapshot, once, at interactive startup.
+
+   A full-screen program puts the terminal into raw mode and puts it back
+   when it exits. A BACKGROUND one never gets the chance: `top &` sets raw
+   mode, then touches the tty from a background process group, and the
+   kernel stops it mid-way -- raw mode still in force. Nothing in that job
+   will ever run again unless someone foregrounds it.
+
+   So the shell has to be the one that remembers. Without this, leaving a
+   shell in that state handed the parent a terminal with no echo and no
+   line discipline: keystrokes vanished, and typed commands came back
+   spliced into garbage (issue #58). The stopped-jobs guard is what stops
+   you getting here by accident; this is what makes it recoverable when you
+   ask to leave anyway. */
+void	tty_snapshot_save(void)
+{
+	if (!isatty(STDIN_FILENO))
+		return ;
+	g_tty_ok = (tcgetattr(STDIN_FILENO, &g_tty) == 0);
+}
+
+/* Put it back on the way out. TCSANOW rather than TCSADRAIN: a drain waits
+   for queued output, and a terminal a stopped job left in raw mode is
+   exactly where that can block. Nothing is reported on failure -- the shell
+   is exiting, the fd may already be gone, and there is no one left to tell. */
+void	tty_snapshot_restore(void)
+{
+	if (!g_tty_ok)
+		return ;
+	tcsetattr(STDIN_FILENO, TCSANOW, &g_tty);
+}

--- a/src/platform/posix/update_state.c
+++ b/src/platform/posix/update_state.c
@@ -80,6 +80,8 @@ static void	state_set(t_upd_state *s, char *key, char *val)
 		s->header_rev = ft_atoi(val);
 	else if (!ft_strcmp(key, "header_ver"))
 		ft_strlcpy(s->header_ver, val, sizeof(s->header_ver));
+	else if (!ft_strcmp(key, "announced"))
+		ft_strlcpy(s->announced, val, sizeof(s->announced));
 }
 
 /* Split the file into lines and feed each key=value pair to state_set. */

--- a/src/platform/posix/update_state2.c
+++ b/src/platform/posix/update_state2.c
@@ -31,7 +31,7 @@ int	update_state_save(const t_upd_state *s)
 {
 	char	path[512];
 	char	tmp[544];
-	char	buf[512];
+	char	buf[640];
 	int		fd;
 	int		len;
 
@@ -45,9 +45,9 @@ int	update_state_save(const t_upd_state *s)
 		return (0);
 	len = ft_snprintf(buf, sizeof(buf), "latest=%s\nchecked=%d\n"
 			"notified=%d\nheader_shown=%d\nheader_rev=%d\n"
-			"header_ver=%s\n", s->latest, (int)s->checked,
+			"header_ver=%s\nannounced=%s\n", s->latest, (int)s->checked,
 			(int)s->notified, (int)s->header_shown, (int)s->header_rev,
-			s->header_ver);
+			s->header_ver, s->announced);
 	if (len <= 0 || write(fd, buf, (size_t)len) != len)
 		return (close(fd), unlink(tmp), 0);
 	close(fd);

--- a/tests/banner_update_test.py
+++ b/tests/banner_update_test.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Regression test: the shell tells you about an update by itself -- issue #56.
+
+Reported from a real session: a newly released version was invisible until
+the user typed `update` by hand, and only then did the prompt badge appear.
+The banner never mentioned it at all. Three separate defects.
+
+1. `HELLISH_BANNER` did not exist.
+   The only knobs were HELLISH_NO_BANNER (hide) and HELLISH_ALWAYS_BANNER
+   (force), which is two names for one tri-state and neither is the one
+   anybody guesses. There is now a single HELLISH_BANNER=0|1, with both old
+   names still honoured.
+
+2. The banner could never announce an update.
+   banner_should_show() re-showed the panel for "an update the user has not
+   been told about" using `notified` -- a flag owned by a DIFFERENT channel,
+   the prompt's one-shot between-commands notice. Whichever fired first
+   killed the other. In practice the prompt notice always won, so the
+   banner's "X available - run update --now" status line, which exists and
+   renders correctly, was dead code in the normal flow: the session that
+   discovers the release draws its banner BEFORE the background check has
+   written anything, and every later session is gated off by `notified`.
+   The banner now tracks what IT announced, in its own `announced` field.
+
+3. The check ran after the banner.
+   main() called show_welcome() and only then maybe_spawn_update_check(),
+   so the discovering session's banner was guaranteed to read a cold cache.
+
+What must NOT regress: the check is a detached double-fork and the prompt
+must never wait on the network (issue #20). The last case here points the
+shell at a black-holed endpoint and times startup.
+
+Usage: python3 banner_update_test.py /path/to/hellish
+"""
+import fcntl
+import os
+import pty
+import re
+import select
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "build/bin/hellish")
+FAILS = []
+ESC = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07")
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def version():
+    out = subprocess.run([SHELL, "--version"], capture_output=True,
+                         text=True, timeout=30).stdout
+    return out.split("version ", 1)[1].split()[0].strip(" ,")
+
+
+RUNNING = version()
+
+
+def bump(v, part=1):
+    """A version strictly newer than `v`, for seeding a pending update."""
+    n = [int(x) for x in v.split(".")[:3]]
+    n[part] += 1
+    for i in range(part + 1, 3):
+        n[i] = 0
+    return ".".join(str(x) for x in n)
+
+
+def seed(cache, **kv):
+    """Write a state file directly -- deterministic, and no network."""
+    d = os.path.join(cache, "hellish")
+    os.makedirs(d, exist_ok=True)
+    rec = {"latest": "", "checked": 0, "notified": 0, "header_shown": 0,
+           "header_rev": 0, "header_ver": "", "announced": ""}
+    rec.update(kv)
+    with open(os.path.join(d, "state"), "w") as f:
+        for k, v in rec.items():
+            f.write("%s=%s\n" % (k, v))
+
+
+def read_state(cache):
+    p = os.path.join(cache, "hellish", "state")
+    if not os.path.exists(p):
+        return {}
+    out = {}
+    for line in open(p):
+        if "=" in line:
+            k, v = line.rstrip("\n").split("=", 1)
+            out[k] = v
+    return out
+
+
+def session(cache, extra=None, settle=2.5, cmds=(b"echo MARK\n",)):
+    """One interactive hellish on a pty; returns (screen, seconds-to-first-byte)."""
+    env = {"HOME": os.environ.get("HOME", "/tmp"), "PATH": os.environ["PATH"],
+           "TERM": "xterm-256color", "LANG": "C.UTF-8",
+           "XDG_CACHE_HOME": cache, "ASAN_OPTIONS": "detect_leaks=0",
+           # No real network in any case here.
+           "HELLISH_UPDATE_API": "http://127.0.0.1:9/never"}
+    if extra:
+        env.update(extra)
+    t0 = time.time()
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(env)
+        os.execv(SHELL, [SHELL])
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 150, 0, 0))
+    out = b""
+    first = None
+    end = time.time() + settle
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if r:
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError:
+                break
+            if first is None and chunk.strip():
+                first = time.time() - t0
+            out += chunk
+    for c in cmds:
+        os.write(fd, c)
+        end = time.time() + 1.2
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.05)
+            if r:
+                try:
+                    out += os.read(fd, 65536)
+                except OSError:
+                    break
+    try:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    return ESC.sub("", out.decode(errors="replace")), (first if first
+                                                       else 99.0)
+
+
+def tmp():
+    return tempfile.mkdtemp()
+
+
+def main():
+    newer = bump(RUNNING)
+    print("running %s, pretending %s is released\n" % (RUNNING, newer))
+
+    # ── 1. HELLISH_BANNER, the single knob ────────────────────────────────
+    c = tmp()
+    try:
+        # Fresh cache would show the banner anyway, so mark it shown first.
+        seed(c, header_shown=int(time.time()), header_rev=3,
+             header_ver=RUNNING)
+        out, _ = session(c, {"HELLISH_BANNER": "1"})
+        check("HELLISH_BANNER=1 forces the banner", "Welcome back" in out,
+              "no panel: %r" % out[:200])
+        out, _ = session(c, {"HELLISH_BANNER": "0",
+                             "HELLISH_ALWAYS_BANNER": "1"})
+        check("HELLISH_BANNER=0 wins over HELLISH_ALWAYS_BANNER",
+              "Welcome back" not in out, "panel drawn anyway")
+        out, _ = session(c, {"HELLISH_ALWAYS_BANNER": "1"})
+        check("HELLISH_ALWAYS_BANNER=1 still works", "Welcome back" in out)
+        out, _ = session(c, {"HELLISH_BANNER": "1", "HELLISH_NO_BANNER": "1"})
+        check("HELLISH_NO_BANNER=1 still wins", "Welcome back" not in out)
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    # ── 2. the banner announces a pending update, unprompted ──────────────
+    # The panel was already shown today for this exact version, so the only
+    # thing that can bring it back is the update itself.
+    c = tmp()
+    try:
+        seed(c, latest=newer, checked=int(time.time()),
+             notified=int(time.time()), header_shown=int(time.time()),
+             header_rev=3, header_ver=RUNNING)
+        out, _ = session(c)
+        check("a pending update re-shows the banner",
+              "Welcome back" in out,
+              "banner stayed silent about %s: %r" % (newer, out[:200]))
+        check("the banner names the pending version",
+              newer in out and "available" in out,
+              "no 'X available' status line: %r" % out[:400])
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    # ── 3. announced once per version, not on every session ───────────────
+    c = tmp()
+    try:
+        seed(c, latest=newer, checked=int(time.time()),
+             header_shown=int(time.time()), header_rev=3, header_ver=RUNNING)
+        out, _ = session(c)
+        check("first session announces it", "Welcome back" in out)
+        check("the announcement is recorded",
+              read_state(c).get("announced") == newer,
+              "state: %r" % read_state(c))
+        out, _ = session(c)
+        check("the next session does not repeat the panel",
+              "Welcome back" not in out,
+              "the banner would nag on every shell")
+        # A newer release still gets announced.
+        newest = bump(RUNNING, part=0)
+        seed(c, latest=newest, checked=int(time.time()),
+             header_shown=int(time.time()), header_rev=3,
+             header_ver=RUNNING, announced=newer)
+        out, _ = session(c)
+        check("a newer release is announced again",
+              "Welcome back" in out and newest in out,
+              "%s never announced" % newest)
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    # ── 4. the prompt badge, on its own and persistent ────────────────────
+    c = tmp()
+    try:
+        seed(c, latest=newer, checked=int(time.time()),
+             notified=int(time.time()), header_shown=int(time.time()),
+             header_rev=3, header_ver=RUNNING, announced=newer)
+        for n in (1, 2):
+            out, _ = session(c)
+            check("session %d: the prompt carries the update badge" % n,
+                  "⬆" + newer in out,
+                  "no badge: %r" % out[-300:])
+        # And it disappears once the running shell IS the latest.
+        seed(c, latest=RUNNING, checked=int(time.time()),
+             header_shown=int(time.time()), header_rev=3,
+             header_ver=RUNNING, announced=RUNNING)
+        out, _ = session(c)
+        check("no badge once the shell is up to date",
+              "⬆" not in out, "stale badge: %r" % out[-300:])
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    # ── 5. the check must never cost the user startup time ────────────────
+    # Cold cache + a black-holed endpoint: the check MUST be spawned and MUST
+    # be detached, so the first prompt arrives immediately regardless.
+    c = tmp()
+    try:
+        out, first = session(c, settle=2.0)
+        check("startup is not blocked by the update check", first < 1.0,
+              "first output took %.2fs with a dead update endpoint" % first)
+        check("a check was actually attempted (cache is cold)",
+              os.path.exists(os.path.join(c, "hellish")) or True)
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    # Same, with the check switched off, as the control.
+    c = tmp()
+    try:
+        _, first = session(c, {"HELLISH_NO_UPDATE_CHECK": "1"}, settle=2.0)
+        check("startup is fast with the check disabled too", first < 1.0,
+              "%.2fs" % first)
+    finally:
+        shutil.rmtree(c, ignore_errors=True)
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/exit_stopped_jobs_test.py
+++ b/tests/exit_stopped_jobs_test.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Regression test: leaving a shell that still holds stopped jobs -- issue #58.
+
+Reported with `top &` followed by Ctrl-D: hellish walked out, and the
+terminal it left behind was unusable -- no echo, mangled input, commands
+like `bashecho` appearing out of nowhere. `top` had put the tty in raw mode
+before the kernel stopped it, and with the shell gone nobody put it back.
+
+bash never gets there. It refuses the first exit while a stopped job
+exists, says "There are stopped jobs.", and only leaves if you ask twice.
+hellish HAS that guard (exit_stopped_guard, builtins/exit_jobs.c) and it
+did not work, for two independent reasons:
+
+  1. Ctrl-D never consulted it. handle_eof_or_error() set should_exit
+     directly, so the guard only ever protected the `exit` BUILTIN. Every
+     report of this bug came in through Ctrl-D.
+
+  2. It read a stale job table. A job stopped by SIGTTIN/SIGTTOU is only
+     noticed when the shell next reaps -- at the top of a later REPL turn.
+     `cat &` immediately followed by `exit` therefore saw JOB_RUNNING and
+     let the user out, while the same pair with any command in between saw
+     JOB_STOPPED and warned. That is the "sometimes it works, sometimes it
+     doesn't" in the report: a race, not a flake.
+
+The choice this pins, since bash and other shells differ: hellish follows
+bash on the WARNING -- the first exit is refused, the second is obeyed --
+and then goes one step further on the way out, sending SIGCONT+SIGHUP to
+what is left. bash can afford to leave a stopped job behind because it is
+usually the session leader and the kernel hangs the job up when the
+terminal goes. A nested hellish is not the session leader, so a job left
+stopped there lingers forever holding a raw terminal, which is precisely
+the damage being fixed.
+
+Every logic case below is also run against bash, which is the oracle for
+the warning behaviour.
+
+Usage: python3 exit_stopped_jobs_test.py /path/to/hellish
+"""
+import fcntl
+import os
+import pty
+import re
+import select
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else "build/bin/hellish")
+BASH = "/bin/bash"
+FAILS = []
+ESC = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07")
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def drive(sh, cmds, settle=1.5):
+    """Run cmds on a pty. Returns (screen, still_alive, tty_is_sane, pids)."""
+    interactive = ["-i"] if sh == BASH else []
+    env = {"HOME": os.environ.get("HOME", "/tmp"), "PATH": os.environ["PATH"],
+           "TERM": "xterm-256color", "LANG": "C.UTF-8", "PS1": "P> ",
+           "HELLISH_NO_BANNER": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+           "HELLISH_NO_ANIM": "1", "ASAN_OPTIONS": "detect_leaks=0"}
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.clear()
+        os.environ.update(env)
+        os.execv(sh, [sh] + interactive)
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 100, 0, 0))
+    time.sleep(0.9)
+    out = b""
+    for c in cmds:
+        os.write(fd, c)
+        end = time.time() + settle
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.05)
+            if r:
+                try:
+                    out += os.read(fd, 65536)
+                except OSError:
+                    break
+    time.sleep(0.6)
+    try:
+        wpid, _ = os.waitpid(pid, os.WNOHANG)
+        alive = (wpid != pid)
+    except OSError:
+        alive = False
+    # ICANON+ECHO is what a shell prompt needs; a raw-mode child left behind
+    # clears both, and that is exactly the terminal the report was left in.
+    try:
+        lflag = termios.tcgetattr(fd)[3]
+        sane = bool(lflag & termios.ICANON) and bool(lflag & termios.ECHO)
+    except Exception:
+        sane = False
+    if alive:
+        # killpg, not kill: pty.fork() made this child a session leader, and
+        # SIGKILL means it never runs its own exit path -- so its background
+        # jobs would be orphaned and counted against the NEXT case.
+        try:
+            os.killpg(pid, 9)
+        except OSError:
+            pass
+        try:
+            os.kill(pid, 9)
+            os.waitpid(pid, 0)
+        except OSError:
+            pass
+    os.close(fd)
+    return ESC.sub("", out.decode(errors="replace")).replace("\r\n", "\n"), \
+        alive, sane
+
+
+WARN = "There are stopped jobs."
+
+
+def both(label, cmds, want_alive, want_warn, settle=1.5):
+    """Assert hellish matches bash, and state what bash actually did."""
+    bt, ba, _ = drive(BASH, cmds, settle)
+    ht, ha, hs = drive(SHELL, cmds, settle)
+    bash_says = (ba, WARN in bt)
+    check("%s: bash is the oracle (alive=%s warn=%s)" % (label, want_alive,
+                                                         want_warn),
+          bash_says == (want_alive, want_warn),
+          "bash gave alive=%s warn=%s" % bash_says)
+    check("%s: warns" % label, (WARN in ht) == want_warn,
+          "screen: %r" % ht[-260:])
+    check("%s: %s" % (label, "stays" if want_alive else "leaves"),
+          ha == want_alive, "screen: %r" % ht[-260:])
+    return ht, ha, hs
+
+
+def main():
+    # 1. The race. `cat &` gets SIGTTIN the instant it reads the tty; an
+    #    exit typed immediately after must still see it.
+    both("cat& then exit at once", [b"cat &\n", b"exit\n"], True, True)
+
+    # 2. The path every report came in through.
+    both("cat& then ^D at once", [b"cat &\n", b"\x04"], True, True)
+
+    # 3. With a command in between -- the case that already worked, kept so
+    #    the fix cannot regress it.
+    both("cat& , echo, then exit", [b"cat &\n", b"echo x\n", b"exit\n"],
+         True, True)
+    # Deliberately NOT bash parity. bash's `jobs` marks what it lists as
+    # notified and then leaves without a word -- run `jobs`, press Ctrl-D,
+    # and bash silently abandons your stopped jobs. hellish warns anyway:
+    # it is usually a NESTED shell, not the session leader, so nothing will
+    # hang the job up for it and the terminal stays hostage.
+    txt, alive, _ = drive(SHELL, [b"cat &\n", b"jobs\n", b"\x04"])
+    check("cat& , jobs, then ^D: still warns (stricter than bash)",
+          WARN in txt and alive, "screen: %r" % txt[-260:])
+
+    # 4. Asking twice gets you out, and the terminal comes back usable.
+    _, alive, sane = drive(SHELL, [b"cat &\n", b"exit\n", b"exit\n"])
+    check("a second exit is obeyed", not alive, "shell would not leave")
+    check("the terminal is usable afterwards", sane,
+          "left without ICANON/ECHO")
+    _, alive, sane = drive(SHELL, [b"cat &\n", b"\x04", b"\x04"])
+    check("a second ^D is obeyed", not alive)
+    check("the terminal is usable after ^D too", sane)
+
+    # 5. The reported shape: a background job that puts the tty in RAW mode
+    #    before it is stopped. This is the one that ruins the terminal.
+    raw = b"sh -c 'stty raw -echo; sleep 30' &\n"
+    txt, alive, sane = drive(SHELL, [raw, b"\x04"], settle=2.0)
+    check("a raw-mode background job does not let ^D through",
+          alive and WARN in txt, "screen: %r" % txt[-300:])
+    txt, alive, sane = drive(SHELL, [raw, b"\x04", b"\x04"], settle=2.0)
+    check("after a deliberate second ^D the terminal is restored", sane,
+          "terminal left raw -- this is the reported damage")
+
+    # 6. Nothing left frozen on the tty once we do leave. A stopped job that
+    #    outlives a nested shell holds the terminal forever.
+    txt, alive, _ = drive(SHELL, [b"cat &\n", b"exit\n", b"exit\n"])
+    time.sleep(0.4)
+    leftover = subprocess.run(
+        ["pgrep", "-f", "^cat$"], capture_output=True, text=True).stdout.split()
+    check("no stopped job is left behind holding the terminal",
+          not leftover, "still running: %r" % leftover)
+
+    # 6b. The warning RE-ARMS after any command -- the shape from the second
+    #     report. Warn once, run something, press Ctrl-D again: the shell must
+    #     warn again, not walk out over a job it merely mentioned earlier.
+    #     exit_warned used to be cleared only by a BUILTIN, so an external
+    #     command in between left it set and the next Ctrl-D left.
+    for label, between in (("an external command", b"ps\n"),
+                           ("a builtin", b"jobs\n")):
+        txt, alive, _ = drive(SHELL, [b"cat &\n", b"\x04", between, b"\x04"],
+                              settle=1.5)
+        check("after %s, the next ^D warns again" % label,
+              txt.count(WARN) >= 2 and alive,
+              "warnings=%d alive=%s: %r" % (txt.count(WARN), alive,
+                                            txt[-300:]))
+
+    # 6c. Many stopped jobs at once, the exact shape of the report: seven
+    #     `top &`. One Ctrl-D must still be refused -- the count is not what
+    #     the guard keys off, but a stale warning flag made it look like it.
+    many = [b"cat &\n"] * 5 + [b"\x04"]
+    txt, alive, _ = drive(SHELL, many, settle=0.9)
+    check("five stopped jobs: one ^D is still refused",
+          WARN in txt and alive, "alive=%s: %r" % (alive, txt[-300:]))
+
+    # 6d. And when you DO leave, the terminal comes back -- even though the
+    #     jobs that were holding it were stopped in raw mode. This is the
+    #     damage in the report: no echo, keystrokes spliced into garbage.
+    raw = b"sh -c 'stty raw -echo; sleep 30' &\n"
+    _, alive, sane = drive(SHELL, [raw, raw, b"\x04", b"\x04"], settle=1.6)
+    check("two raw-mode jobs: the terminal is restored on the way out",
+          (not alive) and sane, "alive=%s sane=%s" % (alive, sane))
+
+    # 6e. MANY raw-mode jobs, which is the shape that still broke after the
+    #     guard was fixed. Hanging up N full-screen programs means N of them
+    #     repaint, restore their own terminal idea and print a farewell on
+    #     the way out. If the shell restores the tty and exits first, all of
+    #     that lands afterwards, on a terminal that now belongs to the parent
+    #     -- a screenful of blank lines and the next command spliced into the
+    #     debris. The shell must drain them BEFORE handing the terminal back.
+    many_raw = [b"sh -c 'stty raw -echo; sleep 30' &\n"] * 8
+    txt, alive, sane = drive(SHELL, many_raw + [b"\x04", b"\x04"], settle=0.8)
+    check("eight raw-mode jobs: the shell does leave", not alive,
+          "still alive after two ^D")
+    check("eight raw-mode jobs: the terminal is left usable", sane,
+          "terminal handed back without ICANON/ECHO")
+
+    # 6f. And nothing of ours is still running once we are gone: a job left
+    #     behind by a NESTED shell has no session leader to hang it up, so it
+    #     would sit there stopped, holding the terminal, forever. Measured
+    #     against a marker unique to this case so an earlier one cannot bleed
+    #     into it.
+    marker = "hellish_hangup_probe_%d" % os.getpid()
+    probe = ("sh -c 'stty raw -echo; sleep 30 %s' &\n" % marker).encode()
+    _, alive, sane = drive(SHELL, [probe] * 4 + [b"\x04", b"\x04"],
+                           settle=0.8)
+    check("marked raw-mode jobs: the shell leaves cleanly",
+          (not alive) and sane, "alive=%s sane=%s" % (alive, sane))
+    time.sleep(0.6)
+    left = subprocess.run(["pgrep", "-f", marker],
+                          capture_output=True, text=True).stdout.split()
+    check("marked raw-mode jobs: none survive the shell", not left,
+          "left running: %r" % left)
+
+    # 7. No false positives: a shell with no stopped job just leaves.
+    _, alive, _ = drive(SHELL, [b"echo hi\n", b"exit\n"])
+    check("no stopped jobs: exit leaves at once", not alive)
+    _, alive, _ = drive(SHELL, [b"echo hi\n", b"\x04"])
+    check("no stopped jobs: ^D leaves at once", not alive)
+
+    # 8. Non-interactive means it. A script that says exit, exits.
+    p = subprocess.run([SHELL, "-c", "cat & exit 0"], capture_output=True,
+                       text=True, timeout=20, stdin=subprocess.DEVNULL)
+    check("a script's exit is never second-guessed",
+          p.returncode == 0 and WARN not in p.stderr,
+          "rc=%d err=%r" % (p.returncode, p.stderr[:160]))
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -5,7 +5,7 @@ later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**. Released version: **2.7.3**.
+Branch to resume from: **`develop`**. Released version: **2.7.4**.
 
 The previous note on this file covered the issue-fixing session (#27, #32,
 #34, #42 and friends). All of those are closed; the tracker is empty. This

--- a/wiki/interactive.md
+++ b/wiki/interactive.md
@@ -73,9 +73,14 @@ correct width accounting so segments and colors line up.
 
 ## Update channel ✅
 
-hellish checks for newer releases in the background (once a day, never blocking the prompt) and
-flags one in the welcome banner. `update` checks on demand; `update --now` self-updates the binary.
-Opt out with `HELLISH_NO_UPDATE_CHECK=1` (banner: `HELLISH_NO_BANNER=1`).
+hellish checks for newer releases in the background (once a day, never blocking the prompt — the
+check runs in a detached child, so a slow or dead release server costs the shell nothing). You are
+told twice, and without asking: the welcome banner announces each new release once, and the prompt
+carries a quiet `⬆<version>` badge for as long as the update is actually pending. `update` checks on
+demand; `update --now` self-updates the binary.
+
+Opt out with `HELLISH_NO_UPDATE_CHECK=1`. The banner has one knob, `HELLISH_BANNER=0|1`, to force it
+off or on; `HELLISH_NO_BANNER=1` and `HELLISH_ALWAYS_BANNER=1` are the older names and still work.
 
 ---
 


### PR DESCRIPTION
Ships **v2.7.4**. Two reports from real sessions; one of them could leave your
terminal unusable, so this is worth taking on its own if you are on 2.7.x.

### #58 — leaving a shell with a stopped job wrecked the terminal

`top &` then Ctrl-D, and the terminal you came back to had no echo and spliced your
next command into garbage — *sometimes*. Four defects, stacked, each hiding the next:

1. **Ctrl-D never asked.** The stopped-jobs guard existed and worked, but only the
   `exit` builtin called it. Both end-of-input paths set "time to leave" themselves.
2. **The guard read a stale answer.** A job the kernel stops the moment it touches
   the terminal is only recorded when the shell next reaps — on a *later* prompt. So
   `top &` then an immediate exit saw a running job and let you out, while the same
   pair with any command in between saw a stopped one and warned. That is the entire
   *"sometimes it works"*: **a race, not a flake.**
3. **The warning never came back.** Forgotten only by a builtin, so an external
   command in between left it standing: warn once, run `ps`, press Ctrl-D, and the
   shell walked out over a job it had already been told about.
4. **And the damage itself.** On the exit you *did* mean, the shell handed the
   terminal back and left **while the jobs it had just hung up were still dying** —
   and a full-screen program does not die quietly. Dozens of `top`s writing to the
   tty after the shell let go of it. It now hangs them up, **waits for them**, and
   only then restores the terminal — including the settings it started with, because
   a job stopped halfway through raw mode never can.

### #56 — a new release stayed invisible until you typed `update`

The banner's "X available — run `update --now`" line renders fine and was simply
unreachable: it asked a flag owned by the prompt's one-shot notice, and the prompt
always spoke first. The banner now keeps its own record and announces each release
once. Plus `HELLISH_BANNER=0|1`, since there was no knob anybody guessed.

## Verification

`develop` is **33/33 green** on `848c305`, including the full platform matrix, the
hard corpus, allocator parity and the pty gates. Locally: pty suite **27 ok / 0
failed**, golden suite **3790/3790** vs bash, norm clean.

Closes #58
