### PR TITLE
chore(release): 2.7.6 -> main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
   # login-shell file order, the help table, the release/update config. These
   # ran only on developer machines before, which is exactly how they rot.
   gates:
-    name: Gates · cli + login + help + cd + update-config
+    name: Gates · cli + login + install + help + cd + update-config
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -218,6 +218,14 @@ jobs:
         run: make cli-opts-test
       - name: Login shell startup file order
         run: make login-test
+      # The no-sudo install route, against a temporary $HOME. It installed the
+      # binary and exec'd it by absolute path, so the shell came up while its
+      # own NAME resolved nowhere: `hellish update` and `command -v hellish`
+      # answered "command not found" on a machine that had just installed it.
+      # Also runs inside `make pty-test` by discovery; named here because it
+      # gates the INSTALLER, which no shell-behaviour job would ever reach.
+      - name: user-install leaves `hellish` on PATH
+        run: make user-install-test
       - name: help builtin covers every dispatched builtin
         run: make help-test
       - name: cd POSIX-mode operand handling

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ endif
 HELP_AWK := mk/help.awk
 
 ##@ Configuration
-##! OPT=1  -O3 + LTO and the ft_malloc heap; default is -O0 -g3 + ASan
+##! MODE=release  Build config: debug (default) | release | relwithdebinfo
+##! OPT=1  Older spelling of MODE=release; still supported
 ##! SAFE=1  libc malloc (ASan can see it). SAFE=0 uses ft_malloc
 ##! CC=clang  Compiler to build with (default cc)
 ##! ROUNDS=7  Benchmark repetitions for `make bench`
@@ -133,6 +134,12 @@ endif
 DEBFLAGS    := -g3 -ggdb -O0
 SANFLAGS    := -fsanitize=address,leak
 
+# Optimized-but-debuggable. -O2 rather than -O3 and no LTO, both so the code
+# a debugger shows you still resembles the code you wrote. -DNDEBUG matches
+# release, because a bug that only appears with assertions compiled out is
+# precisely the kind this configuration is for.
+RELDEBFLAGS := -O2 -g -DNDEBUG
+
 # Optimization flags (portable-ish)
 OPTFLAGS_COMMON := -O3 -ffast-math -funroll-loops -finline-functions -fomit-frame-pointer -DNDEBUG -pipe
 # GCC-only / Clang-only extras
@@ -168,18 +175,56 @@ LDLIBS      := -lreadline
 # there is nothing to do, and exits 0 without compiling a single file.
 BAPTIZE_SHELL ?= hellish
 
-# Choose flags: default = debug; pass OPT=1 when calling make to enable optimizations
+# ── Build configurations ────────────────────────────────────────────────────
+#
+# Three, named, chosen with MODE=. They exist because "make it smaller" and
+# "keep it debuggable" are different jobs and a single set of flags cannot do
+# both -- and because the answer to a Release-only bug must not be "rebuild
+# with symbols and hope it still reproduces".
+#
+#   MODE=debug           -O0 -g3 + ASan/LSan.  The DEFAULT, and the one you
+#                        develop against. Big on purpose: the sanitizer
+#                        runtime and full DWARF are most of it. Never
+#                        shipped.
+#   MODE=release         -O3 + LTO, -DNDEBUG, NO -g, no sanitizer. What is
+#                        installed and what the release artifacts are built
+#                        from. ~620 KB.
+#   MODE=relwithdebinfo  -O2 -g, -DNDEBUG, no sanitizer, no LTO. Optimized
+#                        code you can still put a debugger on -- for the
+#                        bugs that only show up with optimization. LTO is
+#                        deliberately off here: it is what turns a stack
+#                        trace into a list of inlined addresses.
+#
+# Nothing is stripped after the fact. Release simply never compiles -g in,
+# which is why `strip` finds only ~1 KB left to remove: the handful of DWARF
+# stubs the C runtime brings with it, not our code.
+#
+# OPT=1 is the older spelling of MODE=release and stays working -- CI, the
+# install targets, the docker build and `make bench` all pass it, and those
+# are exactly the callers you do not want to break to rename a flag.
 ifdef OPT
+MODE ?= release
+endif
+MODE ?= debug
+
 CPPFLAGS := $(INCLUDES)
+
+ifeq ($(MODE),release)
 CFLAGS   := $(CFLAGS_BASE) $(OPTFLAGS_COMMON) \
             $(if $(CC_IS_GCC),$(OPTFLAGS_GCC),) \
             $(if $(CC_IS_CLANG),$(OPTFLAGS_CLANG),) \
             $(LTO_CFLAGS)
 LDFLAGS  := $(LDFLAGS_BASE) $(LTO_LDFLAGS)
-else
-CPPFLAGS := $(INCLUDES)
+else ifeq ($(MODE),relwithdebinfo)
+CFLAGS   := $(CFLAGS_BASE) $(RELDEBFLAGS) \
+            $(if $(CC_IS_GCC),$(OPTFLAGS_GCC),) \
+            $(if $(CC_IS_CLANG),$(OPTFLAGS_CLANG),)
+LDFLAGS  := $(LDFLAGS_BASE)
+else ifeq ($(MODE),debug)
 CFLAGS   := $(CFLAGS_BASE) $(DEBFLAGS) $(SANFLAGS)
 LDFLAGS  := $(LDFLAGS_BASE) $(SANFLAGS)
+else
+$(error MODE must be debug, release or relwithdebinfo -- got '$(MODE)')
 endif
 
 # Append-only escape hatches for callers that must add flags without rewriting
@@ -202,10 +247,16 @@ LDLIBS  += $(EXTRA_LDLIBS)
 # the debug/ASan build is SAFE, the optimized build exercises ft_malloc. An
 # explicit `SAFE=...` on the command line always wins; `make my_shell` forces 1.
 # libft is built into a per-SAFE tree so the two backends never share objects.
-ifdef OPT
-SAFE ?= 0
-else
+#
+# Keyed off MODE, not OPT. It used to read `ifdef OPT`, which meant OPT=1 and
+# MODE=release -- the same configuration under two names -- disagreed about the
+# allocator and so produced different binaries. Both optimized modes exercise
+# ft_malloc; debug stays on libc so AddressSanitizer can still see every
+# allocation, which is the entire reason the debug build exists.
+ifeq ($(MODE),debug)
 SAFE ?= 1
+else
+SAFE ?= 0
 endif
 ifeq ($(SAFE),0)
 SAFE_TAG := ft
@@ -226,15 +277,17 @@ else
 SAFE_TAG := libc
 endif
 
-# Directories. Object trees are per build mode so the OPT benchmark build
-# never silently reuses stale debug/ASan objects (make won't rebuild on a
-# flag change alone). The binary path is shared and relinked for each mode,
-# so `make bench` always times a true OPT build.
-ifdef OPT
-OBJ_DIR := build/obj-opt
-else
-OBJ_DIR := build/obj
-endif
+# Directories. The object tree is keyed on the build mode AND the allocator
+# backend, because make rebuilds on a changed prerequisite and never on a
+# changed flag: a tree filled by MODE=debug and then reused by MODE=release
+# hands the linker ASan-instrumented objects while the link line carries no
+# -fsanitize at all, and the build dies on "undefined reference to
+# `__asan_report_load4'". SAFE is in the key too -- it decides
+# -DHAVE_ALLOC_ORACLE, a compile-time define. This used to key on `ifdef OPT`,
+# which covered only the OPT benchmark build and left MODE=release and
+# MODE=relwithdebinfo sharing the debug tree. The binary path stays shared and
+# is relinked per mode, so `make bench` still times a true optimized build.
+OBJ_DIR := build/obj-$(MODE)-$(SAFE_TAG)
 BIN_DIR := build/bin
 LIBFT_DIR := vendor/libft/build-$(SAFE_TAG)/lib
 SRC_DIR := src
@@ -511,6 +564,21 @@ norm:  ## 42 norminette over src/ incs/ tests/ (reports only, always exits 0)
 # on my machine" flow. Recursively expanded (`=`, not `:=`) because STATIC_OUT
 # is defined further down the file.
 MY_SHELL_BIN = $(if $(filter 1,$(STATIC)),$(STATIC_OUT),$(BIN_DIR)/$(BAPTIZE_SHELL))
+
+##@ Build info
+# Print the configuration a given MODE actually resolves to, without building
+# anything. This is how you check what you are about to ship -- and what the
+# build-config test asserts against, so the three modes cannot quietly drift
+# into each other.
+#
+#   make flags                     the default (debug)
+#   make flags MODE=release        what the release artifacts are built with
+flags:  ## Show the compiler/linker flags for this MODE
+	@printf 'MODE=%s\n' '$(MODE)'
+	@printf 'CFLAGS=%s\n' '$(CFLAGS)'
+	@printf 'LDFLAGS=%s\n' '$(LDFLAGS)'
+	@printf 'LDLIBS=%s\n' '$(LDLIBS)'
+	@printf 'OBJ_DIR=%s\n' '$(OBJ_DIR)'
 
 ##@ Install
 my_shell:  ## sudo-install to /usr/bin and register as a login shell
@@ -957,7 +1025,7 @@ charts:  ## Regenerate bench/charts/*.svg from harness output on disk
 geoman: all  ## External 42 minishell tester, as an independent cross-check
 	@/bin/bash bench/lib/run_geoman.sh
 
-.PHONY: test bench re all clean fclean norm my_shell help help-targets safe_banner \
+.PHONY: test bench re all clean fclean norm my_shell help help-targets safe_banner flags \
 	static static-verify \
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
 	docker-arch docker-fedora docker-rocky docker-opensuse docker-void \

--- a/Makefile
+++ b/Makefile
@@ -910,6 +910,18 @@ login-test: all  ## Login shells source /etc/profile then ~/.profile; others nei
 	@chmod +x $(TEST_DIR)/login_profile_compare.sh
 	@HELLISH=$(BIN_DIR)/$(BAPTIZE_SHELL) bash $(TEST_DIR)/login_profile_compare.sh
 
+# The no-sudo install route, end to end against a TEMPORARY $$HOME. It put the
+# binary in $$PREFIX/bin and exec'd it by absolute path from your login rc --
+# so the shell came up, and nobody noticed that neither route ever put that
+# directory on PATH. `hellish update`, `command -v hellish`, anything that
+# looks the shell up by NAME: command not found, on a machine that had just
+# installed it. Covers the PATH block in ~/.hellishrc and in the rc hook, the
+# re-source guard, a custom PREFIX, an existing ~/.hellishrc being left alone,
+# re-install idempotence and uninstall. CI runs it through `make pty-test`
+# (tests/*.py is discovered) as well as by name in the gates job.
+user-install-test: all  ## user-install leaves `hellish` on PATH, not just on disk
+	@python3 $(TEST_DIR)/user_install_path_test.py $(BIN_DIR)/$(BAPTIZE_SHELL)
+
 # Third-party conformance sweep: Oils spec tests + mksh check.t, run against
 # hellish, bash --posix and dash; report in bench/conformance.md; the gate
 # fails if hellish's pass count drops vs bench/baseline/. Suites are fetched
@@ -957,5 +969,6 @@ geoman: all  ## External 42 minishell tester, as an independent cross-check
 	bg-tty-test prompt-integrity-test update-badge-test nonblock-tty-test \
 	update-config-test update-test help-test \
 	conformance perf rss \
-	charts cli-opts-test net-redir-test login-test geoman oracle docker-suite docker widechar-test \
+	charts cli-opts-test net-redir-test login-test user-install-test \
+	geoman oracle docker-suite docker widechar-test \
 	user-install user-uninstall

--- a/README.md
+++ b/README.md
@@ -315,11 +315,14 @@ make user-uninstall   # put everything back
 ```
 
 `user-install` installs into `~/.local/bin`, seeds `~/.hellishrc` from
-`hellishrc.example` (never overwriting one you already have), and appends a
-marker-delimited block to your login shell's rc file that `exec`s hellish for
-interactive sessions. `exec` *replaces* the process, so this is a real login
-shell and not an alias or a wrapper: `ps` shows hellish, `$$` is hellish, and
-closing it closes the tab.
+`hellishrc.example` (never overwriting one you already have), puts the
+directory it installed into on `PATH` — from a marker-delimited block in
+`~/.hellishrc` and from the hook itself, so `hellish update` and
+`command -v hellish` work on a machine whose login chain never added
+`~/.local/bin` — and appends a marker-delimited block to your login shell's rc
+file that `exec`s hellish for interactive sessions. `exec` *replaces* the
+process, so this is a real login shell and not an alias or a wrapper: `ps`
+shows hellish, `$$` is hellish, and closing it closes the tab.
 
 Your passwd entry is never touched, which keeps `ssh host 'cmd'` working and
 leaves you a guaranteed way back in. The installed binary is smoke-tested

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,11 +8,93 @@ shows you how to drive the shell.
 
 ---
 
+## v2.7.6
+
+The 2.7.5 fix taken through the full CI gate, plus a proper split between the
+build you develop against and the build you ship.
+
+**Changed**
+
+- **Three named build configurations.** `make` now takes
+  `MODE=debug|release|relwithdebinfo`, and each one is a deliberate answer
+  rather than a side effect of which flags happened to be set:
+
+  | MODE | flags | for |
+  |---|---|---|
+  | `debug` *(default)* | `-O0 -g3 -ggdb`, ASan + LSan, libc malloc | developing |
+  | `release` | `-O3 -DNDEBUG`, LTO, `--gc-sections`, no `-g`, no sanitizer | shipping |
+  | `relwithdebinfo` | `-O2 -g -DNDEBUG`, no sanitizer, no LTO | bugs that only appear optimized |
+
+  Sizes on this machine: **462 KB** release, 3.0 MB relwithdebinfo, 5.6 MB
+  debug.
+
+  This did not change what gets shipped. `OPT=1` — which the release
+  workflow, the platform matrix, both install targets, the Docker build and
+  `make bench` all pass — still means exactly `MODE=release`, byte for byte,
+  and there is a test pinning that. What was missing was the middle
+  configuration and any way to name the other two.
+
+  Nothing is stripped after the fact. Release carries no debug information
+  because release never compiles `-g` in, which is also why `strip` recovers
+  only about a kilobyte from it: that last 807 bytes is libgcc's
+  `crtfastmath.c`, pulled in by `-ffast-math` and shipped by the distro
+  already compiled with `-g`. None of it is ours.
+
+  If you have been reading a 5.6 MB `build/bin/hellish` as the shipped
+  binary, it never was — that is the debug build, and it is large on purpose.
+
+**Fixed**
+
+- **`make user-install` now leaves `hellish` on your PATH**, not just on your
+  disk. The installer put the binary in `$PREFIX/bin` (default
+  `~/.local/bin`) and added an `exec` hook to your login rc — so the shell
+  came up, and the gap was invisible from the outside. What was missing was
+  the *name*:
+
+      $ hellish update
+      hellish: command not found
+
+  on a machine that had just installed it. Nothing on either route ever put
+  that directory on PATH, and the two reasons it looked covered both fail
+  here: a user-install hellish is exec'd from an *interactive* rc, so it is
+  not a login shell and reads neither `/etc/profile` nor `~/.profile`; and
+  Debian/Ubuntu's `~/.profile` adds `~/.local/bin` only `if [ -d ]` — on a
+  first install, this install is what creates that directory.
+
+  The seeder now maintains one marker-delimited, case-guarded PATH block in
+  `~/.hellishrc`, and the login-rc hook prepends the same directory before
+  the `exec` so bash finds it too. Re-sourcing cannot stack duplicates,
+  `--uninstall` removes only that block, and a hand-written `~/.hellishrc`
+  is still never clobbered. `make my_shell`, which installs to `/usr/bin`,
+  is unchanged.
+
+- **Build modes no longer share an object tree.** The object directory keyed
+  on `ifdef OPT`, which covered the `OPT=1` benchmark build and nothing else,
+  so a tree filled by a debug build and then reused by an optimized one
+  handed the linker ASan-instrumented objects under a link line carrying no
+  `-fsanitize`:
+
+      func_retire.o: undefined reference to `__asan_report_load4'
+
+  `make re` hid this; a plain `make MODE=release` after a debug build did
+  not. Objects now live in `build/obj-<mode>-<allocator>`, so the three modes
+  and the two allocator backends coexist and none of them can poison another.
+
+- Release notes and code comments now point at the issue the update fix
+  addressed (#64). 2.7.5 referenced a number that had been handed to the pull
+  request instead, so the trail led back to the fix rather than the report.
+
+If you installed with `make user-install` and have been typing the full path
+to reach the shell, this is the release that fixes it. Otherwise nothing in
+the shell's own behaviour differs from 2.7.5.
+
+---
+
 ## v2.7.5
 
 **Fixed**
 
-- **The shell notices a release published since its last check** (#62). The
+- **The shell notices a release published since its last check** (#64). The
   report was a screenshot:
 
       hellish 2.7.3 ...

--- a/hellishrc.example
+++ b/hellishrc.example
@@ -73,25 +73,36 @@ export EDITOR=vim
 export PAGER=less
 export LESS='-R'        # let pagers pass ANSI colors through
 
-# PATH — deliberately NOT set here, and that is the whole point.
+# PATH — this TEMPLATE sets none, and the installer appends exactly one
+# block. Both halves matter, and they used to be one over-general rule.
 #
 # A LOGIN hellish (chsh, or --login) sources /etc/profile — and so the .sh
 # snippets in /etc/profile.d, which is where your distro adds things like
 # /snap/bin — and then ~/.profile, which on Debian/Ubuntu is what puts
-# ~/.local/bin and ~/bin on PATH. All of that runs BEFORE this file. The
-# PATH you had under bash carries over whole; there is nothing to rebuild.
+# ~/.local/bin and ~/bin on PATH. All of that runs BEFORE this file. On
+# that route the PATH you had under bash carries over whole; there is
+# nothing to rebuild, and a prepend here would only duplicate what the
+# login chain did a moment earlier. Worse, it read as the pattern you were
+# meant to follow, so PATH edits got copy-pasted in over and over (issue
+# #51). That is why the template ships none.
 #
-# This file used to ship an active prepend of ~/.local/bin anyway, which
-# the login chain had already done a moment earlier. Redundant, and worse:
-# it read as the pattern you were meant to follow, so PATH edits got
-# copy-pasted in over and over (issue #51). Your ~/.bashrc does not need a
-# block like this to work, and neither does this file.
+# `make user-install` is the case that reasoning did NOT cover, and the
+# installer now fixes it at the end of this file instead. Hellish is exec'd
+# there from an INTERACTIVE rc, so it is not a login shell and reads
+# neither /etc/profile nor ~/.profile — and ~/.profile would not have
+# helped anyway, because it adds ~/.local/bin only when that directory
+# already exists at login and the install is what created it. The shell
+# started fine (the hook execs an absolute path) while its own NAME
+# resolved nowhere. So user-install appends a marked block for the
+# directory it really installed into; it is regenerated on re-install and
+# removed by `make user-uninstall`. Leave the markers alone and it will
+# never fight your edits.
 #
-# You only need a line here for a directory your login chain does NOT
-# already cover, or one you want under hellish and nowhere else. If you do
-# add one, keep the case guard: this file is re-sourced by every nested
-# interactive hellish, and an unguarded prepend stacks a fresh copy each
-# time until PATH is mostly duplicates.
+# You need a line of your own here only for a directory neither of those
+# covers, or one you want under hellish and nowhere else. If you add one,
+# keep the case guard: this file is re-sourced by every nested interactive
+# hellish, and an unguarded prepend stacks a fresh copy each time until
+# PATH is mostly duplicates.
 #
 # case ":$PATH:" in
 #	*":$HOME/.cargo/bin:"*) ;;

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.7.5"
+# define HELLISH_VERSION "2.7.6"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/platform/posix/update_gate.c
+++ b/src/platform/posix/update_gate.c
@@ -26,7 +26,7 @@
 
    BELIEVED CURRENT: this is the ONLY state in which a release can exist
    without us knowing, so it is the only one where asking buys anything.
-   A flat day here is what produced issue #62 -- checked at noon, 2.7.4
+   A flat day here is what produced issue #64 -- checked at noon, 2.7.4
    published at half past, and every session until the next day reported
    "up to date" with total confidence. A quarter of an hour instead.
 

--- a/tests/build_modes_test.py
+++ b/tests/build_modes_test.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Regression test: the three build configurations stay distinct.
+
+Raised after a 5.6 MB `build/bin/hellish` was mistaken for the shipped
+binary. It was not: that is the DEBUG build, and it is large on purpose --
+full DWARF plus the AddressSanitizer runtime. The release artifact is about
+620 KB and carries no debug information of ours at all, because release
+never compiles -g in. (`strip` on it recovers ~1 KB: DWARF stubs the C
+runtime brings, not our code.)
+
+The lesson worth keeping is not "make it smaller", it is that the two jobs
+must stay separated at the BUILD level rather than by stripping afterwards.
+So this pins the property directly:
+
+  debug            -O0, -g, sanitizer     -- develop against this
+  release          optimized, NO -g, no sanitizer, LTO -- ship this
+  relwithdebinfo   optimized AND -g, no sanitizer, no LTO -- for the bugs
+                   that only appear with optimization on
+
+and that OPT=1, which CI, both install targets, the docker build and
+`make bench` all pass, still means release.
+
+Flags are read from `make flags`, which resolves them without compiling, so
+this costs nothing and cannot be fooled by a stale object tree.
+
+Usage: python3 build_modes_test.py [/path/to/hellish]   (shell unused)
+"""
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def flags(*args):
+    p = subprocess.run(["make", "flags", "--no-print-directory"] + list(args),
+                       cwd=ROOT, capture_output=True, text=True, timeout=120)
+    out = re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", p.stdout)
+    got = {}
+    for line in out.splitlines():
+        if "=" in line and line.split("=", 1)[0] in (
+                "MODE", "CFLAGS", "LDFLAGS", "LDLIBS", "OBJ_DIR"):
+            k, v = line.split("=", 1)
+            got[k] = v
+    return got
+
+
+def has_g(cf):
+    """A real debug-info flag: -g, -g3, -ggdb -- but not -gdwarf-ish noise."""
+    return any(re.fullmatch(r"-g\d?|-ggdb\d?", t) for t in cf.split())
+
+
+def main():
+    d = flags("MODE=debug")
+    check("debug: mode resolves", d.get("MODE") == "debug", repr(d.get("MODE")))
+    check("debug: carries debug info", has_g(d.get("CFLAGS", "")),
+          d.get("CFLAGS", ""))
+    check("debug: unoptimised", "-O0" in d.get("CFLAGS", ""))
+    check("debug: sanitizer on", "-fsanitize" in d.get("CFLAGS", ""),
+          "development instrumentation must not be quietly dropped")
+    check("debug: sanitizer also linked", "-fsanitize" in d.get("LDFLAGS", ""))
+
+    r = flags("MODE=release")
+    check("release: mode resolves", r.get("MODE") == "release")
+    check("release: NO debug info", not has_g(r.get("CFLAGS", "")),
+          "release would ship DWARF: %s" % r.get("CFLAGS", ""))
+    check("release: optimised", "-O3" in r.get("CFLAGS", ""))
+    check("release: assertions compiled out", "-DNDEBUG" in r.get("CFLAGS", ""))
+    check("release: no sanitizer", "-fsanitize" not in r.get("CFLAGS", "")
+          and "-fsanitize" not in r.get("LDFLAGS", ""),
+          "the sanitizer runtime is most of the debug build's size")
+    check("release: link-time optimisation on", "-flto" in r.get("CFLAGS", ""))
+
+    w = flags("MODE=relwithdebinfo")
+    check("relwithdebinfo: mode resolves", w.get("MODE") == "relwithdebinfo")
+    check("relwithdebinfo: optimised", "-O2" in w.get("CFLAGS", ""))
+    check("relwithdebinfo: AND carries debug info", has_g(w.get("CFLAGS", "")),
+          "the whole point is a debuggable optimised build")
+    check("relwithdebinfo: no sanitizer",
+          "-fsanitize" not in w.get("CFLAGS", ""))
+    check("relwithdebinfo: no LTO", "-flto" not in w.get("CFLAGS", ""),
+          "LTO turns a stack trace into a list of inlined addresses")
+
+    # The three must actually differ -- a copy-paste that made two modes
+    # identical would pass every check above and defeat the purpose.
+    check("the three modes are genuinely distinct",
+          len({d.get("CFLAGS"), r.get("CFLAGS"), w.get("CFLAGS")}) == 3,
+          "two modes resolve to the same flags")
+
+    # OPT=1 is load-bearing: CI, my_shell, user-install, docker and bench.
+    o = flags("OPT=1")
+    check("OPT=1 still means release", o.get("MODE") == "release",
+          "renaming the flag would break CI and both install targets")
+    check("OPT=1 matches MODE=release exactly",
+          o.get("CFLAGS") == r.get("CFLAGS"))
+
+    # And an unknown mode must fail loudly rather than silently building
+    # something nobody asked for.
+    p = subprocess.run(["make", "flags", "MODE=nope", "--no-print-directory"],
+                       cwd=ROOT, capture_output=True, text=True, timeout=120)
+    # Separate flags are worth nothing if the modes share an object tree.
+    # make rebuilds on a changed PREREQUISITE, never on a changed flag, so a
+    # tree filled by MODE=debug and then reused by MODE=release hands the
+    # linker ASan-instrumented objects under a link line with no -fsanitize:
+    #
+    #   func_retire.o: undefined reference to `__asan_report_load4'
+    #
+    # That is exactly what happened while this was being written, because
+    # OBJ_DIR still keyed on `ifdef OPT` -- which covered the OPT benchmark
+    # build and nothing else, leaving release and relwithdebinfo both parked
+    # in the debug tree. `make re` hides it; a plain `make MODE=release`
+    # after a debug build does not.
+    trees = [d.get("OBJ_DIR"), r.get("OBJ_DIR"), w.get("OBJ_DIR")]
+    check("each mode gets its own object tree",
+          all(trees) and len(set(trees)) == 3, repr(trees))
+    check("OPT=1 shares release's object tree",
+          o.get("OBJ_DIR") == r.get("OBJ_DIR"),
+          "%r != %r" % (o.get("OBJ_DIR"), r.get("OBJ_DIR")))
+
+    # SAFE rides along in the key for the same reason: it decides
+    # -DHAVE_ALLOC_ORACLE, which is a compile-time define, so the two
+    # allocator backends cannot share objects either.
+    rs = flags("MODE=release", "SAFE=1")
+    check("the allocator backend also splits the object tree",
+          rs.get("OBJ_DIR") not in (None, r.get("OBJ_DIR")),
+          "%r == %r" % (rs.get("OBJ_DIR"), r.get("OBJ_DIR")))
+
+    check("an unknown MODE is refused", p.returncode != 0
+          and "MODE must be" in (p.stdout + p.stderr))
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/link_closure_test.py
+++ b/tests/link_closure_test.py
@@ -48,6 +48,7 @@ is a check nobody learns anything from.
 
 Usage: python3 link_closure_test.py /path/to/hellish
 """
+import glob
 import os
 import platform
 import re
@@ -154,9 +155,17 @@ def nm_symbols(path):
 
 
 def object_tree():
-    """The shell's own objects, from whichever build ran most recently."""
-    for d in ("obj", "obj-opt", "obj-debug"):
-        base = os.path.join(ROOT, "build", d)
+    """The shell's own objects, from whichever build ran most recently.
+
+    Globbed rather than spelled out: the tree is named for the build mode
+    and the allocator backend (build/obj-release-ft, build/obj-debug-libc,
+    ...), so a fixed list goes stale the moment a mode is added. Picking
+    the newest tree is what the one-line summary always claimed to do --
+    the old fixed list returned the first name that happened to exist,
+    which silently checked a stale tree whenever two modes were built.
+    """
+    trees = []
+    for base in glob.glob(os.path.join(ROOT, "build", "obj*")):
         if not os.path.isdir(base):
             continue
         objs = []
@@ -164,8 +173,12 @@ def object_tree():
             objs += [os.path.join(root, f) for f in files
                      if f.endswith(".o")]
         if objs:
-            return (d, sorted(objs))
-    return (None, [])
+            newest = max(os.path.getmtime(o) for o in objs)
+            trees.append((newest, os.path.basename(base), sorted(objs)))
+    if not trees:
+        return (None, [])
+    _, name, objs = max(trees)
+    return (name, objs)
 
 
 def test_no_dangling_weak_refs():

--- a/tests/update_freshness_test.py
+++ b/tests/update_freshness_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression test: a release published AFTER the last check -- issue #62.
+"""Regression test: a release published AFTER the last check -- issue #64.
 
 Reported twice, and the second time with a screenshot that says it all:
 

--- a/tests/user_install_path_test.py
+++ b/tests/user_install_path_test.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Regression test: `make user-install` leaves `hellish` on PATH.
+
+THE BUG. user-install.sh puts the binary in $PREFIX/bin (default
+~/.local/bin) and appends an `exec` hook to your login shell's rc. Both
+halves worked, and the shell came up -- so the gap was invisible from the
+outside. What was missing was the NAME: nothing on either route ever put
+$PREFIX/bin on PATH, so on a machine where the login chain had not already
+done it, a freshly installed user got
+
+    $ hellish update
+    hellish: command not found
+
+inside hellish and out. `command -v hellish`, `hellish --version`, and
+every tool that looks a shell up by name answered the same way.
+
+WHY THE LOGIN CHAIN DOES NOT COVER IT. ~/.hellishrc's own comments used to
+argue that a PATH line here was redundant, because a LOGIN hellish sources
+/etc/profile and then ~/.profile, which is what puts ~/.local/bin on PATH.
+That is true of the `make my_shell` + chsh route and false of this one,
+twice over:
+
+  * user-install's hellish is exec'd from an INTERACTIVE rc. It is not a
+    login shell, so it reads neither file.
+  * Debian/Ubuntu's ~/.profile adds ~/.local/bin only `if [ -d ]` -- and on
+    a first install, this install is what creates that directory. Even a
+    login shell would not have picked it up until the next logout.
+
+THE FIX. tools/seed_hellishrc.sh (the seeder both install routes share)
+maintains one marker-delimited block in ~/.hellishrc that puts the real
+install directory on PATH, and user-install.sh's rc hook does the same
+before it execs. Both are guarded against re-sourcing, both name the
+directory actually installed into, and both are removed by
+`make user-uninstall`.
+
+Hermetic: every case runs against a temporary HOME and a temporary rc file,
+passes --bin so nothing is compiled, and never touches the real $HOME.
+
+Usage: python3 user_install_path_test.py /path/to/hellish
+"""
+import os
+import pty
+import re
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+INSTALLER = os.path.join(ROOT, "user-install.sh")
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else os.path.join(ROOT, "build", "bin", "hellish"))
+
+# A PATH that deliberately does NOT contain any install prefix we use. This
+# is the whole point: it stands in for the machine where the login chain
+# never added ~/.local/bin.
+CLEAN_PATH = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+BASE_ENV = {
+    "PATH": CLEAN_PATH,
+    "TERM": "xterm-256color",
+    "LANG": "C.UTF-8",
+    "HELLISH_NO_BANNER": "1",
+    "HELLISH_NO_UPDATE_CHECK": "1",
+    "HELLISH_NO_ANIM": "1",
+    "ASAN_OPTIONS": "detect_leaks=0",
+}
+
+FAILS = []
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name + ("  " + detail if not ok
+                                                 else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+# ── the installer, driven the way `make user-install` drives it ─────────────
+def install(home, prefix=None, rc=None, uninstall=False):
+    """Run user-install.sh against a temporary HOME. Returns CompletedProcess."""
+    prefix = prefix or os.path.join(home, ".local")
+    rc = rc or os.path.join(home, ".bashrc")
+    env = dict(BASE_ENV)
+    env["HOME"] = home
+    argv = [INSTALLER, "--prefix", prefix, "--rc", rc]
+    if uninstall:
+        argv.append("--uninstall")
+    else:
+        argv += ["--bin", SHELL]
+    return subprocess.run(argv, cwd=ROOT, env=env, capture_output=True,
+                          text=True, timeout=180)
+
+
+def new_home(rc_lines="# a login rc that was here first\nexport FOO=bar\n"):
+    home = tempfile.mkdtemp(prefix="hellish-userinstall-")
+    with open(os.path.join(home, ".bashrc"), "w") as f:
+        f.write(rc_lines)
+    return home
+
+
+def run_in_shell(home, bindir, script):
+    """Run `script` in the INSTALLED hellish, with a PATH lacking bindir."""
+    env = dict(BASE_ENV)
+    env["HOME"] = home
+    return subprocess.run([os.path.join(bindir, "hellish"), "-c", script],
+                          env=env, capture_output=True, text=True, timeout=60)
+
+
+def block_count(path, marker):
+    if not os.path.exists(path):
+        return 0
+    with open(path) as f:
+        return sum(1 for line in f if line.rstrip("\n") == marker)
+
+
+RC_MARK = "# >>> hellish path >>>"
+HOOK_MARK = "# >>> hellish >>>"
+
+
+# ── 1. the reported bug, in the shape the user meets it ────────────────────
+def test_name_resolves_after_install():
+    home = new_home()
+    try:
+        bindir = os.path.join(home, ".local", "bin")
+        r = install(home)
+        check("installer succeeds", r.returncode == 0, r.stderr[-400:])
+
+        rc = os.path.join(home, ".hellishrc")
+        check("~/.hellishrc is seeded", os.path.isfile(rc))
+
+        # The bug: sourcing ~/.hellishrc left PATH untouched, so the shell
+        # could not find itself by name.
+        got = run_in_shell(home, bindir,
+                           '. "$HOME/.hellishrc" >/dev/null 2>&1; '
+                           'command -v hellish')
+        want = os.path.join(bindir, "hellish")
+        check("~/.hellishrc puts the install dir on PATH",
+              got.stdout.strip() == want,
+              "got %r, want %r" % (got.stdout.strip(), want))
+
+        # ... and the same thing said the way a user says it.
+        got = run_in_shell(home, bindir,
+                           '. "$HOME/.hellishrc" >/dev/null 2>&1; '
+                           'hellish -c "echo REACHED-BY-NAME"')
+        check("`hellish` runs as a bare command name",
+              "REACHED-BY-NAME" in got.stdout,
+              "stdout=%r stderr=%r" % (got.stdout, got.stderr[-200:]))
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+# ── 2. the same thing, end to end, in a real terminal ──────────────────────
+def test_interactive_shell_finds_itself():
+    """An interactive hellish sources ~/.hellishrc; that is the real path
+    a user's session takes, and the only one that proves the rc is read at
+    startup rather than merely being sourceable."""
+    home = new_home()
+    try:
+        bindir = os.path.join(home, ".local", "bin")
+        install(home)
+        env = dict(BASE_ENV)
+        env["HOME"] = home
+        env["PS1"] = "$ "
+
+        pid, fd = pty.fork()
+        if pid == 0:
+            os.environ.clear()
+            os.environ.update(env)
+            os.execv(os.path.join(bindir, "hellish"),
+                     [os.path.join(bindir, "hellish")])
+        time.sleep(0.8)
+        os.write(fd, b'command -v hellish\n')
+        time.sleep(0.5)
+        os.write(fd, b'exit\n')
+
+        out = b""
+        deadline = time.time() + 12
+        while time.time() < deadline:
+            r, _, _ = select.select([fd], [], [], 0.4)
+            if not r:
+                continue
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError:
+                break
+            if not chunk:
+                break
+            out += chunk
+        os.close(fd)
+        try:
+            os.waitpid(pid, 0)
+        except ChildProcessError:
+            pass
+
+        text = re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "",
+                      out.decode("utf-8", "replace"))
+        want = os.path.join(bindir, "hellish")
+        check("an interactive hellish resolves its own name", want in text,
+              "pty output tail: %r" % text[-300:])
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+# ── 3. the guard: an rc is re-sourced, PATH must not grow ──────────────────
+def test_no_duplicate_path_entries():
+    home = new_home()
+    try:
+        bindir = os.path.join(home, ".local", "bin")
+        install(home)
+        got = run_in_shell(
+            home, bindir,
+            '. "$HOME/.hellishrc" >/dev/null 2>&1; '
+            '. "$HOME/.hellishrc" >/dev/null 2>&1; '
+            '. "$HOME/.hellishrc" >/dev/null 2>&1; echo "$PATH"')
+        n = got.stdout.strip().split(":").count(bindir)
+        check("three sources leave exactly one PATH entry", n == 1,
+              "counted %d" % n)
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+# ── 4. the login shell's rc hook carries PATH across the exec too ──────────
+def test_login_rc_hook_exports_path():
+    home = new_home()
+    try:
+        bindir = os.path.join(home, ".local", "bin")
+        rc = os.path.join(home, ".bashrc")
+        install(home)
+        env = dict(BASE_ENV)
+        env["HOME"] = home
+        # HELLISH_NO_EXEC=1 stops the handover so we can look at what the
+        # hook did to the environment BEFORE it would have exec'd.
+        env["HELLISH_NO_EXEC"] = "1"
+        got = subprocess.run(
+            ["/bin/sh", "-c", '. "$HOME/.bashrc"; command -v hellish'],
+            env=env, capture_output=True, text=True, timeout=60)
+        check("the login-rc hook puts the dir on PATH as well",
+              got.stdout.strip() == os.path.join(bindir, "hellish"),
+              "got %r" % got.stdout.strip())
+        check("the hook still parses as POSIX sh",
+              subprocess.run(["/bin/sh", "-n", rc]).returncode == 0)
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+# ── 5. it must name the directory it REALLY installed into ────────────────
+def test_custom_prefix_is_honoured():
+    home = new_home()
+    try:
+        prefix = os.path.join(home, "opt", "hellish")
+        bindir = os.path.join(prefix, "bin")
+        install(home, prefix=prefix)
+        got = run_in_shell(home, bindir,
+                           '. "$HOME/.hellishrc" >/dev/null 2>&1; '
+                           'command -v hellish')
+        check("a custom --prefix is what lands in the block",
+              got.stdout.strip() == os.path.join(bindir, "hellish"),
+              "got %r" % got.stdout.strip())
+        with open(os.path.join(home, ".hellishrc")) as f:
+            body = f.read()
+        check("no hardcoded ~/.local/bin leaks into the block",
+              os.path.join(home, ".local", "bin") not in body)
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+# ── 6. the rule that must survive all of this: your rc is YOURS ───────────
+def test_existing_rc_is_not_clobbered():
+    home = new_home()
+    try:
+        rc = os.path.join(home, ".hellishrc")
+        mine = ("# hand-written\nalias mine='echo SENTINEL-KEPT'\n"
+                "export MY_OWN_VAR=42\n")
+        with open(rc, "w") as f:
+            f.write(mine)
+        bindir = os.path.join(home, ".local", "bin")
+        install(home)
+        with open(rc) as f:
+            body = f.read()
+        check("every hand-written line survives",
+              all(line in body for line in mine.strip().splitlines()))
+        check("...and the PATH block was still added",
+              block_count(rc, RC_MARK) == 1)
+        got = run_in_shell(home, bindir,
+                           '. "$HOME/.hellishrc" >/dev/null 2>&1; '
+                           'echo "$MY_OWN_VAR"; command -v hellish')
+        check("the merged rc still works",
+              got.stdout.split() == ["42", os.path.join(bindir, "hellish")],
+              "got %r" % got.stdout)
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+# ── 7. re-running an installer is normal; stacking blocks is not ──────────
+def test_reinstall_is_idempotent():
+    home = new_home()
+    try:
+        rc = os.path.join(home, ".hellishrc")
+        hook = os.path.join(home, ".bashrc")
+        for _ in range(3):
+            install(home)
+        check("~/.hellishrc holds exactly one PATH block",
+              block_count(rc, RC_MARK) == 1,
+              "found %d" % block_count(rc, RC_MARK))
+        check("the login rc holds exactly one hook block",
+              block_count(hook, HOOK_MARK) == 1,
+              "found %d" % block_count(hook, HOOK_MARK))
+        bindir = os.path.join(home, ".local", "bin")
+        got = run_in_shell(home, bindir,
+                           '. "$HOME/.hellishrc" >/dev/null 2>&1; echo "$PATH"')
+        check("PATH still holds one copy after three installs",
+              got.stdout.strip().split(":").count(bindir) == 1)
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+# ── 8. and it all comes back out again ────────────────────────────────────
+def test_uninstall_removes_only_our_block():
+    home = new_home()
+    try:
+        rc = os.path.join(home, ".hellishrc")
+        install(home)
+        with open(rc, "a") as f:
+            f.write("\nalias after='echo AFTER-THE-BLOCK'\n")
+        r = install(home, uninstall=True)
+        check("uninstall succeeds", r.returncode == 0, r.stderr[-300:])
+        with open(rc) as f:
+            body = f.read()
+        check("the PATH block is gone", block_count(rc, RC_MARK) == 0)
+        check("the user's own lines are not",
+              "AFTER-THE-BLOCK" in body and "alias ll=" in body)
+        check("~/.hellishrc still parses",
+              subprocess.run(["/bin/sh", "-n", rc]).returncode == 0)
+        check("the hook block is gone too",
+              block_count(os.path.join(home, ".bashrc"), HOOK_MARK) == 0)
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+def main():
+    if not os.access(SHELL, os.X_OK):
+        print("FAIL no shell at %s -- run make" % SHELL)
+        return 2
+    print("shell:     %s" % SHELL)
+    print("installer: %s\n" % INSTALLER)
+    for fn in (test_name_resolves_after_install,
+               test_interactive_shell_finds_itself,
+               test_no_duplicate_path_entries,
+               test_login_rc_hook_exports_path,
+               test_custom_prefix_is_honoured,
+               test_existing_rc_is_not_clobbered,
+               test_reinstall_is_idempotent,
+               test_uninstall_removes_only_our_block):
+        print("── %s" % fn.__name__)
+        fn()
+    print("\n%d checks failed" % len(FAILS))
+    for f in FAILS:
+        print("  FAIL %s" % f)
+    return 1 if FAILS else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/seed_hellishrc.sh
+++ b/tools/seed_hellishrc.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # ============================================================================
-# tools/seed_hellishrc.sh -- put hellishrc.example at ~/.hellishrc, once.
+# tools/seed_hellishrc.sh -- put hellishrc.example at ~/.hellishrc, once, and
+# keep the one block in it that the INSTALLER owns: the PATH entry for the
+# directory the binary actually landed in.
 #
 # Why this is its own file. The seeding used to live inline in
 # user-install.sh, which meant it only happened on the no-sudo route. The
@@ -12,11 +14,15 @@
 #
 # The one rule that matters: an EXISTING ~/.hellishrc is never touched. It
 # is the user's file, installers get re-run, and eating an edited config is
-# far worse than skipping a template.
+# far worse than skipping a template. --path-dir does not break that rule:
+# it rewrites ONLY the text between its own markers, the same way
+# user-install.sh manages its block in your login shell's rc.
 #
 #   tools/seed_hellishrc.sh                      seed $HOME/.hellishrc
 #   tools/seed_hellishrc.sh --home DIR           seed DIR/.hellishrc
 #   tools/seed_hellishrc.sh --example FILE       use FILE as the template
+#   tools/seed_hellishrc.sh --path-dir DIR       ...and keep DIR on PATH
+#   tools/seed_hellishrc.sh --strip-path         drop the PATH block again
 #
 # Always exits 0 unless it was asked to do something impossible: a missing
 # template is a warning, because an install must not fail over a doc file.
@@ -26,12 +32,16 @@ set -u
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TARGET_HOME="${HOME:-}"
 EXAMPLE="$REPO_ROOT/hellishrc.example"
+PATH_DIR=""
+STRIP_PATH=0
 
 while [ $# -gt 0 ]; do
 	case "$1" in
 	--home) TARGET_HOME="${2:-}"; shift 2 ;;
 	--example) EXAMPLE="${2:-}"; shift 2 ;;
-	-h|--help) sed -n '3,20p' "$0"; exit 0 ;;
+	--path-dir) PATH_DIR="${2:-}"; shift 2 ;;
+	--strip-path) STRIP_PATH=1; shift ;;
+	-h|--help) sed -n '3,28p' "$0"; exit 0 ;;
 	*) echo "seed_hellishrc: unknown argument: $1" >&2; exit 2 ;;
 	esac
 done
@@ -43,19 +53,113 @@ fi
 
 RC="$TARGET_HOME/.hellishrc"
 
-if [ -e "$RC" ]; then
-	printf '  \033[1;34mi\033[0m  %s already exists — left untouched\n' "$RC"
+PATH_BEGIN='# >>> hellish path >>>'
+PATH_END='# <<< hellish path <<<'
+
+# ── seeding ────────────────────────────────────────────────────────────────
+seed_rc() {
+	if [ -e "$RC" ]; then
+		printf '  \033[1;34mi\033[0m  %s already exists — left untouched\n' "$RC"
+		return 0
+	fi
+
+	if [ ! -f "$EXAMPLE" ]; then
+		printf '  \033[1;33m!\033[0m  %s not found — skipping %s\n' \
+			"$EXAMPLE" "$RC" >&2
+		return 0
+	fi
+
+	# Copy to a temp name in the same directory and rename, so an interrupted
+	# copy can never leave a half-written rc that the next shell then sources.
+	cp "$EXAMPLE" "$RC.new" || return 1
+	mv -f "$RC.new" "$RC" || return 1
+	printf '  \033[1;32m✓\033[0m  seeded %s from %s\n' "$RC" "$(basename "$EXAMPLE")"
+}
+
+# ── the managed PATH block ─────────────────────────────────────────────────
+# Delete an existing block from stdin. A half-removed block (someone deleted
+# one marker by hand) degrades to "leave it alone" rather than eating the
+# rest of the file.
+strip_path_block() {
+	awk -v b="$PATH_BEGIN" -v e="$PATH_END" '
+		$0 == e { skip = 0; next }
+		$0 == b { skip = 1 }
+		skip    { next }
+		        { print }
+	'
+}
+
+# Drop trailing blank lines. We insert a blank line ahead of the block, so
+# without this an install/uninstall/install cycle would slowly grow a gap at
+# the end of the file. Interior blank lines are preserved.
+trim_trailing_blanks() {
+	awk 'BEGIN { n = 0 }
+	     /^[[:space:]]*$/ { n++; next }
+	     { while (n-- > 0) print ""; n = 0; print }'
+}
+
+write_path_block() {
+	_dir="$1"
+	[ -e "$RC" ] || : > "$RC"
+	strip_path_block < "$RC" | trim_trailing_blanks > "$RC.new" || return 1
+
+	cat >> "$RC.new" <<EOF
+
+$PATH_BEGIN
+# Added by hellish's installer. Everything between the markers is
+# regenerated on re-install and removed by \`make user-uninstall\` — put your
+# own edits outside them.
+#
+# Why this is here at all. \`make user-install\` puts the binary somewhere
+# your login chain may well NOT have on PATH. Debian/Ubuntu's stock
+# ~/.profile adds ~/.local/bin only when that directory already exists at
+# login — and on a first install this is the run that created it. A
+# user-installed hellish is also exec'd from an interactive rc, so it is not
+# a login shell and never reads /etc/profile or ~/.profile itself.
+#
+# The shell still STARTS without this (the rc hook execs an absolute path),
+# which is exactly why the gap was easy to miss: what broke was the NAME.
+# \`hellish\`, \`hellish update\`, \`command -v hellish\` and every tool that
+# looks the shell up by name answered "command not found" on a freshly
+# installed machine. See tests/user_install_path_test.py.
+#
+# The case guard is load-bearing: this file is re-sourced by every nested
+# interactive hellish, and an unguarded prepend stacks a fresh copy each
+# time until PATH is mostly duplicates.
+case ":\$PATH:" in
+	*":$_dir:"*) ;;
+	*) PATH="$_dir:\$PATH"; export PATH ;;
+esac
+$PATH_END
+EOF
+
+	# Refuse to leave behind an rc that will not parse: this file is sourced
+	# by every interactive hellish, and this script is the one that wrote it.
+	if ! sh -n "$RC.new" 2>/dev/null; then
+		rm -f "$RC.new"
+		printf '  \033[1;33m!\033[0m  generated %s would not parse — left untouched\n' \
+			"$RC" >&2
+		return 1
+	fi
+	mv -f "$RC.new" "$RC" || return 1
+	printf '  \033[1;32m✓\033[0m  %s puts %s on PATH\n' "$RC" "$_dir"
+}
+
+remove_path_block() {
+	[ -f "$RC" ] || return 0
+	grep -qxF "$PATH_BEGIN" "$RC" 2>/dev/null || return 0
+	strip_path_block < "$RC" | trim_trailing_blanks > "$RC.new" || return 1
+	mv -f "$RC.new" "$RC" || return 1
+	printf '  \033[1;32m✓\033[0m  removed the PATH block from %s\n' "$RC"
+}
+
+if [ "$STRIP_PATH" = "1" ]; then
+	remove_path_block || exit 1
 	exit 0
 fi
 
-if [ ! -f "$EXAMPLE" ]; then
-	printf '  \033[1;33m!\033[0m  %s not found — skipping %s\n' \
-		"$EXAMPLE" "$RC" >&2
-	exit 0
+seed_rc || exit 1
+if [ -n "$PATH_DIR" ]; then
+	write_path_block "$PATH_DIR" || exit 1
 fi
-
-# Copy to a temp name in the same directory and rename, so an interrupted
-# copy can never leave a half-written rc that the next shell then sources.
-cp "$EXAMPLE" "$RC.new" || exit 1
-mv -f "$RC.new" "$RC" || exit 1
-printf '  \033[1;32m✓\033[0m  seeded %s from %s\n' "$RC" "$(basename "$EXAMPLE")"
+exit 0

--- a/user-install.sh
+++ b/user-install.sh
@@ -28,7 +28,9 @@
 # WHAT IT TOUCHES
 # ---------------
 #   1. $PREFIX/bin/hellish        the binary                 (default ~/.local)
-#   2. ~/.hellishrc               seeded from hellishrc.example, NEVER clobbered
+#   2. ~/.hellishrc               seeded from hellishrc.example, NEVER clobbered,
+#                                 plus one marker-delimited block that puts
+#                                 $PREFIX/bin on PATH
 #   3. <your login shell's rc>    one marker-delimited block, appended at the end
 #
 # Nothing else. Re-running replaces the block in place rather than stacking a
@@ -180,6 +182,8 @@ if [ "$ACTION" = "uninstall" ]; then
 		rm -f "$DEST"
 		grn "removed $DEST"
 	fi
+	# The rc file is the user's; only the block THIS script wrote comes out.
+	"$REPO_ROOT/tools/seed_hellishrc.sh" --strip-path >&2 || true
 	inf "~/.hellishrc left in place (it is yours; delete it by hand if you want)"
 	printf '\n  Open a NEW terminal and you are back in %s.\n\n' "$LOGIN_SHELL" >&2
 	exit 0
@@ -202,7 +206,11 @@ grn "installed $DEST"
 # Delegated, not inlined. This is the copy `make my_shell` did not have, so
 # the sudo route installed a shell with no config at all (issue #51); one
 # seeder called by both routes is what keeps them from drifting again.
-"$REPO_ROOT/tools/seed_hellishrc.sh" --example "$REPO_ROOT/hellishrc.example"
+# --path-dir is the other half of "install it and it works": $DEST_DIR is
+# NOT necessarily on PATH (see the block the seeder writes), so without it
+# the shell starts but its own name does not resolve.
+"$REPO_ROOT/tools/seed_hellishrc.sh" --example "$REPO_ROOT/hellishrc.example" \
+	--path-dir "$DEST_DIR"
 
 # ── 3. prove the binary works BEFORE anything execs it ────────────────────
 #
@@ -259,6 +267,19 @@ $BEGIN_MARK
 #   make user-uninstall             remove this block for good
 # And from another machine, since your passwd shell is untouched:
 #   ssh $(id -un)@\$(hostname) 'touch ~/.hellish-disable'
+
+# The binary lives in a directory your login chain may not have on PATH:
+# ~/.profile adds ~/.local/bin only when it already exists at login, and on a
+# first install this run is what created it. The exec below uses an absolute
+# path, so the shell starts either way — but without this, \`hellish\` as a
+# COMMAND ("hellish update", "command -v hellish", any tool that looks the
+# shell up by name) is not found, here or inside hellish. Guarded, because
+# an rc gets re-sourced and an unguarded prepend stacks duplicates.
+case ":\$PATH:" in
+	*":$DEST_DIR:"*) ;;
+	*) PATH="$DEST_DIR:\$PATH"; export PATH ;;
+esac
+
 if [ -z "\${HELLISH_NO_EXEC-}" ] && [ -z "\${HELLISH_EXECD-}" ] \\
 	&& [ ! -e "\$HOME/.hellish-disable" ] && [ -x "$DEST" ]; then
 	case \$- in

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -5,7 +5,7 @@ later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**. Released version: **2.7.5**.
+Branch to resume from: **`develop`**. Released version: **2.7.6**.
 
 The previous note on this file covered the issue-fixing session (#27, #32,
 #34, #42 and friends). All of those are closed; the tracker is empty. This


### PR DESCRIPTION
Promotes **v2.7.6** to `main`. Everything here has already gone through the full gate on `develop`.

**What ships in 2.7.6**

- **Separate debug and release build configurations** (#65). `MODE=debug|release|relwithdebinfo`, each a deliberate answer rather than a side effect of which flags happened to be set. Release is 462 KB and carries no debug information of ours — not because anything is stripped afterwards, but because release never compiles `-g` in. `OPT=1` still means exactly `MODE=release`, byte for byte.

  Two real defects fell out of writing the test: `SAFE` and `OBJ_DIR` both keyed on `ifdef OPT`, so `OPT=1` and `MODE=release` picked different allocators, and the optimized modes shared the debug object tree — which handed the linker ASan-instrumented objects under a link line with no `-fsanitize`. Both now key on `MODE`.

- **`make user-install` leaves `hellish` on PATH** (`67508ad`), not just on disk. The installer placed the binary and added an `exec` hook, but nothing on either route put `$PREFIX/bin` on PATH — so `hellish update` and `command -v hellish` failed on a machine that had just installed it.

- Release notes and code comments now cite issue **#64** for the update-freshness fix; 2.7.5 cited the number GitHub had assigned to the pull request.

**Gate on `develop` (023b785 / 8f60e51)**

- CI — 16/16 jobs green, including `Interactive · pty gates`, `Gates · cli + login + install + help + cd + update-config`, `Tests · suite + scripts + leaks`, `Hard corpus + allocator parity`, `42 Norm`, and all three build configurations (`opt SAFE=0`, `opt SAFE=1`, `debug SAFE=1`).
- Platforms — 16/16 green across alpine musl, arch, debian, fedora, opensuse, rocky, ubuntu 22.04/24.04, void and linux arm64, under both gcc and clang.
- Locally: golden suite 3790/3790, pty suite 30 ok / 0 failed / 4 skipped.

Tag `v2.7.6` follows the merge.
