### PR TITLE
docs: school-style docs, one-command installer, and a docs website

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,6 +76,21 @@ jobs:
       - name: Install as a login shell, then update it
         run: make my-shell-test
 
+  # `curl | sh` for both privilege worlds: a sudoer routed to the system
+  # install, a sudo-less account routed to ~/.local/bin, the plugin
+  # questions over a real pty, and both uninstalls. Runs against a fake
+  # in-container release channel, so it tests the mechanism, not GitHub.
+  installer:
+    name: curl|sh installer, sudo and no-sudo
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: install.sh end-to-end in docker
+        run: make installer-test
+
   # hellish as the login shell sshd execs for EVERY remote operation. After
   # `make my_shell`, `ssh host cmd`, scp, sftp, rsync and git all run
   # `$SHELL -c ...`, and those protocols fail on one stray byte of stdout.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: docs
+
+# The documentation site (https://univers42.github.io/hellish/) is MkDocs
+# Material over the wiki/ directory -- see mkdocs.yml. Rebuilt on every push
+# to main that touches the pages, and deployable by hand from any branch for
+# a preview of a docs change.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'wiki/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Build the site
+        # --strict makes a broken internal link a build failure, which is the
+        # only thing standing between a renamed page and a 404 nobody notices.
+        run: |
+          pip install --quiet mkdocs-material
+          mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,19 @@ jobs:
           file hellish-linux-x86_64
           sha256sum hellish-linux-x86_64 > hellish-linux-x86_64.sha256
           cat hellish-linux-x86_64.sha256
+      # The install bundle: the proven install drivers, shipped beside the
+      # binary so `curl | sh` reuses them instead of reimplementing preflight,
+      # smoke-testing and never-clobber seeding. Layout mirrors the repo,
+      # because the scripts locate each other relatively (tools/../share).
+      - name: Stage the install bundle
+        run: |
+          set -eux
+          mkdir -p bundle/tools
+          cp user-install.sh hellishrc.example bundle/
+          cp tools/register_shell.sh tools/seed_hellishrc.sh bundle/tools/
+          cp -R share bundle/share
+          tar -czf hellish-install-bundle.tar.gz -C bundle .
+          tar -tzf hellish-install-bundle.tar.gz | head
       # Proves the asset runs where the old one could not, before it is
       # published rather than after someone reports that it does not.
       - name: The asset runs on an old glibc and with no readline
@@ -65,6 +78,7 @@ jobs:
           files: |
             hellish-linux-x86_64
             hellish-linux-x86_64.sha256
+            hellish-install-bundle.tar.gz
           generate_release_notes: true
           # A tag carrying a pre-release suffix must never become "latest":
           # the update check reads /releases/latest, so publishing a test

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ dist/
 .claude
 .CLAUDE
 *CLAUDE*
+site/

--- a/DEV_DOC.md
+++ b/DEV_DOC.md
@@ -1,0 +1,133 @@
+# hellish — Developer Documentation
+
+How to set the environment up from scratch, build every configuration, run
+every test layer, and understand where Docker and the data live. End-user
+material is in [USER_DOC.md](USER_DOC.md); per-module design notes are in
+`src/<module>/README.md`; the full manual is the
+[docs site](https://univers42.github.io/hellish/).
+
+## 1. From scratch
+
+**Prerequisites**: gcc or clang, GNU make, `libreadline-dev`, git, python3
+(for the pty test suites), and Docker for the container suites. No other
+configuration files or secrets are needed — the project has none.
+
+```sh
+git clone --recursive https://github.com/Univers42/hellish && cd hellish
+# forgot --recursive? →  git submodule update --init --recursive
+make            # prints the self-documenting help page (every target described)
+make all        # debug build (ASan) → build/bin/hellish
+```
+
+Two submodules are required: `vendor/libft` (stdlib + the `ft_malloc`
+allocator) and `vendor/scripts` (dev tooling). A build failing on a missing
+libft means the submodules are not initialised.
+
+Install the git hooks once: `./vendor/scripts/install-hooks.sh`
+(Conventional Commits are enforced at commit time).
+
+## 2. Build — the MODE × SAFE matrix
+
+| Command | Optimization | Allocator | Sanitizers |
+|---|---|---|---|
+| `make all` | `-O0 -g3` (`MODE=debug`, default) | libc (`SAFE=1`) | ASan + LSan |
+| `make MODE=release` / `make OPT=1` | `-O3 -flto`, `-DNDEBUG` | `ft_malloc` (`SAFE=0`) | none |
+| `make MODE=relwithdebinfo` | `-O2 -g`, `-DNDEBUG` | `ft_malloc` | none |
+
+- An explicit `SAFE=…` always wins over the per-mode default.
+- Objects live in `build/obj-$(MODE)-$(SAFE_TAG)`; modes never share objects.
+  The **binary path is shared**, so mode-switching targets delete and relink
+  it first.
+- Flags are `-Wall -Wextra -Werror` — a warning is a build failure. Add flags
+  with `EXTRA_CFLAGS=…`, never with `CFLAGS=…` (that would *replace* the set).
+
+Runtime knobs while developing: `HELLISH_ALLOC_STATS=1` (live-bytes at exit —
+the leak oracle on `SAFE=0`), `HELLISH_BANNER=0`, `HELLISH_NO_UPDATE_CHECK=1`,
+`--debug=lexer --debug=parser --debug=ast`.
+
+## 3. Test layers (a green `make test` is not enough)
+
+| layer | run | covers |
+|---|---|---|
+| golden suite | `make test` (4248 cases) | `hellish -c` diffed vs **pinned bash 5.3.9** — run `make oracle` once to build it into `~/bash-5.3.9`; `make zsh-oracle` pins zsh 5.9 for the dialect tests |
+| whole scripts | `tests/run_scripts.sh` | real programs + ASan scrape |
+| hard corpus | `tests/hard/run.sh` | whole programs with timings |
+| pty / interactive | `make pty-test` | every `tests/*.py`, discovered by glob — a new test file is covered the moment it exists |
+| allocator parity | `cd tests && ./verify_alloc.sh` | both heaps byte-identical, zero leaks |
+| plugin corpus | `make plugin-corpus` | 13 real third-party plugins vs release AND ASan builds |
+| release build | `make test-release` | ASan and `-O3` disagree; run after touching memory |
+| login shell (docker) | `make my-shell-test` | a real `make my_shell` + the updater |
+| ssh login shell (docker) | `make ssh-shell-test` | sshd + chsh: ssh-cmd, scp, sftp, rsync, git vs bash |
+| installer (docker) | `make installer-test` | `install.sh` end-to-end: sudo and no-sudo users, plugin selection, uninstall |
+
+Gotchas that bite: the golden tester `chmod 000`s
+`tests/test_files/invalid_permission` (restore with `chmod 755` before git
+operations); new golden category files must be added to `test_lists` in
+`tests/tester` or they silently never run; leak checking is ASan on `SAFE=1`
+and `HELLISH_ALLOC_STATS=1` on `SAFE=0`.
+
+## 4. Docker — what each container proves
+
+| file / target | proves |
+|---|---|
+| `docker/Dockerfile.static` → `make static` | the **published release binary**: static musl build, no shared deps — runs on Debian 11, RHEL 8, stock ubuntu:24.04 alike |
+| `docker-compose.yml` → `make docker-test` | source builds on 11 distro rungs (glibc + musl × gcc + clang) |
+| `docker/Dockerfile.my-shell` → `make my-shell-test` | a real `make my_shell` as a non-root sudoer, then the update button — needs root-owned `/usr/bin`, `chsh`, `/etc/shells`: machine state a test must never touch on a developer's box |
+| `docker/Dockerfile.sshd` → `make ssh-shell-test` | hellish as sshd's login shell: ssh-cmd, scp, sftp, rsync, git-over-ssh diffed against bash |
+| `docker/Dockerfile.installer` → `make installer-test` | `curl \| sh` install for both privilege worlds + plugin selection, against a **local fake release server** |
+| `docker/Dockerfile.agnostic` → `make agnostic-bench` | the 9-shell race: all competitors built into one image so every shell runs on identical ground |
+
+### The four comparisons, as this project actually lives them
+
+**Virtual machines vs Docker.** Every need above is process- and
+filesystem-isolation with a throwaway root: a container delivers that in
+seconds from a cached layer, where a VM buys a whole kernel we do not need at
+the price of minutes and gigabytes. The one place a VM would be honest and a
+container cannot be — macOS and WSL — is exactly where we use the `Platforms`
+CI runners instead of Docker.
+
+**Secrets vs environment variables.** The shell itself manages no
+credentials, so nothing secret exists at runtime; `HELLISH_*` environment
+variables are behaviour knobs, never secrets. The project's real secrets —
+the npm publish token, GHCR credentials — live in GitHub Actions **secrets**,
+injected only into the release workflow, never in the tree, an image layer,
+or a Dockerfile `ENV` (which would bake them into image history).
+
+**Docker network vs host network.** Test containers stay on the default
+isolated bridge and talk to **fake servers inside the container** (the update
+and installer suites run a local release server), so they prove the mechanism
+offline instead of testing GitHub's uptime — and nothing can accidentally
+reach the developer's host services. Host networking is used nowhere; the
+sshd suite maps one port explicitly, which documents its surface.
+
+**Volumes vs bind mounts.** Test containers use **neither**: their state must
+die with them — an installer test that persisted `/etc/shells` edits between
+runs would be testing its own residue. Bind mounts appear only as developer
+conveniences (sharing a build cache or the source tree into a distro rung),
+where seeing the host's files *is* the point. Named volumes would add
+persistence we explicitly do not want anywhere.
+
+## 5. Where data lives and how it persists
+
+| location | contents | lifetime |
+|---|---|---|
+| `build/obj-<mode>-<alloc>/`, `build/bin/` | objects, the binary | until `make fclean`; modes coexist |
+| `vendor/libft/build-{libc,ft}/` | per-allocator libft trees | rebuilt on submodule bump |
+| `bench/suites/` (gitignored, ~100 MB) | fetched conformance suites | `make conformance` re-fetches |
+| `bench/baseline/`, `bench/charts/` | committed pass-counts and SVGs | updated deliberately (`UPDATE_BASELINE=1`, `make charts`) |
+| `~/bash-5.3.9`, `~/zsh-5.9` | the pinned oracles | built once by `make oracle` / `make zsh-oracle` |
+| `~/.cache/hellish-plugin-corpus` | downloaded corpus plugins | cache; corpus skips cleanly offline |
+| user side | see the table in [USER_DOC.md](USER_DOC.md) | survives reinstalls by design (never-clobber) |
+
+## 6. Workflow
+
+Branch from `develop`; PRs target `develop` (`main`/`develop` are protected).
+Conventional Commits (`type(scope): imperative subject`), enforced by the
+hook. Every fix ships with a test — non-negotiable. Pre-PR gates, all green
+from a clean tree: `make re` + `make re OPT=1` build clean, `make test`,
+`tests/run_scripts.sh`, `tests/hard/run.sh`, `make pty-test`,
+`cd tests && ./verify_alloc.sh`, `make norm`. CI runs 11 required jobs;
+releases ship via tags (`release.yml`: static binary + npm + images).
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) and [CLAUDE.md](CLAUDE.md) for the
+house rules (42 Norm, allocator discipline, the test model).

--- a/Makefile
+++ b/Makefile
@@ -904,6 +904,22 @@ ssh-shell-test:  ## docker: hellish as a login shell (ssh/scp/rsync/git) vs bash
 	docker build -f docker/Dockerfile.sshd -t hellish:sshd .
 	docker run --rm hellish:sshd
 
+# install.sh end-to-end, both privilege worlds, in a container -- see
+# docker/Dockerfile.installer for who lives there and why. Needs the static
+# binary (it plays the role of the release asset) and the hellishrc_plugins
+# working copy: PLUGINS_DIR=path/to/checkout, or it clones from GitHub.
+PLUGINS_DIR ?=
+installer-test: static  ## docker: curl|sh installer, sudo AND no-sudo + plugin picks
+	@if [ -z "$(PLUGINS_DIR)" ]; then \
+		rm -rf build/hellishrc_plugins; \
+		git clone -q --depth 1 https://github.com/Univers42/hellishrc_plugins \
+			build/hellishrc_plugins; \
+	fi
+	docker build -f docker/Dockerfile.installer \
+		--build-context plugins=$(if $(PLUGINS_DIR),$(PLUGINS_DIR),build/hellishrc_plugins) \
+		-t hellish:installer .
+	docker run --rm hellish:installer
+
 # The same report `make my_shell` prints at the end, on demand. Answers the
 # two questions behind every "the update did nothing" report: WHICH hellish
 # does PATH actually reach, and can its directory be written to.
@@ -1206,7 +1222,8 @@ geoman: all  ## External 42 minishell tester, as an independent cross-check
 	docker-build docker-test docker-alpine docker-debian docker-ubuntu \
 	docker-arch docker-fedora docker-rocky docker-opensuse docker-void \
 	smoke docker-clean cd-zsh-test cd-posix-test my-shell-test doctor \
-	my-shell-uninstall my-shell-purge ssh-shell-test agnostic-bench \
+	my-shell-uninstall my-shell-purge ssh-shell-test installer-test \
+	agnostic-bench \
 	hist-test history-opts-test history-matrix-test pty-test git-star-test \
 	completion-test completion-posix-test \
 	readline-test anim-test git-prompt-test \

--- a/README.md
+++ b/README.md
@@ -1,419 +1,109 @@
-<div align="center">
+*This project has been created as part of the 42 curriculum by dlesieur, alcacere.*
 
 # hellish 🐚🔥
 
-**A from-scratch, almost-POSIX shell in C — that runs like a minimalist shell and reads like bash.**
-
 ![shell](https://img.shields.io/badge/shell-POSIX%20%2B%20bashisms-e2543a)
-![language](https://img.shields.io/badge/C-11-5b7fa6)
-![golden suite](https://img.shields.io/badge/golden%20suite-3000%2B%20vs%20bash%20--posix-6f9e78)
-![allocators](https://img.shields.io/badge/allocators-libc%20%7C%20ft__malloc-9a76b8)
+![golden suite](https://img.shields.io/badge/golden%20suite-4248%20vs%20bash%20--posix-6f9e78)
 ![license](https://img.shields.io/badge/license-MIT-7f8fa0)
 
-*Built as a 42 project by **dlesieur** and **alcacere**, grown well past the school subject.*
+## Description
 
-</div>
+`hellish` is a from-scratch, almost-POSIX shell written in C. It started as
+42's shell project and grew well past the subject: it now diffs
+byte-for-byte against a pinned `bash --posix` on 4248 golden cases, races
+**#3 of 9** against real shells (faster than bash, zsh and fish), loads real
+oh-my-zsh plugins through an opt-in zsh dialect, and ships with programmable
+completion, 29 prompt themes, a plugin framework and a self-updater.
 
----
+The goal: prove that one codebase can pair **minimalist-shell speed with
+bash-class features** — and stay readable, 42-norm-clean, and leak-free on
+two different allocators while doing it.
 
-`hellish` is engineered like a teaching lab and benchmarked like a production
-shell: `input → lexer → parser → word reparser → heredoc → expander → executor`,
-each a small readable module, one `t_shell` struct as the single source of
-truth. It diffs **byte-for-byte against `bash --posix`** on thousands of cases,
-runs clean under AddressSanitizer, and ships **two allocators you swap at
-compile time** (libc `malloc` or our own `ft_malloc`).
+**Full documentation: <https://univers42.github.io/hellish/>**
 
-But the reason this README leads with numbers: **it's fast.** Not "fast for a
-student project" — fast against the shells you actually use.
+## Instructions
 
----
-
-## 🏁 The headline: a 9-shell race
-
-We build hellish plus a zoo of real shells — **bash, dash, zsh, mksh, ksh,
-yash, busybox ash, fish** — into one Docker image and race all nine on 17
-portable POSIX workloads (`make agnostic-bench`). Ranking is the **geometric
-mean** of the best-of-7 time on each workload, so no single benchmark can skew
-it and warm-up noise is thrown away.
-
-![Cross-shell speed ranking — 9 shells raced in one Docker image, hellish ranks #3 by geomean](bench/charts/cross-shell.svg)
-
-<div align="center">
-
-### 🥉 hellish ranks **#3 of 9**
-
-</div>
-
-| # | shell | geomean | vs hellish | |
-|:---:|:---|---:|:---:|:---|
-| 1 | ksh | 36.9 ms | 0.55× | *builtin-accelerated ¹* |
-| 2 | dash | 51.4 ms | 0.77× | the minimalist speed king |
-| **3** | **hellish** | **66.6 ms** | **1.00×** | ◀ **us** |
-| 4 | busybox ash | 72.8 ms | 1.09× | |
-| 5 | zsh | 114.1 ms | 1.71× | hellish is **1.7× faster** |
-| 6 | bash | 139.1 ms | 2.09× | hellish is **2.1× faster** |
-| 7 | mksh | 151.1 ms | 2.27× | |
-| 8 | yash | 185.6 ms | 2.79× | |
-| 9 | fish | 742.0 ms | 11.14× | |
-
-**The honest summary:** hellish is **faster than 6 of the 8 other shells** —
-including **bash** (2.1×) and every feature-rich shell (zsh, fish) — and lands
-just behind the two shells built to be minimal and nothing else. And it does
-this while carrying a **bash-class feature surface** those minimalist shells
-don't have (arrays, `[[ =~ ]]`, `${v/p/r}`, process substitution, job control,
-vi/emacs editing). *That combination — minimalist speed, bash features — is the
-whole point.*
-
-> ¹ ksh93's #1 is partly an artifact: its recursion (`fib18` 54.6 ms vs
-> everyone else's 2.4–4.8 **seconds**) and command-substitution rows are orders
-> of magnitude off the field because ksh compiles/forklessly accelerates them —
-> not comparable work. On the ordinary workloads it and hellish trade blows.
-
----
-
-## 📊 Where hellish wins, ties, and loses
-
-No cherry-picking. Per-workload, best-of-7, lower is faster:
-
-![Per-workload comparison: hellish vs bash vs dash on nine representative workloads](bench/charts/cross-shell-workloads.svg)
-
-**vs `bash`** — hellish wins nearly everywhere it's tested:
-
-| area | hellish | bash | verdict |
-|---|---|---|:---:|
-| arithmetic loops | 75 ms | 161 ms | ✅ **2.1× faster** |
-| string concat (grow) | 16 ms | 73 ms | ✅ **4.6× faster** |
-| variable concat | 75 ms | 189 ms | ✅ **2.5× faster** |
-| command substitution | 161 ms | 1211 ms | ✅ **7.5× faster** |
-| `test`/`[ ]` string ops | 69 ms | 155 ms | ✅ **2.3× faster** |
-| function calls | 19 ms | 47 ms | ✅ **2.5× faster** |
-| parse a 50k-line script | 55 ms | 75 ms | ✅ **1.4× faster** |
-
-**vs `dash`** — the honest losses. dash is a tiny POSIX-only shell; matching it
-is the goal, not always reached:
-
-| area | hellish | dash | verdict |
-|---|---|---|:---:|
-| arithmetic loops | 75 ms | 66 ms | ≈ within 15% |
-| command substitution | 161 ms | 615 ms | ✅ **3.8× faster** |
-| `read` loop | 125 ms | 724 ms | ✅ **5.8× faster** |
-| function calls | 19 ms | 14 ms | ➖ dash faster |
-| parameter expansion | 114 ms | 60 ms | ➖ dash faster |
-| parse a 50k-line script | 55 ms | 29 ms | ➖ dash faster |
-
-So: **hellish beats dash on the fork- and I/O-heavy work** (command
-substitution, read loops) and trails it on the pure-parse and pure-expansion
-micro-loops, where dash's do-almost-nothing design is hard to beat.
-
----
-
-## 🧠 Memory
-
-Peak resident set, median of 7 runs (`make rss`). hellish keeps a **flat ~4 MB
-working set** on loops — competitive with bash, sometimes tighter — and pays for
-its richer parser only where it parses a lot:
-
-| workload | hellish | bash | dash |
-|---|---:|---:|---:|
-| startup | 3.9 MB | 3.8 MB | **2.2 MB** |
-| arith loop | **3.8 MB** | 3.9 MB | 2.2 MB |
-| string concat | **3.9 MB** | 4.1 MB | 2.2 MB |
-| read loop | 3.9 MB | 3.9 MB | 2.2 MB |
-| parse 50k lines | 11.6 MB | **4.9 MB** | 2.2 MB |
-
-The parse-50k line is our one real memory cost: the lexer materialises the
-whole file's tokens up front. It's down from **158 MB → 20 MB → 11.6 MB** over
-successive rounds (8-byte deque tokens, a borrowed input buffer); the remaining
-gap to bash is documented and the pull-lexer that closes it is planned in
-[`backlog.md`](backlog.md).
-
----
-
-## ✅ Conformance — more POSIX than dash
-
-Two independent third-party suites, run against `bash --posix` **and** `dash`
-(`make conformance`). hellish's rate is deliberately **conservative** — the Oils
-harness credits a "known-ok" annotation that exists for bash/dash but cannot
-exist for a shell it's never heard of, so we only ever count a hard `pass`.
-
-**mksh `check.t`** (the ksh regression suite) — hellish now **beats dash**:
-
-| shell | passed |
-|---|---:|
-| bash | 292 |
-| **hellish** | **218** 🎉 |
-| dash | 216 |
-
-**Oils spec suite** (1622 cases spanning bash + POSIX features):
-
-| shell | hard passes | pass-rate |
-|---|---:|---:|
-| bash --posix | 1311 | 85.1% |
-| dash | 977 | 68.5% |
-| **hellish --posix** | **1071** | **66.0%** ᶜᵒⁿˢᵉʳᵛᵃᵗⁱᵛᵉ |
-
-hellish sits between dash and bash on raw Oils count — but Oils tests a pile of
-bash-isms dash simply lacks, so on the **shared POSIX core** hellish is much
-closer to bash than the headline number suggests, and it already **passes more
-of the ksh suite than dash does**.
-
----
-
-## 🏆 So where does hellish rank, today?
-
-<div align="center">
-
-| dimension | tier | who's ahead |
-|---|:---:|---|
-| **Speed** | 🥉 top-3 of 9 | only ksh & dash (both minimalist specialists) |
-| **vs bash specifically** | ✅ faster | hellish wins ~2× on the geomean |
-| **Features** | high | far beyond dash/busybox/mksh; near bash/zsh |
-| **Memory** | good | flat ~4 MB; heavier only on big parses |
-| **POSIX conformance** | solid | ahead of dash on mksh, behind bash overall |
-
-</div>
-
-**The one-line placement:** *hellish is a top-tier-fast shell that behaves like
-bash.* Nothing else in the field pairs dash-adjacent speed with bash-class
-features — the minimalist shells (dash, busybox, mksh) are fast but bare, and
-the featureful ones (bash, zsh, fish) are slower. hellish sits in the empty
-quadrant between them.
-
-*Every number above is measured, not asserted.* Reproduce it:
-
-```sh
-make agnostic-bench     # the 9-shell Docker race (needs docker; installs the shells for you)
-make rss conformance    # memory + the two conformance suites
-make charts             # redraw every SVG on this page from the raw artifacts
-```
-
-Fairness rules and the measurement traps this harness has already fallen into
-(uutils-`timeout` quantization, ASan builds sneaking into a benchmark) are
-documented honestly in [`bench/METHODOLOGY.md`](bench/METHODOLOGY.md).
-
----
-
-## 🚀 Quick start
-
-```sh
-git clone --recursive https://github.com/Univers42/hellish && cd hellish
-make OPT=1            # optimized build (the one you'll want day to day)
-./build/bin/hellish   # drop into the shell
-```
-
-`--recursive` matters: hellish pulls in two submodules,
-[`vendor/libft`](vendor/libft) (stdlib + the `ft_malloc` allocator) and
-`vendor/scripts` (dev tooling). If you forgot it:
-
-```sh
-git submodule update --init --recursive
-```
-
----
-
-## 📦 Install
-
-**From source (recommended, always works):**
-
-```sh
-git clone --recursive https://github.com/Univers42/hellish && cd hellish
-make OPT=1 all && ./build/bin/hellish
-```
-
-**Prebuilt binary (curl one-liner)** — fetches the latest release into `$PREFIX`
-(default `/usr/local/bin`, falling back to `~/.local/bin`):
+**Install in one command** (Linux x86-64 — detects your rights: with sudo it
+installs system-wide and registers your login shell; without sudo — a 42
+machine — it installs to `~/.local/bin` with an rc hook; then it lets you
+pick plugins):
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Univers42/hellish/main/install.sh | sh
 ```
 
-**npm / pnpm / yarn** — the package is `hellish-shell`; its `postinstall`
-downloads the matching release binary:
+**From a source checkout:**
 
 ```sh
-npm install -g hellish-shell      # or: pnpm add -g hellish-shell
+git clone --recursive https://github.com/Univers42/hellish && cd hellish
+make OPT=1 all          # optimized build → build/bin/hellish
+./build/bin/hellish     # run it
+make user-install       # no sudo: ~/.local/bin + rc hook (42 machines)
+make my_shell           # sudo: /usr/bin + login shell registration
 ```
 
-**Docker (easiest way to try it)** — a prebuilt image, no toolchain, nothing to
-compile:
+`--recursive` matters (two submodules); if forgotten:
+`git submodule update --init --recursive`. `make` alone prints a
+self-documenting help page; `make test` runs the golden suite;
+`make doctor` diagnoses an installation. To undo an install:
+`make user-uninstall` or `make my-shell-uninstall`.
 
-```sh
-docker run --rm -it dlesieur/hellish-shell        # latest
-```
+More: **[USER_DOC.md](USER_DOC.md)** (use it) ·
+**[DEV_DOC.md](DEV_DOC.md)** (build, test and hack on it).
 
-Prefer to **build from source in a clean container**? Every supported
-platform has a rung — glibc and musl, gcc and clang, five package managers:
+## Features
 
-```sh
-docker compose run --rm alpine     # interactive hellish on Alpine/musl
-make docker-test                   # build + run the portability smoke on ALL of them
-make smoke                         # ... or just run that smoke against a local build
-```
+- Everything POSIX plus the bashisms you use: arrays, `[[ =~ ]]`,
+  `${v/pat/repl}`, process substitution, heredocs, job control, `set -o`
+  options, traps, functions — diffed against bash, not guessed.
+- Interactive comfort: readline editing (vi/emacs), persistent multi-line
+  history, tab completion with `complete`/`compgen` specs, 29 prompt themes
+  and both prompt languages (bash `\u\w\$` *and* zsh `%n %~ %#`).
+- An opt-in **zsh dialect** that loads real third-party plugins — proven by
+  a 13-plugin corpus (oh-my-zsh, git's own scripts, z, bash-preexec) run in CI.
+- Two compile-time-swappable allocators, ASan-clean, `-Wall -Wextra -Werror`,
+  42-norm-clean.
+- Background update channel: `update --now` self-updates from GitHub releases.
 
-| | rungs |
-|---|---|
-| glibc | `ubuntu` (24.04), `ubuntu2204`, `debian`, `arch`, `fedora`, `rocky`, `opensuse`, `void` |
-| musl | `alpine`, `alpine-clang`, `alpine-ftmalloc` |
-| compilers | gcc (11 → current) and clang, on both libcs, `-Werror` throughout |
-| architectures | x86_64 and arm64 (native runner in CI) |
+## Technical choices
 
-macOS and WSL are covered by the `Platforms` workflow rather than Docker —
-Apple's kernel cannot legally or practically run in a container, and WSL's
-whole point is the Windows bridge a container does not have. Both are
-**informational** today; see [wiki/platforms.md](wiki/platforms.md) for what
-works and what does not.
+Docker is load-bearing here, not decoration: the **published release binary
+is built statically (musl) inside a container** so it runs on any distro; a
+**14-rung distro matrix** (glibc/musl × gcc/clang) builds from source in CI;
+the **installer, login-shell and ssh suites** run in containers because they
+must edit `/etc/shells`, `chsh`, and a root-owned `/usr/bin` no developer
+machine should lend them; and the **9-shell benchmark** builds all
+competitors into one image so every shell races on identical ground.
 
-Once installed, hellish checks for newer releases in the background (once a day,
-never blocking the prompt — the check is a detached child, so a slow or dead
-release server costs your shell nothing). When one is waiting you are told twice
-and unprompted: the welcome panel announces it once, and the prompt carries a
-quiet `⬆2.7.4` badge until you actually update. `update` checks on demand,
-`update --now` self-updates.
+| choice | what we use | why |
+|---|---|---|
+| VMs vs **Docker** | Docker | test needs are per-process isolation + a throwaway filesystem, not a kernel; a container gives both in seconds where a VM costs minutes and GBs |
+| Secrets vs **env variables** | repo secrets in CI, env knobs at runtime | the shell itself holds no credentials; CI tokens (npm, GHCR) live in GitHub secrets, never in the tree — env vars configure behaviour (`HELLISH_*`), they never carry secrets |
+| Docker vs **host network** | isolated bridge + local fake servers | update/installer tests talk to a fake release server inside the container, so they prove the mechanism offline instead of testing GitHub's uptime |
+| Volumes vs **bind mounts** | neither in tests, bind mounts for dev caches | test containers are hermetic by design (state must die with them); only developer conveniences (build caches) bind-mount |
 
-Knobs: `HELLISH_BANNER=0|1` forces the welcome panel off or on
-(`HELLISH_NO_BANNER=1` and `HELLISH_ALWAYS_BANNER=1` are the older names and
-still work); `HELLISH_NO_UPDATE_CHECK=1` disables the check and the badge.
+Full discussion: **[DEV_DOC.md](DEV_DOC.md)**.
 
----
+## Resources
 
-## 🛠 Build & the SAFE / OPT matrix
+- [POSIX.1-2018 Shell & Utilities (XCU)](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html) — the specification
+- [Bash Reference Manual](https://www.gnu.org/software/bash/manual/) — the behavioural oracle (pinned at 5.3.9 by `make oracle`)
+- [zsh documentation](https://zsh.sourceforge.io/Doc/) — the dialect's oracle (pinned at 5.9)
+- [GNU Readline](https://tiswww.case.edu/php/chet/readline/rltop.html) — the line editor underneath
+- [Oils spec tests](https://github.com/oils-for-unix/oils) and [mksh check.t](https://github.com/MirBSD/mksh) — third-party conformance suites we run
+- [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh) — source of the real-world plugin corpus
 
-Two independent knobs shape the build: **`OPT`** (optimization) and **`SAFE`**
-(which allocator). They combine freely, and the build banner announces the
-active allocator so it's never a surprise.
+**AI use.** Claude (Anthropic's Claude Code) was used extensively across the
+project: implementation assistance in most modules, debugging, writing and
+hardening the golden/pty/corpus test suites, CI workflows, release
+engineering, and this documentation. Every AI-assisted behaviour change was
+validated the same way as a human one — diffed against the pinned bash/zsh
+oracles and taken through the full test gates — and the architecture,
+design decisions and 42-norm C style are the authors'.
 
-| Command | Optimization | Allocator | Sanitizers | Use it for |
-|---|---|---|---|---|
-| `make all` | `-O0 -g3` | libc (`SAFE=1`) | ASan + LeakSanitizer | dev, debugging, leak hunts |
-| `make OPT=1` | `-O3 -flto` | **`ft_malloc`** (`SAFE=0`) | none | speed, benchmarks, daily driving |
-| `make SAFE=0` | `-O0 -g3` | `ft_malloc` | ASan | the custom heap under a debugger |
-| `make OPT=1 SAFE=1` | `-O3 -flto` | libc | none | optimized build on the battle-tested heap |
+## Documentation
 
-An explicit `SAFE=…` on the command line always wins. libft compiles into a
-**per-`SAFE` tree** (`build-libc` vs `build-ft`) so the two allocators never
-share objects — flip `SAFE`, get the right archive, not a stale one.
-
-```sh
-make            # what you can ask for — the self-documenting help page
-make all        # debug build  -> build/bin/hellish
-make OPT=1      # optimized build
-make re         # fclean + rebuild
-make test       # full suite: thousands of golden-diff cases vs bash --posix
-make norm       # 42 norminette over src/ incs/ tests/
-make my_shell   # install as your login shell (rebuilds OPT=1 SAFE=1 first)
-```
-
-### Making it your shell without root
-
-`make my_shell` needs sudo twice over: to write `/usr/bin`, and because
-`chsh` refuses any shell that is not listed in `/etc/shells` — a file only
-root can edit. On a lab machine or a shared server that route is closed.
-
-```sh
-make user-install     # ~/.local/bin + an exec hook in your login shell's rc
-make user-uninstall   # put everything back
-```
-
-`user-install` installs into `~/.local/bin`, seeds `~/.hellishrc` from
-`hellishrc.example` (never overwriting one you already have), puts the
-directory it installed into on `PATH` — from a marker-delimited block in
-`~/.hellishrc` and from the hook itself, so `hellish update` and
-`command -v hellish` work on a machine whose login chain never added
-`~/.local/bin` — and appends a marker-delimited block to your login shell's rc
-file that `exec`s hellish for interactive sessions. `exec` *replaces* the
-process, so this is a real login shell and not an alias or a wrapper: `ps`
-shows hellish, `$$` is hellish, and closing it closes the tab.
-
-Your passwd entry is never touched, which keeps `ssh host 'cmd'` working and
-leaves you a guaranteed way back in. The installed binary is smoke-tested
-*before* the hook is written, so a bad build can never leave you with
-terminals that die on open. Escape hatches, in increasing permanence:
-`HELLISH_NO_EXEC=1` for one session, `touch ~/.hellish-disable` for all of
-them, `make user-uninstall` to remove the block.
-
-Knobs: `PREFIX=~/opt`, `RC_TARGET=~/.bashrc`, `STATIC=1` (install the
-docker-built static binary instead of compiling here).
-
----
-
-## 🐚 What it can do
-
-**Interactive** — vi & emacs line editing (readline), persistent de-duplicated
-history with multi-line-safe escaping (`history`, `fc`, `!`-expansion), tab
-completion for commands / files / `$variables`, a multibyte- and ANSI-aware
-prompt (user, cwd, git branch, venv, time) that never drifts the cursor, a
-`~/.hellishrc` startup file, and job control (`&`, `jobs`, `fg`, `bg`, `wait`,
-`kill`, `$!`).
-
-**Scripting / POSIX** — pipelines and lists (`;`, `&&`, `||`, `&`), subshells,
-brace groups; `if/elif/else`, `for`, `while`, `until`, `case/esac`, and
-**functions** (`local`, `return`, recursion); every redirection including
-here-docs `<<`/`<<-` and **process substitution** `<( )` / `>( )`; the full
-expansion pipeline in classic order — brace, tilde, parameter
-(`${v:-d}` `${v#p}` `${v%p}` **`${v/p/r}`**), command `$( )` / `` `…` ``,
-arithmetic `$(( ))`, `IFS` word splitting, globbing (`*` `?` `[…]` POSIX
-classes); positional params, `shift`, `getopts`, `set -o` options, `trap`,
-`[[ … ]]`, arrays, `let`.
-
-**Builtins (47):** `echo export cd pushd popd dirs [[ exit pwd env unset type
-set shift : break continue eval . source true false umask command return getopts
-exec wait times trap readonly read test [ alias unalias hash jobs fg bg fc
-history let local kill printf ulimit update`.
-
----
-
-## 🧬 The two allocators (SAFE)
-
-Every allocation in hellish goes through one `xmalloc`/`xfree` macro family that
-resolves **at compile time** to libc `malloc` or our own `ft_malloc` — no
-pointer ever crosses heaps. So you can A/B the exact same shell on two
-completely different allocators and prove they produce byte-identical output:
-
-```sh
-cd tests && ./verify_alloc.sh   # builds BOTH heaps, proves output parity + zero leaks
-```
-
-`ft_malloc` (in the `vendor/libft` submodule) is a slab + big-alloc allocator
-with an O(1) free path; on `SAFE=0` its own live-bytes oracle
-(`HELLISH_ALLOC_STATS=1`) replaces ASan as the leak gate.
-
----
-
-## 🏗 Architecture in one breath
-
-`main → on() → repl_shell() → parse_and_execute_input()`. The lexer slices
-tokens straight out of the input buffer (no copies); the parser builds a
-`t_ast_node` tree that **deliberately keeps raw tokens** so loops and functions
-re-expand each iteration without re-parsing; the expander runs **lazily,
-per-simple-command**, during the executor's tree walk. Heredocs are gathered in
-a pre-exec pass; command substitution has a forkless fast path for provably
-side-effect-free bodies. Each module under [`src/`](src) has its own `README.md`.
-
----
-
-## 🔬 Testing & quality gates
-
-Nothing lands without all of these green from a clean tree:
-
-- **`make test`** — thousands of cases, each diffed (stdout + exit status +
-  files written) against `bash --posix`.
-- **`tests/run_scripts.sh`** — whole real programs vs `bash --posix`.
-- **`cd tests && ./verify_alloc.sh`** — output parity + zero leaks on **both** heaps.
-- **`make conformance`** — Oils spec + mksh `check.t`, gated so a pass-count drop fails.
-- **`make readline-test` / `make hist-test`** — real-pty coverage of the interactive
-  paths the `-c` suite can't reach.
-- **`make norm`** — 42 norminette clean.
-
----
-
-## 🤝 Contributing
-
-Branch from `develop`; PRs target `develop` (`main`/`develop` are protected).
-Conventional Commits, enforced by a hook. Every fix ships with a test —
-non-negotiable. See [`CONTRIBUTING.md`](CONTRIBUTING.md) and
-[`CLAUDE.md`](CLAUDE.md) for the house rules (42 Norm, allocator discipline,
-the test model).
-
-## 📄 License
-
-[MIT](LICENSE) — © the hellish authors.
+**[Docs site](https://univers42.github.io/hellish/)** ·
+[USER_DOC.md](USER_DOC.md) · [DEV_DOC.md](DEV_DOC.md) ·
+[RELEASE.md](RELEASE.md) · [CONTRIBUTING.md](CONTRIBUTING.md) ·
+[LICENSE](LICENSE) (MIT)

--- a/USER_DOC.md
+++ b/USER_DOC.md
@@ -1,0 +1,91 @@
+# hellish — User Documentation
+
+How to install it, use it, configure it, and check it is healthy. For
+building and hacking on it, see [DEV_DOC.md](DEV_DOC.md); for the full
+manual, see the [docs site](https://univers42.github.io/hellish/).
+
+## What you get
+
+| service | what it is |
+|---|---|
+| the shell | an almost-POSIX shell that runs your bash scripts and muscle memory — `hellish`, `hellish script.sh`, `hellish -c 'cmd'` |
+| prompt themes | 29 named themes; `prompt` lists them, `prompt <name>` switches, `prompt save <name>` persists |
+| plugin framework | `~/.hellish/` with a `conf` manager — `conf list`, `conf on\|off <name>`, `hxp list`; plus oh-my-zsh plugin support through the zsh dialect |
+| completion | tab completion for commands/files/variables; `complete`/`compgen` specs behind `shopt -s progcomp` |
+| update channel | a daily background check; `update` on demand, `update --now` to self-update |
+
+## Install
+
+**One command** (detects sudo rights, asks about plugins):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Univers42/hellish/main/install.sh | sh
+```
+
+- **With sudo** → installs to `/usr/bin/hellish`, adds it to `/etc/shells`,
+  and offers to make it your login shell (`chsh`). Same as `make my_shell`.
+- **Without sudo** (42 school machines, shared boxes) → installs to
+  `~/.local/bin/hellish`, seeds `~/.hellishrc`, and adds a small hook to your
+  login shell's rc that `exec`s hellish for interactive sessions — a real
+  login shell, not an alias. Same as `make user-install`.
+- Non-interactive: `sh install.sh --yes --plugins=all` (or `none`, or a list:
+  `--plugins="git jump z"`); force a mode with `--user` / `--system`.
+
+**From a source checkout:** `make user-install` (no sudo) or `make my_shell`
+(sudo). Or just run it without installing: `./build/bin/hellish` after
+`make OPT=1 all`.
+
+## Start and stop
+
+- **Start**: open a new terminal (if installed as a login shell), or run
+  `hellish`.
+- **Stop**: `exit` or Ctrl-D. If stopped jobs exist, the first exit warns
+  and the second obeys — like bash.
+- **Skip the hook once** (user-install route): `HELLISH_NO_EXEC=1 bash`.
+  Disable it entirely: `touch ~/.hellish-disable`.
+
+## Uninstall
+
+| how you installed | how to undo |
+|---|---|
+| `install.sh` / `make my_shell` | `make my-shell-uninstall` (restores your login shell **before** removing the binary); `make my-shell-purge` also removes config + caches |
+| `install.sh` / `make user-install` | `make user-uninstall` — removes the rc hook and PATH block, leaves your `~/.hellishrc` |
+| npm | `npm uninstall -g hellish-shell` |
+
+## Configuration — where everything lives
+
+| path | what it holds |
+|---|---|
+| `~/.hellishrc` | your startup file (aliases, exports, `shopt`, PS1) — sourced by **interactive** shells only, never by scripts. Seeded from `hellishrc.example`, never overwritten |
+| `$XDG_CONFIG_HOME/hellish/rc.d/` | drop-in config fragments, sourced in order |
+| `$XDG_CONFIG_HOME/hellish/themes/` | the 29 prompt themes (yours to edit; edited ones are never clobbered by reinstall) |
+| `$XDG_CONFIG_HOME/hellish/plugins/` | plugins as `<name>/plugin.hsh` |
+| `~/.hellish/` | the plugin framework (`conf`, `hxp`, its plugins and state) |
+| history file | in `$HOME`, multi-line-safe; `shopt -s lithist` keeps newlines on recall |
+| `~/.cache/hellish` | update-check state (which release was already announced) |
+
+No passwords or credentials are stored anywhere — hellish has none to manage.
+The files above are the complete list of what an install touches.
+
+## Check that it works
+
+```sh
+hellish --version            # version + which repo the updater points at
+echo 'echo ok $((6*7))' | hellish    # prints: ok 42
+make doctor                  # from a checkout: which hellish PATH reaches,
+                             # and whether `update` will need sudo
+update                       # ask the release channel by hand
+conf list                    # plugin framework: what is on and off
+```
+
+If a terminal ever misbehaves after an experiment: `reset` — and the
+escape hatches above get you back to your previous shell at any time.
+
+## Knobs
+
+| variable | effect |
+|---|---|
+| `HELLISH_BANNER=0\|1` | welcome panel off / on |
+| `HELLISH_NO_UPDATE_CHECK=1` | never check for updates, no badge |
+| `HELLISH_NO_ANIM=1` | no startup animation |
+| `HELLISH_NO_EXEC=1` | user-install hook: skip for this one session |

--- a/docker/Dockerfile.installer
+++ b/docker/Dockerfile.installer
@@ -1,0 +1,77 @@
+# ============================================================================
+# `curl | sh` on a machine we are allowed to break: install.sh end-to-end for
+# BOTH privilege worlds, against a local fake release channel.
+#
+#   make installer-test
+# or by hand (the plugins context is the hellishrc_plugins checkout):
+#   docker build -f docker/Dockerfile.installer \
+#       --build-context plugins=/path/to/hellishrc_plugins -t hellish:installer .
+#   docker run --rm hellish:installer
+#
+# Why a container: the sudo route edits /etc/shells and chsh's a login shell,
+# and detecting "no sudo" needs an account that genuinely has none -- machine
+# state no developer box should lend a test. Two humans live here:
+#
+#   maxine  in sudoers, NOPASSWD -- the "I have rights" world. NOPASSWD
+#           because THIS test is about routing, not about the password prompt;
+#           Dockerfile.my-shell owns the real-password drama.
+#   nora    no sudo at all -- the 42 school machine.
+#   nora2   same, for the interactive scenario, so A's leftovers cannot
+#           satisfy C's assertions.
+#
+# The "release" is a directory served by python3 -m http.server inside the
+# container: the static binary (built by `make static` before the image),
+# its sha256, the install bundle tarred by the same recipe release.yml uses,
+# and the plugin framework from the named build context. Only scenario E
+# touches the real network, and it skips cleanly without one.
+# ============================================================================
+FROM ubuntu:24.04
+
+# script(1) [util-linux] gives the interactive scenario its pty; passwd gives
+# chsh; python3 is the fake server and nothing else.
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates curl sudo passwd python3 util-linux git; \
+	rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash maxine \
+	&& useradd -m -s /bin/bash nora \
+	&& useradd -m -s /bin/bash nora2 \
+	&& printf 'maxine ALL=(ALL) NOPASSWD: ALL\n' > /etc/sudoers.d/maxine \
+	&& chmod 440 /etc/sudoers.d/maxine
+
+WORKDIR /hellish
+COPY . .
+
+# The plugin framework, from a named build context so the test can run
+# against a local working copy before it is even pushed.
+COPY --from=plugins . /srv/hellishrc_plugins
+
+# The fake release channel, laid out the way install.sh expects GitHub's
+# /releases/latest/download/ to answer. The bundle is built with the SAME
+# recipe as release.yml -- if the two drift, this test is where it shows.
+RUN set -eux; \
+	mkdir -p /srv/release/latest/download; \
+	# `make static` names by docker platform (amd64); the release renames to
+	# uname -m (x86_64). The fake channel mirrors the release, not the build.
+	cp dist/hellish-linux-amd64 /srv/release/latest/download/hellish-linux-x86_64; \
+	( cd /srv/release/latest/download && sha256sum hellish-linux-x86_64 \
+		> hellish-linux-x86_64.sha256 ); \
+	mkdir -p /tmp/bundle/tools; \
+	cp user-install.sh hellishrc.example /tmp/bundle/; \
+	cp tools/register_shell.sh tools/seed_hellishrc.sh /tmp/bundle/tools/; \
+	cp -R share /tmp/bundle/share; \
+	tar -czf /srv/release/latest/download/hellish-install-bundle.tar.gz \
+		-C /tmp/bundle .; \
+	tar -czf /srv/release/hellishrc_plugins.tar.gz \
+		-C /srv hellishrc_plugins; \
+	rm -rf /tmp/bundle; \
+	chmod +x install.sh tools/*.sh user-install.sh; \
+	# install.sh treats "a Makefile next to me" as a source checkout and
+	# skips the download path -- the very path this image exists to test.
+	rm -f Makefile; rm -rf dist
+
+ENV HELLISH_NO_UPDATE_CHECK=1 HELLISH_NO_BANNER=1 HELLISH_NO_ANIM=1
+
+CMD ["/bin/sh", "/hellish/tests/installer_suite.sh"]

--- a/docker/Dockerfile.installer.dockerignore
+++ b/docker/Dockerfile.installer.dockerignore
@@ -1,0 +1,20 @@
+# Build context for docker/Dockerfile.installer: the installer scripts, the
+# static binary in dist/, and the test harness -- never host build objects or
+# git internals. dist/ is NOT ignored here: the image serves that binary as
+# its fake release.
+.git
+**/.git
+build/
+vendor/libft/build
+vendor/libft/build-*
+vendor/libft/src
+vendor/scripts
+**/*.o
+**/*.a
+npm/node_modules/
+tests/outfiles/
+tests/mini_outfiles/
+tests/bash_outfiles/
+bench/suites/
+wiki/assets/pdfs/
+site/

--- a/install.sh
+++ b/install.sh
@@ -1,53 +1,284 @@
 #!/bin/sh
-# hellish installer — fetch the latest prebuilt binary from GitHub Releases.
+# ============================================================================
+# hellish installer -- one command, both privilege worlds.
 #
 #   curl -fsSL https://raw.githubusercontent.com/Univers42/hellish/main/install.sh | sh
 #
-# Honours $PREFIX (default: /usr/local/bin, or ~/.local/bin without write access).
+# What it does, in order:
+#   1. downloads the latest static release binary and verifies its sha256;
+#   2. detects whether you can use sudo, and routes to the right install:
+#        with sudo    -> /usr/bin/hellish + /etc/shells + chsh
+#                        (exactly `make my_shell`, via tools/register_shell.sh)
+#        without sudo -> ~/.local/bin/hellish + an exec hook in your rc
+#                        (exactly `make user-install`, via user-install.sh)
+#      Both drivers ship in a small "install bundle" published beside the
+#      binary, so this script REUSES the proven scripts instead of
+#      reimplementing them -- preflight, smoke-test, never-clobber seeding,
+#      uninstall markers and all.
+#   3. offers the hellish plugin framework (github.com/Univers42/hellishrc_plugins)
+#      and lets you pick plugins -- interactively when a terminal is there
+#      (questions read /dev/tty, so `curl | sh` still gets to ask), silently
+#      when there is not.
+#
+# Flags (after `sh -s --` when piped):
+#   --user | --system        force the install mode instead of detecting
+#   --yes                    assume the default answer to every question
+#   --plugins=all|none|LIST  plugin selection without questions
+#                            (LIST is space-separated: --plugins="git jump z")
+#   --version vX.Y.Z         install that release instead of the latest
+#   --no-login-shell         system mode: install the binary, skip chsh
+#   --prefix DIR             user mode: install under DIR (default ~/.local)
+#   --uninstall              undo a user-mode install (system: make my-shell-uninstall)
+#
+# Environment (mainly for tests -- docker/Dockerfile.installer drives these):
+#   HELLISH_INSTALL_MODE     user|system         same as --user/--system
+#   HELLISH_INSTALL_PLUGINS  all|none|LIST       same as --plugins
+#   HELLISH_RELEASE_BASE     base URL for release downloads
+#                            (default https://github.com/Univers42/hellish/releases)
+#   HELLISH_RAW_BASE         base URL for raw-file fallback
+#   HELLISH_PLUGINS_SRC      git URL, tarball URL or local dir for the framework
+#
+# From a source checkout this script uses the local files and, if present, the
+# locally built binary -- so `sh install.sh` in the repo works offline.
+# ============================================================================
 set -eu
 
 REPO="Univers42/hellish"
 ASSET="hellish-linux-x86_64"
-OS="$(uname -s)"
-ARCH="$(uname -m)"
+BUNDLE="hellish-install-bundle.tar.gz"
+RELEASE_BASE="${HELLISH_RELEASE_BASE:-https://github.com/$REPO/releases}"
+RAW_BASE="${HELLISH_RAW_BASE:-https://raw.githubusercontent.com/$REPO/main}"
+PLUGINS_SRC="${HELLISH_PLUGINS_SRC:-https://github.com/Univers42/hellishrc_plugins}"
 
-if [ "$OS" != "Linux" ] || [ "$ARCH" != "x86_64" ]; then
-	echo "hellish: no prebuilt binary for $OS/$ARCH yet — build from source:" >&2
-	echo "  git clone https://github.com/$REPO && cd hellish && make OPT=1 all" >&2
-	exit 1
+MODE="${HELLISH_INSTALL_MODE:-}"
+PLUGINS="${HELLISH_INSTALL_PLUGINS:-}"
+ASSUME_YES=0
+VERSION=""
+LOGIN_SHELL=1
+UPREFIX="${PREFIX:-$HOME/.local}"
+ACTION="install"
+
+say()  { printf '\033[1;36mhellish:\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mhellish:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mhellish:\033[0m %s\n' "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--user)   MODE="user" ;;
+	--system) MODE="system" ;;
+	--yes|-y) ASSUME_YES=1 ;;
+	--plugins=*) PLUGINS="${1#--plugins=}" ;;
+	--plugins)   shift; [ $# -gt 0 ] || die "--plugins needs a value"; PLUGINS="$1" ;;
+	--version)   shift; [ $# -gt 0 ] || die "--version needs a tag"; VERSION="$1" ;;
+	--no-login-shell) LOGIN_SHELL=0 ;;
+	--prefix) shift; [ $# -gt 0 ] || die "--prefix needs a directory"; UPREFIX="$1" ;;
+	--uninstall) ACTION="uninstall" ;;
+	-h|--help) sed -n '2,45p' "$0" 2>/dev/null | sed 's/^# \{0,1\}//'; exit 0 ;;
+	*) die "unknown argument '$1' (try --help)" ;;
+	esac
+	shift
+done
+
+# ── can we ask questions? ───────────────────────────────────────────────────
+# Under `curl | sh`, stdin is the pipe -- but /dev/tty is still the terminal,
+# so questions remain possible. No tty (CI, docker build) means every answer
+# is the default and the plugin step is skipped unless flags said otherwise.
+INTERACTIVE=0
+if [ "$ASSUME_YES" = "0" ] && { : </dev/tty; } 2>/dev/null; then
+	INTERACTIVE=1
 fi
 
-URL="https://github.com/$REPO/releases/latest/download/$ASSET"
-TMP="$(mktemp)"
-trap 'rm -f "$TMP"' EXIT
+# ask "question" "default(y|n)" -> 0 for yes
+ask() {
+	if [ "$INTERACTIVE" = "0" ]; then
+		[ "$2" = "y" ]
+		return
+	fi
+	if [ "$2" = "y" ]; then _p="[Y/n]"; else _p="[y/N]"; fi
+	printf '\033[1;36m?\033[0m %s %s ' "$1" "$_p" >/dev/tty
+	IFS= read -r _a </dev/tty || _a=""
+	case "$_a" in
+	[yY]*) return 0 ;;
+	[nN]*) return 1 ;;
+	*) [ "$2" = "y" ] ;;
+	esac
+}
 
-echo "hellish: downloading the latest release…"
-if command -v curl >/dev/null 2>&1; then
-	curl -fSL "$URL" -o "$TMP"
+fetch() { # fetch URL DEST -> 0/1
+	if command -v curl >/dev/null 2>&1; then
+		curl -fsSL "$1" -o "$2"
+	elif command -v wget >/dev/null 2>&1; then
+		wget -q -O "$2" "$1"
+	else
+		die "neither curl nor wget is available"
+	fi
+}
+
+# ── where do the pieces come from? ──────────────────────────────────────────
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WORK=""
+cleanup() { [ -n "$WORK" ] && rm -rf "$WORK"; }
+trap cleanup EXIT INT TERM
+
+if [ -f "$HERE/Makefile" ] && [ -x "$HERE/tools/register_shell.sh" ]; then
+	# A source checkout: the drivers are right here, and a built binary wins
+	# over a download.
+	SRC_ROOT="$HERE"
+	BIN=""
+	[ -x "$HERE/build/bin/hellish" ] && BIN="$HERE/build/bin/hellish"
+	[ -z "$BIN" ] && [ -x "$HERE/dist/$ASSET" ] && BIN="$HERE/dist/$ASSET"
 else
-	wget -O "$TMP" "$URL"
+	SRC_ROOT=""
+	BIN=""
 fi
-chmod +x "$TMP"
 
-SUDO=""
-if [ -n "${PREFIX:-}" ]; then
-	DEST="$PREFIX/hellish"
-elif [ -w /usr/local/bin ]; then
-	DEST="/usr/local/bin/hellish"
-elif command -v sudo >/dev/null 2>&1; then
-	DEST="/usr/local/bin/hellish"
-	SUDO="sudo"
+WORK="$(mktemp -d)"
+
+if [ -z "$BIN" ]; then
+	OS="$(uname -s)"; ARCH="$(uname -m)"
+	if [ "$OS" != "Linux" ] || [ "$ARCH" != "x86_64" ]; then
+		warn "no prebuilt binary for $OS/$ARCH yet -- build from source:"
+		warn "  git clone --recursive https://github.com/$REPO && cd hellish && make OPT=1 all"
+		exit 1
+	fi
+	if [ -n "$VERSION" ]; then DL="$RELEASE_BASE/download/$VERSION"
+	else DL="$RELEASE_BASE/latest/download"; fi
+	say "downloading ${VERSION:-the latest release}..."
+	fetch "$DL/$ASSET" "$WORK/hellish" || die "download failed: $DL/$ASSET"
+	if fetch "$DL/$ASSET.sha256" "$WORK/hellish.sha256" 2>/dev/null \
+		&& command -v sha256sum >/dev/null 2>&1; then
+		( cd "$WORK" && sed "s/ .*/  hellish/" hellish.sha256 \
+			| sha256sum -c - >/dev/null 2>&1 ) \
+			|| die "sha256 verification FAILED -- refusing to install"
+		say "sha256 verified"
+	else
+		warn "could not verify the checksum (missing .sha256 or sha256sum)"
+	fi
+	chmod +x "$WORK/hellish"
+	BIN="$WORK/hellish"
+fi
+
+if [ -z "$SRC_ROOT" ]; then
+	# The drivers travel as a bundle beside the binary. A release too old to
+	# have one falls back to the scripts on main -- they are drivers of a
+	# binary, not part of it, so the newest ones are the right ones anyway.
+	if [ -n "$VERSION" ]; then DL="$RELEASE_BASE/download/$VERSION"
+	else DL="$RELEASE_BASE/latest/download"; fi
+	if fetch "$DL/$BUNDLE" "$WORK/bundle.tgz" 2>/dev/null; then
+		( cd "$WORK" && tar -xzf bundle.tgz )
+	else
+		say "no install bundle on this release -- fetching the scripts from main"
+		mkdir -p "$WORK/tools" "$WORK/share"
+		for f in user-install.sh tools/register_shell.sh \
+			tools/seed_hellishrc.sh hellishrc.example; do
+			fetch "$RAW_BASE/$f" "$WORK/$f" || die "could not fetch $f"
+		done
+		chmod +x "$WORK/user-install.sh" "$WORK"/tools/*.sh
+	fi
+	SRC_ROOT="$WORK"
+fi
+
+# ── uninstall (user mode; system mode has richer tooling in the repo) ───────
+if [ "$ACTION" = "uninstall" ]; then
+	sh "$SRC_ROOT/user-install.sh" --uninstall
+	say "for a system install, run from a checkout: make my-shell-uninstall"
+	exit 0
+fi
+
+# ── which world are we in? ──────────────────────────────────────────────────
+if [ -z "$MODE" ]; then
+	if [ "$(id -u)" = "0" ]; then
+		MODE="system"
+	elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+		MODE="system"
+	elif command -v sudo >/dev/null 2>&1 && [ "$INTERACTIVE" = "1" ] \
+		&& ask "You are not root -- do you have sudo rights on this machine?" n; then
+		MODE="system"
+	else
+		MODE="user"
+	fi
+fi
+say "install mode: $MODE$( [ "$MODE" = "user" ] && printf ' (no sudo needed -- the 42-machine path)' )"
+
+# ── install ─────────────────────────────────────────────────────────────────
+if [ "$MODE" = "system" ]; then
+	# Changing a login shell is never done silently: it happens when a human
+	# answered yes, or when --yes said to take the defaults. A tty-less run
+	# with no flags gets the binary and keeps its shell.
+	if [ "$LOGIN_SHELL" = "1" ] && [ "$INTERACTIVE" = "0" ] \
+		&& [ "$ASSUME_YES" = "0" ]; then
+		LOGIN_SHELL=0
+		say "no terminal to ask on -- installing the binary only (--yes opts into chsh)"
+	elif [ "$LOGIN_SHELL" = "1" ] \
+		&& ! ask "Register hellish as your login shell (chsh)?" y; then
+		LOGIN_SHELL=0
+	fi
+	( cd "$SRC_ROOT" && sh tools/seed_hellishrc.sh )
+	if [ "$LOGIN_SHELL" = "1" ]; then
+		( cd "$SRC_ROOT" && sh tools/register_shell.sh \
+			--bin "$BIN" --dest /usr/bin/hellish )
+	else
+		_as_root=""; [ "$(id -u)" = "0" ] || _as_root="sudo"
+		$_as_root install -m 0755 "$BIN" /usr/bin/hellish
+		say "installed /usr/bin/hellish (login shell untouched; run: hellish)"
+	fi
 else
-	mkdir -p "$HOME/.local/bin"
-	DEST="$HOME/.local/bin/hellish"
+	( cd "$SRC_ROOT" && sh user-install.sh --bin "$BIN" --prefix "$UPREFIX" )
 fi
 
-$SUDO mkdir -p "$(dirname "$DEST")"
-$SUDO mv "$TMP" "$DEST"
-trap - EXIT
+# ── plugins ─────────────────────────────────────────────────────────────────
+# The framework repo owns the catalog and its own installer; this script only
+# asks the coarse questions and hands the answer down, so adding a plugin to
+# the catalog never needs a change here.
+want_framework=0
+if [ -n "$PLUGINS" ] && [ "$PLUGINS" != "none" ]; then
+	want_framework=1
+elif [ -z "$PLUGINS" ] \
+	&& { [ "$INTERACTIVE" = "1" ] || [ "$ASSUME_YES" = "1" ]; } \
+	&& ask "Install the hellish plugin framework (git, jump, docker, net + a plugin catalog)?" y; then
+	want_framework=1
+	if [ "$INTERACTIVE" = "1" ]; then
+		printf '\033[1;36m?\033[0m Plugins: [a]ll / [c]hoose one by one / [n]one  [a] ' >/dev/tty
+		IFS= read -r _a </dev/tty || _a=""
+		case "$_a" in
+		[cC]*) PLUGINS="choose" ;;
+		[nN]*) PLUGINS="none" ;;
+		*)     PLUGINS="all" ;;
+		esac
+	else
+		PLUGINS="all"
+	fi
+fi
 
-echo "hellish: installed → $DEST"
-echo "make it a login shell:   echo $DEST | sudo tee -a /etc/shells && chsh -s $DEST"
-echo "                         (chsh only affects sessions you start AFTER it —"
-echo "                          your current terminal stays on the old shell)"
-echo "or just run:             $DEST"
+if [ "$want_framework" = "1" ]; then
+	say "setting up the plugin framework..."
+	FW="$WORK/hellishrc_plugins"
+	case "$PLUGINS_SRC" in
+	/*)	cp -R "$PLUGINS_SRC" "$FW" ;;
+	*.tar.gz|*.tgz)
+		fetch "$PLUGINS_SRC" "$WORK/fw.tgz" || die "could not fetch $PLUGINS_SRC"
+		mkdir -p "$FW" && tar -xzf "$WORK/fw.tgz" -C "$FW" --strip-components=1 ;;
+	*)	if command -v git >/dev/null 2>&1; then
+			git clone -q --depth 1 "$PLUGINS_SRC" "$FW" \
+				|| die "could not clone $PLUGINS_SRC"
+		else
+			fetch "$PLUGINS_SRC/archive/refs/heads/main.tar.gz" "$WORK/fw.tgz" \
+				|| die "could not fetch the framework"
+			mkdir -p "$FW" && tar -xzf "$WORK/fw.tgz" -C "$FW" --strip-components=1
+		fi ;;
+	esac
+	sh "$FW/install.sh" --plugins "${PLUGINS:-all}"
+fi
+
+# ── report ──────────────────────────────────────────────────────────────────
+if [ "$MODE" = "system" ]; then DEST="/usr/bin/hellish"
+else DEST="$UPREFIX/bin/hellish"; fi
+say "done. installed -> $DEST"
+"$DEST" --version 2>/dev/null | head -1 || true
+if [ "$MODE" = "user" ]; then
+	say "open a new terminal to land in hellish (or run: $DEST)"
+	say "undo any time:  sh install.sh --uninstall"
+else
+	say "log out and back in for the login shell (or run: exec $DEST --login)"
+	say "undo any time:  make my-shell-uninstall   (from a checkout)"
+fi

--- a/install.sh
+++ b/install.sh
@@ -83,8 +83,11 @@ done
 # Under `curl | sh`, stdin is the pipe -- but /dev/tty is still the terminal,
 # so questions remain possible. No tty (CI, docker build) means every answer
 # is the default and the plugin step is skipped unless flags said otherwise.
+# The probe runs in a SUBSHELL on purpose: a failed redirection on a special
+# builtin like `:` is fatal to a non-interactive POSIX shell, even inside an
+# `if` -- the subshell dies in the parent's place.
 INTERACTIVE=0
-if [ "$ASSUME_YES" = "0" ] && { : </dev/tty; } 2>/dev/null; then
+if [ "$ASSUME_YES" = "0" ] && ( exec </dev/tty ) 2>/dev/null; then
 	INTERACTIVE=1
 fi
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,68 @@
+# The docs site: https://univers42.github.io/hellish/
+#
+# The source of the site IS the wiki/ directory -- one set of pages, readable
+# on GitHub and rendered by MkDocs, so the two can never drift. Built and
+# deployed by .github/workflows/docs.yml on every push to main.
+site_name: hellish
+site_description: A from-scratch, almost-POSIX shell in C — minimalist-shell speed, bash-class features.
+site_url: https://univers42.github.io/hellish/
+repo_url: https://github.com/Univers42/hellish
+repo_name: Univers42/hellish
+edit_uri: edit/main/wiki/
+
+docs_dir: wiki
+
+# Working material that lives in wiki/ but is not part of the site: session
+# notes, reference PDFs (19 MB), captured logs, the legacy readme collection.
+exclude_docs: |
+  context.md
+  assets/pdfs/
+  assets/logs/
+  assets/manual/
+  assets/readmes/
+  assets/hellishrc.example
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep orange
+      accent: red
+      toggle:
+        icon: material/weather-night
+        name: dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep orange
+      accent: red
+      toggle:
+        icon: material/weather-sunny
+        name: light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+
+markdown_extensions:
+  - admonition
+  - tables
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - What it is + Install: product.md
+  - Interactive Experience: interactive.md
+  - Scripting & Compatibility: scripting.md
+  - Benchmarks: benchmarks.md
+  - Architecture: architecture.md
+  - Performance: performance.md
+  - Platforms: platforms.md
+  - Builtins:
+      - cd: builtins/cd.md
+  - Troubleshooting: troubleshoot/README.md
+  - Fix write-ups: fixes/README.md

--- a/tests/installer_suite.sh
+++ b/tests/installer_suite.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+# tests/installer_suite.sh -- drives install.sh end-to-end inside
+# docker/Dockerfile.installer. Runs as root, which is the orchestrator's job
+# only: every install under test runs as one of the two humans the image
+# defines -- maxine (NOPASSWD sudoer) and nora (no sudo at all).
+#
+# Scenarios:
+#   A  nora   --yes --plugins="git jump"   user mode picked automatically,
+#                                          binary + rc hook + framework
+#   B  maxine --yes --plugins=none         system mode picked automatically,
+#                                          /usr/bin + /etc/shells + chsh
+#   C  nora2  interactive over a pty       questions really read /dev/tty
+#   D  uninstalls                          both worlds restored
+#   E  one external plugin over the net    skips cleanly offline
+#
+# Everything hermetic: the "release" is a local server started here, serving
+# the binary, its sha256, the install bundle and the plugin framework built
+# into the image. Only scenario E touches the real network, and it skips.
+set -u
+
+PASS=0; FAILS=0
+ok()  { PASS=$((PASS + 1)); printf 'ok   %s\n' "$1"; }
+bad() { FAILS=$((FAILS + 1)); printf 'FAIL %s%s\n' "$1" "${2:+  -- $2}"; }
+check() { # check <label> <command...>
+	_l="$1"; shift
+	if "$@" >/dev/null 2>&1; then ok "$_l"; else bad "$_l"; fi
+}
+
+# ── the fake release channel ────────────────────────────────────────────────
+cd /srv/release
+python3 -m http.server 8377 --bind 127.0.0.1 >/dev/null 2>&1 &
+SRV=$!
+trap 'kill $SRV 2>/dev/null' EXIT
+sleep 1
+check "fake release server answers" \
+	curl -fsS -o /dev/null http://127.0.0.1:8377/latest/download/hellish-linux-x86_64
+
+ENV_COMMON="HELLISH_RELEASE_BASE=http://127.0.0.1:8377 \
+HELLISH_PLUGINS_SRC=http://127.0.0.1:8377/hellishrc_plugins.tar.gz \
+HELLISH_NO_BANNER=1 HELLISH_NO_UPDATE_CHECK=1 HELLISH_NO_ANIM=1"
+
+# ── A: no sudo rights -> user mode, automatically ───────────────────────────
+echo "--- A: nora (no sudo) + --yes --plugins='git jump'"
+su nora -c "cd /tmp && $ENV_COMMON sh /hellish/install.sh --yes --plugins='git jump'" \
+	|| bad "A: install.sh exited $?"
+NH=/home/nora
+check "A: binary in ~/.local/bin"       test -x "$NH/.local/bin/hellish"
+check "A: nothing landed in /usr/bin"   test ! -e /usr/bin/hellish
+check "A: the binary answers"           su nora -c "$NH/.local/bin/hellish -c 'echo ok'"
+check "A: ~/.hellishrc seeded"          test -f "$NH/.hellishrc"
+check "A: rc hook block written"        grep -q "^# >>> hellish >>>" "$NH/.bashrc"
+# The framework's installer replaces ~/.hellishrc with its loader and
+# preserves the seeded rc as rc.d/95-previous-rc.hsh -- so the PATH block
+# lives in one of the two, and both are loaded.
+check "A: PATH block survives somewhere loaded" \
+	sh -c "grep -rq 'local/bin' $NH/.hellishrc $NH/.hellish/rc.d/ 2>/dev/null"
+check "A: framework installed"          test -d "$NH/.hellish/lib"
+check "A: chosen plugin present"        test -d "$NH/.hellish/plugins/git"
+check "A: unchosen builtin off in conf" grep -q "^feature net *off" "$NH/.hellish/hellish.conf"
+check "A: framework loads with 0 errors" \
+	su nora -c "$NH/.local/bin/hellish -c '. ~/.hellishrc >/dev/null 2>&1; [ \${#HX_ERRORS[@]} -eq 0 ]'"
+check "A: conf sees git on" \
+	su nora -c "$NH/.local/bin/hellish -c '. ~/.hellishrc >/dev/null 2>&1; conf list' | grep -q 'on  git'"
+
+# ── B: passwordless sudo -> system mode, automatically ──────────────────────
+echo "--- B: maxine (sudoer) + --yes --plugins=none"
+PREV_SHELL="$(getent passwd maxine | cut -d: -f7)"
+su maxine -c "cd /tmp && $ENV_COMMON sh /hellish/install.sh --yes --plugins=none" \
+	|| bad "B: install.sh exited $?"
+check "B: binary in /usr/bin"           test -x /usr/bin/hellish
+check "B: /etc/shells lists it"         grep -qx /usr/bin/hellish /etc/shells
+check "B: login shell changed"          sh -c '[ "$(getent passwd maxine | cut -d: -f7)" = /usr/bin/hellish ]'
+check "B: the binary answers"           su maxine -c "/usr/bin/hellish -c 'echo ok'"
+check "B: ~/.hellishrc seeded"          test -f /home/maxine/.hellishrc
+check "B: no framework without asking"  test ! -d /home/maxine/.hellish
+
+# ── C: the interactive path, through a real pty ─────────────────────────────
+# `script` gives the child a controlling tty, so install.sh's /dev/tty reads
+# are exercised for real. Two questions reach nora2: "do you have sudo
+# rights?" (no) and the framework offer (no).
+echo "--- C: nora2, interactive, answers n n"
+printf 'n\nn\n' | su nora2 -c \
+	"cd /tmp && script -qec '$ENV_COMMON sh /hellish/install.sh' /dev/null" \
+	>/dev/null 2>&1 || bad "C: interactive install exited $?"
+check "C: binary installed"             test -x /home/nora2/.local/bin/hellish
+check "C: framework declined -> absent" test ! -d /home/nora2/.hellish
+
+# ── D: both uninstall routes ────────────────────────────────────────────────
+echo "--- D: uninstall puts both worlds back"
+su nora -c "cd /tmp && sh /hellish/install.sh --uninstall" >/dev/null 2>&1 \
+	|| bad "D: user uninstall exited $?"
+check "D: rc hook gone"                 sh -c "! grep -q '^# >>> hellish >>>' $NH/.bashrc"
+check "D: user binary gone"             test ! -e "$NH/.local/bin/hellish"
+# NOT wrapped in sudo: the script escalates internally (as_root), and a
+# blanket sudo would swap $HOME away from the .hellish-previous-shell
+# marker it restores from.
+su maxine -c "/hellish/tools/register_shell.sh --uninstall --dest /usr/bin/hellish" \
+	>/dev/null 2>&1 || bad "D: system uninstall exited $?"
+check "D: login shell restored"         sh -c "[ \"\$(getent passwd maxine | cut -d: -f7)\" = '$PREV_SHELL' ]"
+check "D: system binary gone"           test ! -e /usr/bin/hellish
+
+# ── E: one real external plugin, network permitting ─────────────────────────
+echo "--- E: hxp install z (real network; skips cleanly offline)"
+if curl -fsS -o /dev/null --max-time 10 https://raw.githubusercontent.com 2>/dev/null; then
+	su nora -c "cd /tmp && $ENV_COMMON sh /hellish/install.sh --yes --plugins=none" >/dev/null 2>&1
+	check "E: hxp install z fetches and wires" \
+		su nora -c "$NH/.local/bin/hellish -c '. ~/.hellishrc >/dev/null 2>&1; hxp install z' && test -f $NH/.hellish/plugins/z/z.sh"
+else
+	echo "skip E: no network"
+fi
+
+printf '\n%d ok, %d failed\n' "$PASS" "$FAILS"
+[ "$FAILS" -eq 0 ]

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -1,0 +1,100 @@
+# Architecture
+
+> The whole shell in one breath, then where to read more. Each module under
+> [`src/`](https://github.com/Univers42/hellish/tree/main/src) carries its own
+> `README.md` with the real design notes — this page is the map, those are the
+> territory.
+
+## The pipeline
+
+`main → on() → repl_shell() → parse_and_execute_input()`, conceptually:
+
+```
+input → lexer → parser (AST) → word reparser → heredoc → expander → executor
+```
+
+- The **lexer** slices tokens straight out of the input buffer — no copies.
+- The **parser** builds a `t_ast_node` tree that *deliberately keeps raw
+  tokens*, so loops and functions re-expand each iteration without re-parsing.
+- The **expander** runs *lazily, per simple command*, during the executor's
+  tree walk — the pipeline is conceptual, not literal.
+- **Heredocs** are gathered in a pre-exec pass; bodies land in temp files and
+  are rewritten as plain redirects.
+- **Command substitution** has a forkless fast path (`cmdsub_fast`) for
+  provably side-effect-free bodies; anything else forks.
+
+One struct, `t_shell` (`incs/shell.h`), is the single source of truth; every
+subsystem takes `t_shell *`. Subshells fork and the child inherits a copy.
+
+| stage | entry point | design notes |
+|---|---|---|
+| lifecycle / REPL | `src/core/shell.c` | [`src/core/README.md`](https://github.com/Univers42/hellish/blob/main/src/core/README.md) |
+| lexer | `tokenizer()` | [`src/lexer/README.md`](https://github.com/Univers42/hellish/blob/main/src/lexer/README.md) |
+| parser | `parse_tokens()` | [`src/parsing/README.md`](https://github.com/Univers42/hellish/blob/main/src/parsing/README.md) |
+| word reparser | `reparse_words()` | [`src/word_splitting/README.md`](https://github.com/Univers42/hellish/blob/main/src/word_splitting/README.md) |
+| heredoc | `gather_heredocs()` | [`src/heredoc/README.md`](https://github.com/Univers42/hellish/blob/main/src/heredoc/README.md) |
+| expander | `expand_simple_command()` | [`src/expander/README.md`](https://github.com/Univers42/hellish/blob/main/src/expander/README.md) |
+| executor | `execute_top_level()` | [`src/execution/README.md`](https://github.com/Univers42/hellish/blob/main/src/execution/README.md) |
+
+Other modules: `builtins` (65 names, O(1) hash dispatch), `environment`,
+`arith` (a self-contained lexer/parser/eval for `$(( ))`), `glob`, `alias`,
+`job_control`, `completion` + `editing` (readline, vi/emacs, and the ZLE
+widget layer), `infrastructure` (input driver, prompt, history, error
+reporting).
+
+## The zsh dialect
+
+zsh syntax is not bash and not POSIX, so **none of it is reachable unless
+something arms the mode**: `set -o zsh`, `emulate zsh`, or sourcing a `.zsh`
+file (restored when the file finishes). There is no heuristic on file content —
+the golden suite pins the bash meaning of the same text by construction. See
+[Interactive Experience](interactive.md) and the plugin corpus in
+[`tests/plugin_corpus_test.py`](https://github.com/Univers42/hellish/blob/main/tests/plugin_corpus_test.py).
+
+## The two allocators (SAFE)
+
+Every allocation goes through one `xmalloc`/`xfree` macro family that resolves
+**at compile time** to libc `malloc` or our own `ft_malloc` — no pointer ever
+crosses heaps. So you can A/B the exact same shell on two completely different
+allocators and prove they produce byte-identical output:
+
+```sh
+cd tests && ./verify_alloc.sh   # builds BOTH heaps, proves output parity + zero leaks
+```
+
+`ft_malloc` (in the `vendor/libft` submodule) is a slab + big-alloc allocator
+with an O(1) free path; on `SAFE=0` its own live-bytes oracle
+(`HELLISH_ALLOC_STATS=1`) replaces ASan as the leak gate.
+
+## Build matrix
+
+| Command | Optimization | Allocator | Sanitizers | Use it for |
+|---|---|---|---|---|
+| `make all` | `-O0 -g3` | libc (`SAFE=1`) | ASan + LeakSanitizer | dev, debugging, leak hunts |
+| `make OPT=1` | `-O3 -flto` | **`ft_malloc`** (`SAFE=0`) | none | speed, benchmarks, daily driving |
+| `make MODE=relwithdebinfo` | `-O2 -g` | `ft_malloc` | none | bugs that only appear optimized |
+| `make OPT=1 SAFE=1` | `-O3 -flto` | libc | none | optimized build on the battle-tested heap |
+
+An explicit `SAFE=…` on the command line always wins. Objects live in
+per-mode, per-allocator trees, so modes never share objects. `make` with no
+target prints the self-documenting help page.
+
+## Testing & quality gates
+
+Nothing lands without all of these green from a clean tree:
+
+- **`make test`** — 4000+ golden cases, each diffed (stdout + exit status +
+  files written) against a **pinned bash 5.3.9** (`make oracle`).
+- **`tests/run_scripts.sh`** — whole real programs vs `bash --posix`.
+- **`make pty-test`** — every `tests/*.py`, discovered by glob: real-pty
+  coverage of the interactive paths `-c` can't reach.
+- **`cd tests && ./verify_alloc.sh`** — output parity + zero leaks on both heaps.
+- **`make plugin-corpus`** — 13 real third-party plugins sourced against the
+  release *and* the ASan build, each with a declared expectation.
+- **`make conformance`** — Oils spec + mksh `check.t`, gated so a pass-count
+  drop fails.
+- **`make norm`** — 42 norminette clean.
+
+See also: **[Benchmarks](benchmarks.md)** · **[Performance](performance.md)** ·
+**[Platforms](platforms.md)** · the developer guide in
+[`DEV_DOC.md`](https://github.com/Univers42/hellish/blob/main/DEV_DOC.md)

--- a/wiki/assets/cross-shell-workloads.svg
+++ b/wiki/assets/cross-shell-workloads.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="676" viewBox="0 0 880 676" font-family="system-ui">
+<style>
+  .bg{fill:#ffffff}.card{fill:#f6f8fa;stroke:#d0d7de}
+  .title{fill:#1f2328;font:600 17px system-ui,-apple-system,Segoe UI,sans-serif}
+  .sub{fill:#59636e;font:400 12px system-ui,-apple-system,Segoe UI,sans-serif}
+  .lbl{fill:#1f2328;font:600 12.5px system-ui,-apple-system,Segoe UI,sans-serif}
+  .val{fill:#1f2328;font:600 11px ui-monospace,SFMono-Regular,Menlo,monospace}
+  .muted{fill:#59636e;font:400 10.5px system-ui,-apple-system,sans-serif}
+  .us{fill:#e2543a;font:700 12.5px system-ui,-apple-system,Segoe UI,sans-serif}
+  .axis{stroke:#8c959f;stroke-width:1}
+  @media (prefers-color-scheme:dark){
+   .bg{fill:#0d1117}.card{fill:#161b22;stroke:#30363d}
+   .title{fill:#e6edf3}.sub{fill:#8b949e}.lbl{fill:#e6edf3}.val{fill:#e6edf3}
+   .muted{fill:#8b949e}.axis{stroke:#6e7681}}
+  :root[data-theme=dark] .bg{fill:#0d1117}
+  :root[data-theme=dark] .card{fill:#161b22;stroke:#30363d}
+  :root[data-theme=dark] .title{fill:#e6edf3}:root[data-theme=dark] .sub{fill:#8b949e}
+  :root[data-theme=dark] .lbl{fill:#e6edf3}:root[data-theme=dark] .val{fill:#e6edf3}
+  :root[data-theme=dark] .muted{fill:#8b949e}
+  :root[data-theme=light] .bg{fill:#ffffff}:root[data-theme=light] .card{fill:#f6f8fa;stroke:#d0d7de}
+  :root[data-theme=light] .title{fill:#1f2328}:root[data-theme=light] .lbl{fill:#1f2328}
+</style>
+<rect class="bg" width="880" height="676"/>
+<rect class="card" x="8" y="8" width="864" height="660" rx="10"/>
+<text class="title" x="26" y="40">Per-workload: hellish vs bash vs dash</text>
+<text class="sub" x="26" y="62">Best-of-7 ms, lower is faster. Legend: <tspan fill="#e2543a">hellish</tspan> <tspan fill="#5b7fa6">bash</tspan> <tspan fill="#6f9e78">dash</tspan></text>
+<text class="lbl" x="156" y="114" text-anchor="end">while-arith 50k</text>
+<rect x="168" y="98" width="291.0" height="12" rx="2" fill="#e2543a"/>
+<text class="val" x="465.0" y="108">75</text>
+<rect x="168" y="113" width="622.0" height="12" rx="2" fill="#5b7fa6"/>
+<text class="val" x="796.0" y="123">160</text>
+<rect x="168" y="128" width="255.0" height="12" rx="2" fill="#6f9e78"/>
+<text class="val" x="429.0" y="138">66</text>
+<text class="lbl" x="156" y="174" text-anchor="end">func-call 5k</text>
+<rect x="168" y="158" width="252.8" height="12" rx="2" fill="#e2543a"/>
+<text class="val" x="426.8" y="168">19</text>
+<rect x="168" y="173" width="622.0" height="12" rx="2" fill="#5b7fa6"/>
+<text class="val" x="796.0" y="183">46</text>
+<rect x="168" y="188" width="184.6" height="12" rx="2" fill="#6f9e78"/>
+<text class="val" x="358.6" y="198">14</text>
+<text class="lbl" x="156" y="234" text-anchor="end">var-concat 30k</text>
+<rect x="168" y="218" width="245.7" height="12" rx="2" fill="#e2543a"/>
+<text class="val" x="419.7" y="228">74</text>
+<rect x="168" y="233" width="622.0" height="12" rx="2" fill="#5b7fa6"/>
+<text class="val" x="796.0" y="243">189</text>
+<rect x="168" y="248" width="236.5" height="12" rx="2" fill="#6f9e78"/>
+<text class="val" x="410.5" y="258">72</text>
+<text class="lbl" x="156" y="294" text-anchor="end">concat-grow 4k</text>
+<rect x="168" y="278" width="135.2" height="12" rx="2" fill="#e2543a"/>
+<text class="val" x="309.2" y="288">16</text>
+<rect x="168" y="293" width="622.0" height="12" rx="2" fill="#5b7fa6"/>
+<text class="val" x="796.0" y="303">73</text>
+<rect x="168" y="308" width="150.6" height="12" rx="2" fill="#6f9e78"/>
+<text class="val" x="324.6" y="318">18</text>
+<text class="lbl" x="156" y="354" text-anchor="end">cmdsub 3k</text>
+<rect x="168" y="338" width="82.9" height="12" rx="2" fill="#e2543a"/>
+<text class="val" x="256.9" y="348">161</text>
+<rect x="168" y="353" width="622.0" height="12" rx="2" fill="#5b7fa6"/>
+<text class="val" x="796.0" y="363">1211</text>
+<rect x="168" y="368" width="316.0" height="12" rx="2" fill="#6f9e78"/>
+<text class="val" x="490.0" y="378">615</text>
+<text class="lbl" x="156" y="414" text-anchor="end">param-expand 20k</text>
+<rect x="168" y="398" width="374.0" height="12" rx="2" fill="#e2543a"/>
+<text class="val" x="548.0" y="408">114</text>
+<rect x="168" y="413" width="622.0" height="12" rx="2" fill="#5b7fa6"/>
+<text class="val" x="796.0" y="423">190</text>
+<rect x="168" y="428" width="195.2" height="12" rx="2" fill="#6f9e78"/>
+<text class="val" x="369.2" y="438">60</text>
+<text class="lbl" x="156" y="474" text-anchor="end">case-loop 20k</text>
+<rect x="168" y="458" width="447.0" height="12" rx="2" fill="#e2543a"/>
+<text class="val" x="621.0" y="468">81</text>
+<rect x="168" y="473" width="622.0" height="12" rx="2" fill="#5b7fa6"/>
+<text class="val" x="796.0" y="483">113</text>
+<rect x="168" y="488" width="197.6" height="12" rx="2" fill="#6f9e78"/>
+<text class="val" x="371.6" y="498">36</text>
+<text class="lbl" x="156" y="534" text-anchor="end">test-string 20k</text>
+<rect x="168" y="518" width="274.5" height="12" rx="2" fill="#e2543a"/>
+<text class="val" x="448.5" y="528">68</text>
+<rect x="168" y="533" width="622.0" height="12" rx="2" fill="#5b7fa6"/>
+<text class="val" x="796.0" y="543">155</text>
+<rect x="168" y="548" width="216.8" height="12" rx="2" fill="#6f9e78"/>
+<text class="val" x="390.8" y="558">54</text>
+<text class="lbl" x="156" y="594" text-anchor="end">arith-mix 20k</text>
+<rect x="168" y="578" width="244.6" height="12" rx="2" fill="#e2543a"/>
+<text class="val" x="418.6" y="588">44</text>
+<rect x="168" y="593" width="622.0" height="12" rx="2" fill="#5b7fa6"/>
+<text class="val" x="796.0" y="603">112</text>
+<rect x="168" y="608" width="218.6" height="12" rx="2" fill="#6f9e78"/>
+<text class="val" x="392.6" y="618">40</text>
+</svg>

--- a/wiki/assets/cross-shell.svg
+++ b/wiki/assets/cross-shell.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="438" viewBox="0 0 880 438" font-family="system-ui">
+<style>
+  .bg{fill:#ffffff}.card{fill:#f6f8fa;stroke:#d0d7de}
+  .title{fill:#1f2328;font:600 17px system-ui,-apple-system,Segoe UI,sans-serif}
+  .sub{fill:#59636e;font:400 12px system-ui,-apple-system,Segoe UI,sans-serif}
+  .lbl{fill:#1f2328;font:600 12.5px system-ui,-apple-system,Segoe UI,sans-serif}
+  .val{fill:#1f2328;font:600 11px ui-monospace,SFMono-Regular,Menlo,monospace}
+  .muted{fill:#59636e;font:400 10.5px system-ui,-apple-system,sans-serif}
+  .us{fill:#e2543a;font:700 12.5px system-ui,-apple-system,Segoe UI,sans-serif}
+  .axis{stroke:#8c959f;stroke-width:1}
+  @media (prefers-color-scheme:dark){
+   .bg{fill:#0d1117}.card{fill:#161b22;stroke:#30363d}
+   .title{fill:#e6edf3}.sub{fill:#8b949e}.lbl{fill:#e6edf3}.val{fill:#e6edf3}
+   .muted{fill:#8b949e}.axis{stroke:#6e7681}}
+  :root[data-theme=dark] .bg{fill:#0d1117}
+  :root[data-theme=dark] .card{fill:#161b22;stroke:#30363d}
+  :root[data-theme=dark] .title{fill:#e6edf3}:root[data-theme=dark] .sub{fill:#8b949e}
+  :root[data-theme=dark] .lbl{fill:#e6edf3}:root[data-theme=dark] .val{fill:#e6edf3}
+  :root[data-theme=dark] .muted{fill:#8b949e}
+  :root[data-theme=light] .bg{fill:#ffffff}:root[data-theme=light] .card{fill:#f6f8fa;stroke:#d0d7de}
+  :root[data-theme=light] .title{fill:#1f2328}:root[data-theme=light] .lbl{fill:#1f2328}
+</style>
+<rect class="bg" width="880" height="438"/>
+<rect class="card" x="8" y="8" width="864" height="422" rx="10"/>
+<text class="title" x="26" y="40">Cross-shell speed ranking &#8212; 9 shells, one Docker image</text>
+<text class="sub" x="26" y="62">Geometric mean of best-of-7 across 17 portable POSIX workloads. Lower is faster; bar = geomean, label = ratio vs hellish.</text>
+<text class="lbl" x="138" y="113" text-anchor="end">#1 ksh</text>
+<rect x="150" y="101" width="30.4" height="16" rx="3" fill="#7f8fa0" opacity=".82"/>
+<text class="val" x="188.4" y="113">36.9 ms</text>
+<text class="muted" x="854" y="113" text-anchor="end">0.55&#215; faster</text>
+<text class="lbl" x="138" y="147" text-anchor="end">#2 dash</text>
+<rect x="150" y="135" width="42.4" height="16" rx="3" fill="#6f9e78" opacity=".82"/>
+<text class="val" x="200.4" y="147">51.4 ms</text>
+<text class="muted" x="854" y="147" text-anchor="end">0.77&#215; faster</text>
+<text class="us" x="138" y="181" text-anchor="end">#3 hellish &#9666;</text>
+<rect x="150" y="169" width="54.9" height="16" rx="3" fill="#e2543a" opacity="1"/>
+<text class="val" x="212.9" y="181">66.6 ms</text>
+<text class="muted" x="854" y="181" text-anchor="end">1.00&#215;</text>
+<text class="lbl" x="138" y="215" text-anchor="end">#4 busybox</text>
+<rect x="150" y="203" width="60.0" height="16" rx="3" fill="#a0708a" opacity=".82"/>
+<text class="val" x="218.0" y="215">72.8 ms</text>
+<text class="muted" x="854" y="215" text-anchor="end">1.09&#215; slower</text>
+<text class="lbl" x="138" y="249" text-anchor="end">#5 zsh</text>
+<rect x="150" y="237" width="94.1" height="16" rx="3" fill="#9a76b8" opacity=".82"/>
+<text class="val" x="252.1" y="249">114.1 ms</text>
+<text class="muted" x="854" y="249" text-anchor="end">1.71&#215; slower</text>
+<text class="lbl" x="138" y="283" text-anchor="end">#6 bash</text>
+<rect x="150" y="271" width="114.7" height="16" rx="3" fill="#5b7fa6" opacity=".82"/>
+<text class="val" x="272.7" y="283">139.1 ms</text>
+<text class="muted" x="854" y="283" text-anchor="end">2.09&#215; slower</text>
+<text class="lbl" x="138" y="317" text-anchor="end">#7 mksh</text>
+<rect x="150" y="305" width="124.6" height="16" rx="3" fill="#b8925c" opacity=".82"/>
+<text class="val" x="282.6" y="317">151.1 ms</text>
+<text class="muted" x="854" y="317" text-anchor="end">2.27&#215; slower</text>
+<text class="lbl" x="138" y="351" text-anchor="end">#8 yash</text>
+<rect x="150" y="339" width="153.1" height="16" rx="3" fill="#8aa05c" opacity=".82"/>
+<text class="val" x="311.1" y="351">185.6 ms</text>
+<text class="muted" x="854" y="351" text-anchor="end">2.79&#215; slower</text>
+<text class="lbl" x="138" y="385" text-anchor="end">#9 fish</text>
+<rect x="150" y="373" width="612.0" height="16" rx="3" fill="#5f9ea0" opacity=".82"/>
+<text class="val" x="770.0" y="385">742.0 ms</text>
+<text class="muted" x="854" y="385" text-anchor="end">11.14&#215; slower</text>
+<line class="axis" x1="150" y1="86" x2="150" y2="392"/>
+<text class="muted" x="26" y="418">oracle=bash &#183; ksh's recursion/cmdsub rows are builtin-accelerated outliers, not comparable work</text>
+</svg>

--- a/wiki/benchmarks.md
+++ b/wiki/benchmarks.md
@@ -1,0 +1,150 @@
+# Benchmarks — the 9-shell race
+
+> Every number on this page is measured, not asserted, and reproducible with
+> one command. Fairness rules and the measurement traps this harness has
+> already fallen into are documented in
+> [`bench/METHODOLOGY.md`](https://github.com/Univers42/hellish/blob/main/bench/METHODOLOGY.md).
+
+We build hellish plus a zoo of real shells — **bash, dash, zsh, mksh, ksh,
+yash, busybox ash, fish** — into one Docker image and race all nine on 17
+portable POSIX workloads (`make agnostic-bench`). Ranking is the **geometric
+mean** of the best-of-7 time on each workload, so no single benchmark can skew
+it and warm-up noise is thrown away.
+
+![Cross-shell speed ranking — 9 shells raced in one Docker image, hellish ranks #3 by geomean](assets/cross-shell.svg)
+
+## hellish ranks #3 of 9
+
+| # | shell | geomean | vs hellish | |
+|:---:|:---|---:|:---:|:---|
+| 1 | ksh | 36.9 ms | 0.55× | *builtin-accelerated ¹* |
+| 2 | dash | 51.4 ms | 0.77× | the minimalist speed king |
+| **3** | **hellish** | **66.6 ms** | **1.00×** | ◀ **us** |
+| 4 | busybox ash | 72.8 ms | 1.09× | |
+| 5 | zsh | 114.1 ms | 1.71× | hellish is **1.7× faster** |
+| 6 | bash | 139.1 ms | 2.09× | hellish is **2.1× faster** |
+| 7 | mksh | 151.1 ms | 2.27× | |
+| 8 | yash | 185.6 ms | 2.79× | |
+| 9 | fish | 742.0 ms | 11.14× | |
+
+**The honest summary:** hellish is **faster than 6 of the 8 other shells** —
+including **bash** (2.1×) and every feature-rich shell (zsh, fish) — and lands
+just behind the two shells built to be minimal and nothing else. And it does
+this while carrying a **bash-class feature surface** those minimalist shells
+don't have (arrays, `[[ =~ ]]`, `${v/p/r}`, process substitution, job control,
+vi/emacs editing). *That combination — minimalist speed, bash features — is the
+whole point.*
+
+> ¹ ksh93's #1 is partly an artifact: its recursion (`fib18` 54.6 ms vs
+> everyone else's 2.4–4.8 **seconds**) and command-substitution rows are orders
+> of magnitude off the field because ksh compiles/forklessly accelerates them —
+> not comparable work. On the ordinary workloads it and hellish trade blows.
+
+## Where hellish wins, ties, and loses
+
+No cherry-picking. Per-workload, best-of-7, lower is faster:
+
+![Per-workload comparison: hellish vs bash vs dash on nine representative workloads](assets/cross-shell-workloads.svg)
+
+**vs `bash`** — hellish wins nearly everywhere it's tested:
+
+| area | hellish | bash | verdict |
+|---|---|---|:---:|
+| arithmetic loops | 75 ms | 161 ms | ✅ **2.1× faster** |
+| string concat (grow) | 16 ms | 73 ms | ✅ **4.6× faster** |
+| variable concat | 75 ms | 189 ms | ✅ **2.5× faster** |
+| command substitution | 161 ms | 1211 ms | ✅ **7.5× faster** |
+| `test`/`[ ]` string ops | 69 ms | 155 ms | ✅ **2.3× faster** |
+| function calls | 19 ms | 47 ms | ✅ **2.5× faster** |
+| parse a 50k-line script | 55 ms | 75 ms | ✅ **1.4× faster** |
+
+**vs `dash`** — the honest losses. dash is a tiny POSIX-only shell; matching it
+is the goal, not always reached:
+
+| area | hellish | dash | verdict |
+|---|---|---|:---:|
+| arithmetic loops | 75 ms | 66 ms | ≈ within 15% |
+| command substitution | 161 ms | 615 ms | ✅ **3.8× faster** |
+| `read` loop | 125 ms | 724 ms | ✅ **5.8× faster** |
+| function calls | 19 ms | 14 ms | ➖ dash faster |
+| parameter expansion | 114 ms | 60 ms | ➖ dash faster |
+| parse a 50k-line script | 55 ms | 29 ms | ➖ dash faster |
+
+So: **hellish beats dash on the fork- and I/O-heavy work** (command
+substitution, read loops) and trails it on the pure-parse and pure-expansion
+micro-loops, where dash's do-almost-nothing design is hard to beat.
+
+## Memory
+
+Peak resident set, median of 7 runs (`make rss`). hellish keeps a **flat ~4 MB
+working set** on loops — competitive with bash, sometimes tighter — and pays for
+its richer parser only where it parses a lot:
+
+| workload | hellish | bash | dash |
+|---|---:|---:|---:|
+| startup | 3.9 MB | 3.8 MB | **2.2 MB** |
+| arith loop | **3.8 MB** | 3.9 MB | 2.2 MB |
+| string concat | **3.9 MB** | 4.1 MB | 2.2 MB |
+| read loop | 3.9 MB | 3.9 MB | 2.2 MB |
+| parse 50k lines | 11.6 MB | **4.9 MB** | 2.2 MB |
+
+The parse-50k line is our one real memory cost: the lexer materialises the
+whole file's tokens up front. It's down from **158 MB → 20 MB → 11.6 MB** over
+successive rounds (8-byte deque tokens, a borrowed input buffer); the remaining
+gap to bash is documented and the pull-lexer that closes it is planned in
+[`backlog.md`](https://github.com/Univers42/hellish/blob/main/backlog.md).
+
+## Conformance — more POSIX than dash
+
+Two independent third-party suites, run against `bash --posix` **and** `dash`
+(`make conformance`). hellish's rate is deliberately **conservative** — the Oils
+harness credits a "known-ok" annotation that exists for bash/dash but cannot
+exist for a shell it's never heard of, so we only ever count a hard `pass`.
+
+**mksh `check.t`** (the ksh regression suite) — hellish now **beats dash**:
+
+| shell | passed |
+|---|---:|
+| bash | 292 |
+| **hellish** | **218** 🎉 |
+| dash | 216 |
+
+**Oils spec suite** (1622 cases spanning bash + POSIX features):
+
+| shell | hard passes | pass-rate |
+|---|---:|---:|
+| bash --posix | 1311 | 85.1% |
+| dash | 977 | 68.5% |
+| **hellish --posix** | **1071** | **66.0%** ᶜᵒⁿˢᵉʳᵛᵃᵗⁱᵛᵉ |
+
+hellish sits between dash and bash on raw Oils count — but Oils tests a pile of
+bash-isms dash simply lacks, so on the **shared POSIX core** hellish is much
+closer to bash than the headline number suggests, and it already **passes more
+of the ksh suite than dash does**.
+
+## So where does hellish rank, today?
+
+| dimension | tier | who's ahead |
+|---|:---:|---|
+| **Speed** | 🥉 top-3 of 9 | only ksh & dash (both minimalist specialists) |
+| **vs bash specifically** | ✅ faster | hellish wins ~2× on the geomean |
+| **Features** | high | far beyond dash/busybox/mksh; near bash/zsh |
+| **Memory** | good | flat ~4 MB; heavier only on big parses |
+| **POSIX conformance** | solid | ahead of dash on mksh, behind bash overall |
+
+**The one-line placement:** *hellish is a top-tier-fast shell that behaves like
+bash.* Nothing else in the field pairs dash-adjacent speed with bash-class
+features — the minimalist shells (dash, busybox, mksh) are fast but bare, and
+the featureful ones (bash, zsh, fish) are slower. hellish sits in the empty
+quadrant between them.
+
+## Reproduce it
+
+```sh
+make agnostic-bench     # the 9-shell Docker race (needs docker; installs the shells for you)
+make rss conformance    # memory + the two conformance suites
+make charts             # redraw every SVG on this page from the raw artifacts
+```
+
+See also: **[Performance & Robustness](performance.md)** ·
+**[Architecture](architecture.md)**

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,39 @@
+# hellish 🐚🔥
+
+**A from-scratch, almost-POSIX shell in C — runs like a minimalist shell,
+reads like bash, and loads real oh-my-zsh plugins.**
+
+hellish is engineered like a teaching lab and benchmarked like a production
+shell: `input → lexer → parser → word reparser → heredoc → expander →
+executor`, each a small readable module, one `t_shell` struct as the single
+source of truth. It diffs **byte-for-byte against a pinned bash 5.3.9** on
+4248 golden cases, runs clean under AddressSanitizer, ships **two allocators
+you swap at compile time**, and races **#3 of 9** against the shells you
+actually use — faster than bash, zsh, mksh, yash and fish.
+
+## Install in one command
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Univers42/hellish/main/install.sh | sh
+```
+
+The installer detects whether you have sudo rights and routes itself — system
+install + login shell with sudo, `~/.local/bin` + rc hook without (the 42
+school machine path) — then offers the plugin framework and a pick-list of
+plugins. Details and every other route (source, npm, Docker):
+**[What hellish is + Install](product.md)**.
+
+## Find your way
+
+| you want to… | read |
+|---|---|
+| know what it is and install it | [Product & Install](product.md) |
+| live at the prompt — themes, completion, plugins, zsh dialect | [Interactive Experience](interactive.md) |
+| run your bash scripts on it | [Bash Compatibility & Scripting](scripting.md) |
+| see the numbers | [Benchmarks](benchmarks.md) · [Performance](performance.md) |
+| understand how it's built | [Architecture](architecture.md) |
+| run it on your OS | [Platforms](platforms.md) |
+| fix something | [Troubleshooting](troubleshoot/README.md) · [Fix write-ups](fixes/README.md) |
+
+Source, issues and releases live at
+[github.com/Univers42/hellish](https://github.com/Univers42/hellish).

--- a/wiki/product.md
+++ b/wiki/product.md
@@ -28,51 +28,91 @@ straight read:
 | **dash** | Slower and larger (dash is the minimalist floor) — but vastly more capable. |
 
 What makes it credible rather than a toy: it's **fast**, it's **correct enough to build and boot an
-entire Linux From Scratch distro under itself**, and it's held to a strict automated bar (2481+
-tests, conformance vs `bash --posix`, ASan/leak-clean, norm). See
+entire Linux From Scratch distro under itself**, and it's held to a strict automated bar (4248
+golden cases diffed against a pinned bash 5.3.9, conformance suites, ASan/leak-clean on two
+allocators, norm). See **[Benchmarks](benchmarks.md)** and
 **[Performance & Robustness](performance.md)**.
 
 ---
 
 ## Install
 
-**One-liner (Linux x86-64):**
+**One-liner (Linux x86-64)** — detects whether you have sudo rights and routes
+itself: with sudo it installs to `/usr/bin` and registers hellish as your login
+shell (the `make my_shell` path); without sudo — a 42 school machine, a shared
+box — it installs to `~/.local/bin` with an rc hook (the `make user-install`
+path). It also offers to set up the plugin framework and lets you pick plugins:
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Univers42/hellish/main/install.sh | sh
 ```
+
+Non-interactive (scripts, CI): `sh install.sh --yes --plugins=all` (or
+`--plugins=none`, `--plugins="git jump z"`, `--user`, `--system`).
+
+**From a source checkout:**
+
+```sh
+git clone --recursive https://github.com/Univers42/hellish && cd hellish
+make OPT=1 all && ./build/bin/hellish    # just run it
+make user-install                        # no sudo: ~/.local/bin + rc hook
+make my_shell                            # sudo: /usr/bin + login shell
+```
+
+`--recursive` matters — hellish pulls in two submodules (`vendor/libft`,
+`vendor/scripts`). Forgot it? `git submodule update --init --recursive`.
 
 **npm / pnpm / yarn:**
 ```sh
 npm install -g hellish-shell      # or: pnpm add -g hellish-shell
 ```
 
-**Docker:**
+**Docker (easiest way to try it):**
 ```sh
 docker run --rm -it dlesieur/hellish-shell
 ```
 
-**From source:**
+Prefer to build from source in a clean container? Every supported platform has
+a rung — glibc and musl, gcc and clang, five package managers:
+
+| | rungs |
+|---|---|
+| glibc | `ubuntu` (24.04), `ubuntu2204`, `debian`, `arch`, `fedora`, `rocky`, `opensuse`, `void` |
+| musl | `alpine`, `alpine-clang`, `alpine-ftmalloc` |
+| compilers | gcc (11 → current) and clang, on both libcs, `-Werror` throughout |
+| architectures | x86_64 and arm64 (native runner in CI) |
+
 ```sh
-git clone --recursive https://github.com/Univers42/hellish && cd hellish
-make OPT=1 all && ./build/bin/hellish
+docker compose run --rm alpine     # interactive hellish on Alpine/musl
+make docker-test                   # build + run the portability smoke on ALL of them
 ```
 
-After install, hellish checks for newer releases in the background and can self-update with
-`update --now`. Opt out via `HELLISH_NO_UPDATE_CHECK=1`.
+macOS and WSL are covered by the `Platforms` workflow rather than Docker; both
+are **informational** today — see [platforms.md](platforms.md).
+
+**Updates.** Once installed, hellish checks for newer releases in the
+background (once a day, in a detached child — a dead release server costs your
+prompt nothing). A pending release is announced once in the welcome panel and
+sits as a quiet `⬆x.y.z` badge in the prompt until you update. `update` checks
+on demand, `update --now` self-updates. Knobs: `HELLISH_BANNER=0|1`,
+`HELLISH_NO_UPDATE_CHECK=1`.
 
 ---
 
 ## Roadmap
 
-**This cycle (4 weeks, UX-first):**
-1. **Week 1 — Interactive UX:** syntax highlighting + autosuggestions + completion polish. → [details](interactive.md)
-2. **Weeks 2–3 — Scripting:** indexed arrays (`declare -a`, `${a[@]}`, …) + crash-hardening + correct `set -e` in pipelines. → [details](scripting.md)
-3. **Week 4 — Performance + release:** script-mode startup (narrow the dash gap), rigorous benchmarks, a tagged release. → [details](performance.md)
+**Shipped since this page was first written** (the previous roadmap, in full):
+indexed *and* associative arrays, `${v/pat/repl}`, `extglob`,
+`mapfile`/`readarray`, namerefs, `coproc`, the zsh dialect + plugin corpus,
+programmable completion at TAB, the zsh prompt language, and the ZLE widget
+layer. See [RELEASE.md](https://github.com/Univers42/hellish/blob/main/RELEASE.md).
 
-**Beyond:**
-- Associative arrays (`declare -A`).
-- A native line editor (replacing readline) for fully native highlighting/autosuggest/completion menus.
-- `extglob`, `mapfile`/`readarray`, namerefs, `coproc`, `${v/pat/repl}`.
+**Still ahead:**
+- Syntax highlighting + autosuggestions at the prompt. → [details](interactive.md)
+- bash-completion framework support (incremental lexing vs `shopt -s extglob`) —
+  the thing that flips `progcomp` on by default.
+- A native line editor (replacing readline) for fully native
+  highlighting/autosuggest/completion menus.
 
 ---
 


### PR DESCRIPTION
## What this is

The documentation and installation overhaul:

- **README** rewritten to the 42 school shape (curriculum line, Description, Instructions, Resources + AI use, Docker technical choices); the 419-line benchmark page moved into `wiki/` (`benchmarks.md`, `architecture.md`) with numbers refreshed. **USER_DOC.md** and **DEV_DOC.md** land at the root.
- **install.sh**: one `curl | sh` for both privilege worlds — detects sudo, routes to the proven drivers (`tools/register_shell.sh` / `user-install.sh`) shipped as an install bundle beside the release binary, asks the plugin questions over `/dev/tty`, and has flags for every question. The plugin backend is [hellishrc_plugins](https://github.com/Univers42/hellishrc_plugins) v1.0.0 (catalog, `hxp install`, never-clobber rc preservation).
- **Docs site**: MkDocs Material over `wiki/` (`mkdocs.yml`, strict links), deployed to GitHub Pages by `docs.yml` on pushes to main.
- **Proof**: `make installer-test` — a docker machine with a sudoer and a no-sudo account, a fake in-container release channel, 25 assertions incl. the interactive path over a real pty. Green locally twice (dev image + full `make` path with fresh static binary and the framework cloned from GitHub); `make my-shell-test` still green; the seed/user-install/login-chain/register-shell suites all pass; `update_config_check` clean; zero C changes.

## Verification
- `make installer-test`: 25 ok, 0 failed
- `make my-shell-test`: 0 checks failed, machine left clean
- `mkdocs build --strict`: clean
- framework suite vs hellish 2.8.0: 94/94, all 13 default plugins loaded