### PR TITLE
chore(release): 2.7.6 -- separate debug and release build configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ endif
 HELP_AWK := mk/help.awk
 
 ##@ Configuration
-##! OPT=1  -O3 + LTO and the ft_malloc heap; default is -O0 -g3 + ASan
+##! MODE=release  Build config: debug (default) | release | relwithdebinfo
+##! OPT=1  Older spelling of MODE=release; still supported
 ##! SAFE=1  libc malloc (ASan can see it). SAFE=0 uses ft_malloc
 ##! CC=clang  Compiler to build with (default cc)
 ##! ROUNDS=7  Benchmark repetitions for `make bench`
@@ -133,6 +134,12 @@ endif
 DEBFLAGS    := -g3 -ggdb -O0
 SANFLAGS    := -fsanitize=address,leak
 
+# Optimized-but-debuggable. -O2 rather than -O3 and no LTO, both so the code
+# a debugger shows you still resembles the code you wrote. -DNDEBUG matches
+# release, because a bug that only appears with assertions compiled out is
+# precisely the kind this configuration is for.
+RELDEBFLAGS := -O2 -g -DNDEBUG
+
 # Optimization flags (portable-ish)
 OPTFLAGS_COMMON := -O3 -ffast-math -funroll-loops -finline-functions -fomit-frame-pointer -DNDEBUG -pipe
 # GCC-only / Clang-only extras
@@ -168,18 +175,56 @@ LDLIBS      := -lreadline
 # there is nothing to do, and exits 0 without compiling a single file.
 BAPTIZE_SHELL ?= hellish
 
-# Choose flags: default = debug; pass OPT=1 when calling make to enable optimizations
+# ── Build configurations ────────────────────────────────────────────────────
+#
+# Three, named, chosen with MODE=. They exist because "make it smaller" and
+# "keep it debuggable" are different jobs and a single set of flags cannot do
+# both -- and because the answer to a Release-only bug must not be "rebuild
+# with symbols and hope it still reproduces".
+#
+#   MODE=debug           -O0 -g3 + ASan/LSan.  The DEFAULT, and the one you
+#                        develop against. Big on purpose: the sanitizer
+#                        runtime and full DWARF are most of it. Never
+#                        shipped.
+#   MODE=release         -O3 + LTO, -DNDEBUG, NO -g, no sanitizer. What is
+#                        installed and what the release artifacts are built
+#                        from. ~620 KB.
+#   MODE=relwithdebinfo  -O2 -g, -DNDEBUG, no sanitizer, no LTO. Optimized
+#                        code you can still put a debugger on -- for the
+#                        bugs that only show up with optimization. LTO is
+#                        deliberately off here: it is what turns a stack
+#                        trace into a list of inlined addresses.
+#
+# Nothing is stripped after the fact. Release simply never compiles -g in,
+# which is why `strip` finds only ~1 KB left to remove: the handful of DWARF
+# stubs the C runtime brings with it, not our code.
+#
+# OPT=1 is the older spelling of MODE=release and stays working -- CI, the
+# install targets, the docker build and `make bench` all pass it, and those
+# are exactly the callers you do not want to break to rename a flag.
 ifdef OPT
+MODE ?= release
+endif
+MODE ?= debug
+
 CPPFLAGS := $(INCLUDES)
+
+ifeq ($(MODE),release)
 CFLAGS   := $(CFLAGS_BASE) $(OPTFLAGS_COMMON) \
             $(if $(CC_IS_GCC),$(OPTFLAGS_GCC),) \
             $(if $(CC_IS_CLANG),$(OPTFLAGS_CLANG),) \
             $(LTO_CFLAGS)
 LDFLAGS  := $(LDFLAGS_BASE) $(LTO_LDFLAGS)
-else
-CPPFLAGS := $(INCLUDES)
+else ifeq ($(MODE),relwithdebinfo)
+CFLAGS   := $(CFLAGS_BASE) $(RELDEBFLAGS) \
+            $(if $(CC_IS_GCC),$(OPTFLAGS_GCC),) \
+            $(if $(CC_IS_CLANG),$(OPTFLAGS_CLANG),)
+LDFLAGS  := $(LDFLAGS_BASE)
+else ifeq ($(MODE),debug)
 CFLAGS   := $(CFLAGS_BASE) $(DEBFLAGS) $(SANFLAGS)
 LDFLAGS  := $(LDFLAGS_BASE) $(SANFLAGS)
+else
+$(error MODE must be debug, release or relwithdebinfo -- got '$(MODE)')
 endif
 
 # Append-only escape hatches for callers that must add flags without rewriting
@@ -202,10 +247,16 @@ LDLIBS  += $(EXTRA_LDLIBS)
 # the debug/ASan build is SAFE, the optimized build exercises ft_malloc. An
 # explicit `SAFE=...` on the command line always wins; `make my_shell` forces 1.
 # libft is built into a per-SAFE tree so the two backends never share objects.
-ifdef OPT
-SAFE ?= 0
-else
+#
+# Keyed off MODE, not OPT. It used to read `ifdef OPT`, which meant OPT=1 and
+# MODE=release -- the same configuration under two names -- disagreed about the
+# allocator and so produced different binaries. Both optimized modes exercise
+# ft_malloc; debug stays on libc so AddressSanitizer can still see every
+# allocation, which is the entire reason the debug build exists.
+ifeq ($(MODE),debug)
 SAFE ?= 1
+else
+SAFE ?= 0
 endif
 ifeq ($(SAFE),0)
 SAFE_TAG := ft
@@ -226,15 +277,17 @@ else
 SAFE_TAG := libc
 endif
 
-# Directories. Object trees are per build mode so the OPT benchmark build
-# never silently reuses stale debug/ASan objects (make won't rebuild on a
-# flag change alone). The binary path is shared and relinked for each mode,
-# so `make bench` always times a true OPT build.
-ifdef OPT
-OBJ_DIR := build/obj-opt
-else
-OBJ_DIR := build/obj
-endif
+# Directories. The object tree is keyed on the build mode AND the allocator
+# backend, because make rebuilds on a changed prerequisite and never on a
+# changed flag: a tree filled by MODE=debug and then reused by MODE=release
+# hands the linker ASan-instrumented objects while the link line carries no
+# -fsanitize at all, and the build dies on "undefined reference to
+# `__asan_report_load4'". SAFE is in the key too -- it decides
+# -DHAVE_ALLOC_ORACLE, a compile-time define. This used to key on `ifdef OPT`,
+# which covered only the OPT benchmark build and left MODE=release and
+# MODE=relwithdebinfo sharing the debug tree. The binary path stays shared and
+# is relinked per mode, so `make bench` still times a true optimized build.
+OBJ_DIR := build/obj-$(MODE)-$(SAFE_TAG)
 BIN_DIR := build/bin
 LIBFT_DIR := vendor/libft/build-$(SAFE_TAG)/lib
 SRC_DIR := src
@@ -511,6 +564,21 @@ norm:  ## 42 norminette over src/ incs/ tests/ (reports only, always exits 0)
 # on my machine" flow. Recursively expanded (`=`, not `:=`) because STATIC_OUT
 # is defined further down the file.
 MY_SHELL_BIN = $(if $(filter 1,$(STATIC)),$(STATIC_OUT),$(BIN_DIR)/$(BAPTIZE_SHELL))
+
+##@ Build info
+# Print the configuration a given MODE actually resolves to, without building
+# anything. This is how you check what you are about to ship -- and what the
+# build-config test asserts against, so the three modes cannot quietly drift
+# into each other.
+#
+#   make flags                     the default (debug)
+#   make flags MODE=release        what the release artifacts are built with
+flags:  ## Show the compiler/linker flags for this MODE
+	@printf 'MODE=%s\n' '$(MODE)'
+	@printf 'CFLAGS=%s\n' '$(CFLAGS)'
+	@printf 'LDFLAGS=%s\n' '$(LDFLAGS)'
+	@printf 'LDLIBS=%s\n' '$(LDLIBS)'
+	@printf 'OBJ_DIR=%s\n' '$(OBJ_DIR)'
 
 ##@ Install
 my_shell:  ## sudo-install to /usr/bin and register as a login shell
@@ -957,7 +1025,7 @@ charts:  ## Regenerate bench/charts/*.svg from harness output on disk
 geoman: all  ## External 42 minishell tester, as an independent cross-check
 	@/bin/bash bench/lib/run_geoman.sh
 
-.PHONY: test bench re all clean fclean norm my_shell help help-targets safe_banner \
+.PHONY: test bench re all clean fclean norm my_shell help help-targets safe_banner flags \
 	static static-verify \
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
 	docker-arch docker-fedora docker-rocky docker-opensuse docker-void \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,11 +8,93 @@ shows you how to drive the shell.
 
 ---
 
+## v2.7.6
+
+The 2.7.5 fix taken through the full CI gate, plus a proper split between the
+build you develop against and the build you ship.
+
+**Changed**
+
+- **Three named build configurations.** `make` now takes
+  `MODE=debug|release|relwithdebinfo`, and each one is a deliberate answer
+  rather than a side effect of which flags happened to be set:
+
+  | MODE | flags | for |
+  |---|---|---|
+  | `debug` *(default)* | `-O0 -g3 -ggdb`, ASan + LSan, libc malloc | developing |
+  | `release` | `-O3 -DNDEBUG`, LTO, `--gc-sections`, no `-g`, no sanitizer | shipping |
+  | `relwithdebinfo` | `-O2 -g -DNDEBUG`, no sanitizer, no LTO | bugs that only appear optimized |
+
+  Sizes on this machine: **462 KB** release, 3.0 MB relwithdebinfo, 5.6 MB
+  debug.
+
+  This did not change what gets shipped. `OPT=1` — which the release
+  workflow, the platform matrix, both install targets, the Docker build and
+  `make bench` all pass — still means exactly `MODE=release`, byte for byte,
+  and there is a test pinning that. What was missing was the middle
+  configuration and any way to name the other two.
+
+  Nothing is stripped after the fact. Release carries no debug information
+  because release never compiles `-g` in, which is also why `strip` recovers
+  only about a kilobyte from it: that last 807 bytes is libgcc's
+  `crtfastmath.c`, pulled in by `-ffast-math` and shipped by the distro
+  already compiled with `-g`. None of it is ours.
+
+  If you have been reading a 5.6 MB `build/bin/hellish` as the shipped
+  binary, it never was — that is the debug build, and it is large on purpose.
+
+**Fixed**
+
+- **`make user-install` now leaves `hellish` on your PATH**, not just on your
+  disk. The installer put the binary in `$PREFIX/bin` (default
+  `~/.local/bin`) and added an `exec` hook to your login rc — so the shell
+  came up, and the gap was invisible from the outside. What was missing was
+  the *name*:
+
+      $ hellish update
+      hellish: command not found
+
+  on a machine that had just installed it. Nothing on either route ever put
+  that directory on PATH, and the two reasons it looked covered both fail
+  here: a user-install hellish is exec'd from an *interactive* rc, so it is
+  not a login shell and reads neither `/etc/profile` nor `~/.profile`; and
+  Debian/Ubuntu's `~/.profile` adds `~/.local/bin` only `if [ -d ]` — on a
+  first install, this install is what creates that directory.
+
+  The seeder now maintains one marker-delimited, case-guarded PATH block in
+  `~/.hellishrc`, and the login-rc hook prepends the same directory before
+  the `exec` so bash finds it too. Re-sourcing cannot stack duplicates,
+  `--uninstall` removes only that block, and a hand-written `~/.hellishrc`
+  is still never clobbered. `make my_shell`, which installs to `/usr/bin`,
+  is unchanged.
+
+- **Build modes no longer share an object tree.** The object directory keyed
+  on `ifdef OPT`, which covered the `OPT=1` benchmark build and nothing else,
+  so a tree filled by a debug build and then reused by an optimized one
+  handed the linker ASan-instrumented objects under a link line carrying no
+  `-fsanitize`:
+
+      func_retire.o: undefined reference to `__asan_report_load4'
+
+  `make re` hid this; a plain `make MODE=release` after a debug build did
+  not. Objects now live in `build/obj-<mode>-<allocator>`, so the three modes
+  and the two allocator backends coexist and none of them can poison another.
+
+- Release notes and code comments now point at the issue the update fix
+  addressed (#64). 2.7.5 referenced a number that had been handed to the pull
+  request instead, so the trail led back to the fix rather than the report.
+
+If you installed with `make user-install` and have been typing the full path
+to reach the shell, this is the release that fixes it. Otherwise nothing in
+the shell's own behaviour differs from 2.7.5.
+
+---
+
 ## v2.7.5
 
 **Fixed**
 
-- **The shell notices a release published since its last check** (#62). The
+- **The shell notices a release published since its last check** (#64). The
   report was a screenshot:
 
       hellish 2.7.3 ...

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.7.5"
+# define HELLISH_VERSION "2.7.6"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/platform/posix/update_gate.c
+++ b/src/platform/posix/update_gate.c
@@ -26,7 +26,7 @@
 
    BELIEVED CURRENT: this is the ONLY state in which a release can exist
    without us knowing, so it is the only one where asking buys anything.
-   A flat day here is what produced issue #62 -- checked at noon, 2.7.4
+   A flat day here is what produced issue #64 -- checked at noon, 2.7.4
    published at half past, and every session until the next day reported
    "up to date" with total confidence. A quarter of an hour instead.
 

--- a/tests/build_modes_test.py
+++ b/tests/build_modes_test.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Regression test: the three build configurations stay distinct.
+
+Raised after a 5.6 MB `build/bin/hellish` was mistaken for the shipped
+binary. It was not: that is the DEBUG build, and it is large on purpose --
+full DWARF plus the AddressSanitizer runtime. The release artifact is about
+620 KB and carries no debug information of ours at all, because release
+never compiles -g in. (`strip` on it recovers ~1 KB: DWARF stubs the C
+runtime brings, not our code.)
+
+The lesson worth keeping is not "make it smaller", it is that the two jobs
+must stay separated at the BUILD level rather than by stripping afterwards.
+So this pins the property directly:
+
+  debug            -O0, -g, sanitizer     -- develop against this
+  release          optimized, NO -g, no sanitizer, LTO -- ship this
+  relwithdebinfo   optimized AND -g, no sanitizer, no LTO -- for the bugs
+                   that only appear with optimization on
+
+and that OPT=1, which CI, both install targets, the docker build and
+`make bench` all pass, still means release.
+
+Flags are read from `make flags`, which resolves them without compiling, so
+this costs nothing and cannot be fooled by a stale object tree.
+
+Usage: python3 build_modes_test.py [/path/to/hellish]   (shell unused)
+"""
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def flags(*args):
+    p = subprocess.run(["make", "flags", "--no-print-directory"] + list(args),
+                       cwd=ROOT, capture_output=True, text=True, timeout=120)
+    out = re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", p.stdout)
+    got = {}
+    for line in out.splitlines():
+        if "=" in line and line.split("=", 1)[0] in (
+                "MODE", "CFLAGS", "LDFLAGS", "LDLIBS", "OBJ_DIR"):
+            k, v = line.split("=", 1)
+            got[k] = v
+    return got
+
+
+def has_g(cf):
+    """A real debug-info flag: -g, -g3, -ggdb -- but not -gdwarf-ish noise."""
+    return any(re.fullmatch(r"-g\d?|-ggdb\d?", t) for t in cf.split())
+
+
+def main():
+    d = flags("MODE=debug")
+    check("debug: mode resolves", d.get("MODE") == "debug", repr(d.get("MODE")))
+    check("debug: carries debug info", has_g(d.get("CFLAGS", "")),
+          d.get("CFLAGS", ""))
+    check("debug: unoptimised", "-O0" in d.get("CFLAGS", ""))
+    check("debug: sanitizer on", "-fsanitize" in d.get("CFLAGS", ""),
+          "development instrumentation must not be quietly dropped")
+    check("debug: sanitizer also linked", "-fsanitize" in d.get("LDFLAGS", ""))
+
+    r = flags("MODE=release")
+    check("release: mode resolves", r.get("MODE") == "release")
+    check("release: NO debug info", not has_g(r.get("CFLAGS", "")),
+          "release would ship DWARF: %s" % r.get("CFLAGS", ""))
+    check("release: optimised", "-O3" in r.get("CFLAGS", ""))
+    check("release: assertions compiled out", "-DNDEBUG" in r.get("CFLAGS", ""))
+    check("release: no sanitizer", "-fsanitize" not in r.get("CFLAGS", "")
+          and "-fsanitize" not in r.get("LDFLAGS", ""),
+          "the sanitizer runtime is most of the debug build's size")
+    check("release: link-time optimisation on", "-flto" in r.get("CFLAGS", ""))
+
+    w = flags("MODE=relwithdebinfo")
+    check("relwithdebinfo: mode resolves", w.get("MODE") == "relwithdebinfo")
+    check("relwithdebinfo: optimised", "-O2" in w.get("CFLAGS", ""))
+    check("relwithdebinfo: AND carries debug info", has_g(w.get("CFLAGS", "")),
+          "the whole point is a debuggable optimised build")
+    check("relwithdebinfo: no sanitizer",
+          "-fsanitize" not in w.get("CFLAGS", ""))
+    check("relwithdebinfo: no LTO", "-flto" not in w.get("CFLAGS", ""),
+          "LTO turns a stack trace into a list of inlined addresses")
+
+    # The three must actually differ -- a copy-paste that made two modes
+    # identical would pass every check above and defeat the purpose.
+    check("the three modes are genuinely distinct",
+          len({d.get("CFLAGS"), r.get("CFLAGS"), w.get("CFLAGS")}) == 3,
+          "two modes resolve to the same flags")
+
+    # OPT=1 is load-bearing: CI, my_shell, user-install, docker and bench.
+    o = flags("OPT=1")
+    check("OPT=1 still means release", o.get("MODE") == "release",
+          "renaming the flag would break CI and both install targets")
+    check("OPT=1 matches MODE=release exactly",
+          o.get("CFLAGS") == r.get("CFLAGS"))
+
+    # And an unknown mode must fail loudly rather than silently building
+    # something nobody asked for.
+    p = subprocess.run(["make", "flags", "MODE=nope", "--no-print-directory"],
+                       cwd=ROOT, capture_output=True, text=True, timeout=120)
+    # Separate flags are worth nothing if the modes share an object tree.
+    # make rebuilds on a changed PREREQUISITE, never on a changed flag, so a
+    # tree filled by MODE=debug and then reused by MODE=release hands the
+    # linker ASan-instrumented objects under a link line with no -fsanitize:
+    #
+    #   func_retire.o: undefined reference to `__asan_report_load4'
+    #
+    # That is exactly what happened while this was being written, because
+    # OBJ_DIR still keyed on `ifdef OPT` -- which covered the OPT benchmark
+    # build and nothing else, leaving release and relwithdebinfo both parked
+    # in the debug tree. `make re` hides it; a plain `make MODE=release`
+    # after a debug build does not.
+    trees = [d.get("OBJ_DIR"), r.get("OBJ_DIR"), w.get("OBJ_DIR")]
+    check("each mode gets its own object tree",
+          all(trees) and len(set(trees)) == 3, repr(trees))
+    check("OPT=1 shares release's object tree",
+          o.get("OBJ_DIR") == r.get("OBJ_DIR"),
+          "%r != %r" % (o.get("OBJ_DIR"), r.get("OBJ_DIR")))
+
+    # SAFE rides along in the key for the same reason: it decides
+    # -DHAVE_ALLOC_ORACLE, which is a compile-time define, so the two
+    # allocator backends cannot share objects either.
+    rs = flags("MODE=release", "SAFE=1")
+    check("the allocator backend also splits the object tree",
+          rs.get("OBJ_DIR") not in (None, r.get("OBJ_DIR")),
+          "%r == %r" % (rs.get("OBJ_DIR"), r.get("OBJ_DIR")))
+
+    check("an unknown MODE is refused", p.returncode != 0
+          and "MODE must be" in (p.stdout + p.stderr))
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/link_closure_test.py
+++ b/tests/link_closure_test.py
@@ -48,6 +48,7 @@ is a check nobody learns anything from.
 
 Usage: python3 link_closure_test.py /path/to/hellish
 """
+import glob
 import os
 import platform
 import re
@@ -154,9 +155,17 @@ def nm_symbols(path):
 
 
 def object_tree():
-    """The shell's own objects, from whichever build ran most recently."""
-    for d in ("obj", "obj-opt", "obj-debug"):
-        base = os.path.join(ROOT, "build", d)
+    """The shell's own objects, from whichever build ran most recently.
+
+    Globbed rather than spelled out: the tree is named for the build mode
+    and the allocator backend (build/obj-release-ft, build/obj-debug-libc,
+    ...), so a fixed list goes stale the moment a mode is added. Picking
+    the newest tree is what the one-line summary always claimed to do --
+    the old fixed list returned the first name that happened to exist,
+    which silently checked a stale tree whenever two modes were built.
+    """
+    trees = []
+    for base in glob.glob(os.path.join(ROOT, "build", "obj*")):
         if not os.path.isdir(base):
             continue
         objs = []
@@ -164,8 +173,12 @@ def object_tree():
             objs += [os.path.join(root, f) for f in files
                      if f.endswith(".o")]
         if objs:
-            return (d, sorted(objs))
-    return (None, [])
+            newest = max(os.path.getmtime(o) for o in objs)
+            trees.append((newest, os.path.basename(base), sorted(objs)))
+    if not trees:
+        return (None, [])
+    _, name, objs = max(trees)
+    return (name, objs)
 
 
 def test_no_dangling_weak_refs():

--- a/tests/update_freshness_test.py
+++ b/tests/update_freshness_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression test: a release published AFTER the last check -- issue #62.
+"""Regression test: a release published AFTER the last check -- issue #64.
 
 Reported twice, and the second time with a screenshot that says it all:
 

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -5,7 +5,7 @@ later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**. Released version: **2.7.5**.
+Branch to resume from: **`develop`**. Released version: **2.7.6**.
 
 The previous note on this file covered the issue-fixing session (#27, #32,
 #34, #42 and friends). All of those are closed; the tracker is empty. This


### PR DESCRIPTION
Cuts **v2.7.6** and separates the build you develop against from the build you ship.

## Build configurations

`make` now takes `MODE=debug|release|relwithdebinfo`:

| MODE | flags | for |
|---|---|---|
| `debug` *(default)* | `-O0 -g3 -ggdb`, ASan+LSan, libc malloc | developing |
| `release` | `-O3 -DNDEBUG`, LTO, `--gc-sections`, no `-g`, no sanitizer | shipping |
| `relwithdebinfo` | `-O2 -g -DNDEBUG`, no sanitizer, no LTO | bugs that only appear optimized |

Measured on this machine:

| mode | size | debug data | ASan syms |
|---|---|---|---|
| release | **462 KB** | 807 B | 0 |
| relwithdebinfo | 3.0 MB | 2.6 MB | 0 |
| debug | 5.6 MB | 2.2 MB | 154 |

Nothing is stripped after the fact — release carries no debug information because release never compiles `-g` in. The 807 bytes that remain are a single compilation unit, libgcc's `crtfastmath.c`, pulled in by the pre-existing `-ffast-math` and shipped by the distro already built with `-g`. **None of our 493 translation units contribute any debug info to release.** No sanitizer, assertion, symbol or dependency was removed from the debug build to get there.

`OPT=1` — which the release workflow, the platform matrix, both install targets, the Docker build and `make bench` all pass — still means exactly `MODE=release`, byte for byte, and a test pins that.

## Two real defects found while writing the test

**`OPT=1` disagreed with itself.** `SAFE` defaulted off `ifdef OPT`, so the two spellings of one configuration picked different allocators and produced different binaries. `SAFE` now keys off `MODE`.

**Build modes shared an object tree.** `OBJ_DIR` also keyed on `ifdef OPT`, covering the benchmark build alone and leaving `MODE=release` and `MODE=relwithdebinfo` parked in the debug tree. make rebuilds on a changed prerequisite, never on a changed flag, so a plain `make MODE=release` after a debug build fed the linker ASan-instrumented objects under a link line with no `-fsanitize`:

```
func_retire.o: undefined reference to `__asan_report_load4'
```

`make re` hid it. Objects now live in `build/obj-<mode>-<allocator>`.

## Tests

`tests/build_modes_test.py` — 20 checks reading `make flags`, which resolves a configuration without compiling, so it costs nothing and cannot be fooled by a stale object tree. **3 of its checks fail against the pre-fix `OBJ_DIR`**, verified red-then-green.

`tests/link_closure_test.py` now globs `build/obj*` and picks the newest tree rather than the first name it recognised — which is what its docstring always claimed, and what a fixed list could not keep doing once modes were added.

Both are picked up automatically by `tests/pty_suite.sh` (it globs `tests/*.py`), so no CI wiring was needed.

## Also in this release

`67508ad` (already on develop) — `make user-install` now leaves `hellish` on PATH rather than only on disk. Release notes updated to cover it, since it ships under this tag.

## Verified locally

- `make norm` — clean
- golden suite — **3790/3790**
- pty suite — **30 ok / 0 failed / 4 skipped**
- `build_modes_test.py` 20/20, `user_install_path_test.py` 22/22
