### PR TITLE
chore(release): 2.8.1 -> main

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,35 @@ shows you how to drive the shell.
 
 ---
 
+## v2.8.1 — *the first-prompt release*
+
+A fresh `curl install.sh | sh` with the plugin framework, bash-preexec and z
+enabled greeted its very first prompt with
+`_hx_precmd_run__bp_install: command not found`, a `[1] <pid>` job notice,
+and two whole function bodies dumped over the banner (issue #88). Three
+separate shell bugs stacked into that first impression, each fixed and
+pinned:
+
+- **POSIX character classes in `case` and `${var#…}` patterns** —
+  `[[:space:]]`, `[![:space:]]` and the rest matched *nothing* in the
+  case/trim matcher (filename globs had them all along — a second matcher
+  had drifted). bash-preexec's own PROMPT_COMMAND surgery depends on them.
+  31 new golden cases diff the classes against bash 5.3.9 on every push.
+- **`declare -ft fn` is silent** — `-f` plus an attribute letter applies
+  the attribute in bash; it printed the function bodies here, which is
+  where the dump came from. Measured semantics: silent, 0 when every name
+  is a function, 1 otherwise. Plain `declare -f fn` still prints.
+- **`( cmd & )` no longer announces a job** — bash keeps job control off
+  in subshells, and z backgrounds its bookkeeping exactly that way to stay
+  silent. A top-level `cmd &` still prints its `[n] pid` line.
+
+New regression rig: `tests/fresh_install_test.py` rebuilds the reporting
+machine — the framework's PROMPT_COMMAND convention plus the real upstream
+`bash-preexec.sh` and `z.sh` on a live pty. It fails 5 of its 8 checks
+against v2.8.0 and passes 8/8 here.
+
+---
+
 ## v2.8.0 — *the runs-your-plugins release*
 
 The biggest release since 2.0. The headline: **real third-party plugins now

--- a/incs/case_match.h
+++ b/incs/case_match.h
@@ -25,6 +25,12 @@
 
 bool		case_match(const char *s, const char *p);
 
+/* POSIX classes for the bracket arm (case_match2.c): skip advances past a
+   whole [:name:] (false = unterminated, treat '[' as a member); match
+   tests one character against it and advances the same way. */
+bool		cm_class_skip(const char **q);
+bool		cm_class_match(char c, const char **pp);
+
 /* extglob (case_match_ext*.c): xg_start says a group begins here,
    xg_match matches the group PLUS the rest of the pattern. */
 bool		xg_start(const char *p);

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.8.0"
+# define HELLISH_VERSION "2.8.1"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/builtins/builtin_declare.c
+++ b/src/builtins/builtin_declare.c
@@ -96,6 +96,10 @@ static size_t	declare_scan(t_vec argv, int *flags, char *term)
 			*flags |= 2;
 		if (ft_strchr(((char **)argv.ctx)[i], 'A'))
 			*flags |= 4;
+		if (ft_strchr(((char **)argv.ctx)[i], 't')
+			|| ft_strchr(((char **)argv.ctx)[i], 'r')
+			|| ft_strchr(((char **)argv.ctx)[i], 'g'))
+			*flags |= 8;
 		*term = scan_term(((char **)argv.ctx)[i]);
 		if (*term)
 			return (i);
@@ -111,6 +115,9 @@ int	builtin_declare(t_shell *state, t_vec argv)
 	char	term;
 
 	i = declare_scan(argv, &flags, &term);
+	if ((term == 'F' || term == 'f') && i + 1 < argv.len
+		&& (flags & (2 | 8)) && !(flags & 1))
+		return (declare_func_attrs(state, argv, i + 1));
 	if (term == 'F' || term == 'f')
 		return (declare_functions(state, argv, i + 1, term == 'f'));
 	if (term == 'n')

--- a/src/builtins/builtin_declare4.c
+++ b/src/builtins/builtin_declare4.c
@@ -59,3 +59,26 @@ int	declare_functions(t_shell *state, t_vec argv, size_t i, bool bodies)
 		return (bodies_of(state, argv, i));
 	return (declare_names(state, argv, i));
 }
+
+/* `declare -ft name` (or -fx, -fr, -fg): -f combined with an ATTRIBUTE
+   letter is bash's "apply the attribute to these functions" -- it prints
+   NOTHING and answers 0 when every name is a function, 1 otherwise
+   (measured on the oracle). It used to fall into the print path, so
+   bash-preexec's closing `declare -ft __bp_install ...` dumped both
+   function bodies onto the screen of every fresh install (issue #88).
+   The attributes themselves are accepted and dropped: trace/export
+   semantics for functions are not implemented, and silently succeeding
+   is what bash's own scripts expect from the call. */
+int	declare_func_attrs(t_shell *state, t_vec argv, size_t i)
+{
+	int	rc;
+
+	rc = 0;
+	while (i < argv.len)
+	{
+		if (!func_lookup(state, ((char **)argv.ctx)[i]))
+			rc = 1;
+		i++;
+	}
+	return (rc);
+}

--- a/src/builtins/builtins_private.h
+++ b/src/builtins/builtins_private.h
@@ -344,6 +344,7 @@ int		pretty_show(t_shell *state, bool reusable);
 int		pretty_list(t_shell *state);
 void	glob_opts_sync(t_shell *state);
 
+int		declare_func_attrs(t_shell *state, t_vec argv, size_t i);
 int		declare_functions(t_shell *state, t_vec argv, size_t i,
 			bool bodies);
 

--- a/src/execution/case_match.c
+++ b/src/execution/case_match.c
@@ -37,10 +37,40 @@ static const char	*bracket_close(const char *p)
 	if (*q == ']')
 		q++;
 	while (*q && *q != ']')
-		q++;
+	{
+		if (q[0] == '[' && q[1] == ':')
+			cm_class_skip(&q);
+		else
+			q++;
+	}
 	if (*q == ']')
 		return (q);
 	return (NULL);
+}
+
+/* Walk the members between the (optional) leading ']' and the closing one,
+   accumulating whether `c` matched any: [:class:]es, X-Y ranges, then
+   single characters. Returns where the walk stopped -- the closing ']' or
+   the NUL of an expression bracket_close should have rejected. */
+static const char	*cm_members(char c, const char *p, bool *hit)
+{
+	while (*p && *p != ']')
+	{
+		if (p[0] == '[' && p[1] == ':')
+			*hit = cm_class_match(c, &p) || *hit;
+		else if (p[1] == '-' && p[2] && p[2] != ']')
+		{
+			*hit = *hit || ((unsigned char)c >= (unsigned char)p[0]
+					&& (unsigned char)c <= (unsigned char)p[2]);
+			p += 3;
+		}
+		else
+		{
+			*hit = *hit || (c == *p);
+			p++;
+		}
+	}
+	return (p);
 }
 
 /* Match the single char `c` against a [...] bracket expression starting at
@@ -59,20 +89,7 @@ static bool	match_bracket(char c, const char **pp)
 	p += neg;
 	hit = (*p == ']' && c == ']');
 	p += (*p == ']');
-	while (*p && *p != ']')
-	{
-		if (p[1] == '-' && p[2] && p[2] != ']')
-		{
-			hit = hit || ((unsigned char)c >= (unsigned char)p[0]
-					&& (unsigned char)c <= (unsigned char)p[2]);
-			p += 3;
-		}
-		else
-		{
-			hit = hit || (c == *p);
-			p++;
-		}
-	}
+	p = cm_members(c, p, &hit);
 	*pp = p + (*p == ']');
 	return (hit != neg);
 }

--- a/src/execution/case_match2.c
+++ b/src/execution/case_match2.c
@@ -1,0 +1,112 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   case_match2.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/08/31 23:30:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/08/31 23:30:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "case_match.h"
+#include <ctype.h>
+#include "libft.h"
+
+/* POSIX character classes inside a bracket expression -- [[:space:]] and
+** friends -- for the CASE/trim matcher. Issue #88: this matcher had none,
+** so bash-preexec's own
+**
+**     text="${text#"${text%%[![:space:]]*}"}"
+**
+** silently trimmed every PROMPT_COMMAND to the empty string, and the
+** install string was then appended to the untouched variable with no
+** separator: `_hx_precmd_run__bp_install "$_"` at every prompt of a fresh
+** install. The FILENAME matcher had classes all along (the golden suite
+** pins those at tests/globbing:24), which is exactly the two-matchers
+** drift case_match.h warns about.
+*/
+
+/* The second half of the class table: display/control classes plus bash's
+   own `ascii` and `word`. An unknown name matches nothing, like bash. */
+static bool	cm_class_has2(const char *name, int len, char c)
+{
+	unsigned char	u;
+
+	u = (unsigned char)c;
+	if (len == 5 && !ft_strncmp(name, "punct", 5))
+		return (ispunct(u) != 0);
+	if (len == 5 && !ft_strncmp(name, "print", 5))
+		return (isprint(u) != 0);
+	if (len == 5 && !ft_strncmp(name, "graph", 5))
+		return (isgraph(u) != 0);
+	if (len == 5 && !ft_strncmp(name, "cntrl", 5))
+		return (iscntrl(u) != 0);
+	if (len == 5 && !ft_strncmp(name, "blank", 5))
+		return (c == ' ' || c == '\t');
+	if (len == 5 && !ft_strncmp(name, "ascii", 5))
+		return (u < 128);
+	if (len == 6 && !ft_strncmp(name, "xdigit", 6))
+		return (isxdigit(u) != 0);
+	if (len == 4 && !ft_strncmp(name, "word", 4))
+		return (isalnum(u) || c == '_');
+	return (false);
+}
+
+/* Does character c belong to the class named by name[0..len)? The list is
+   bash's: the twelve POSIX classes plus its own `ascii` and `word`. */
+static bool	cm_class_has(const char *name, int len, char c)
+{
+	unsigned char	u;
+
+	u = (unsigned char)c;
+	if (len == 5 && !ft_strncmp(name, "alpha", 5))
+		return (isalpha(u) != 0);
+	if (len == 5 && !ft_strncmp(name, "digit", 5))
+		return (isdigit(u) != 0);
+	if (len == 5 && !ft_strncmp(name, "alnum", 5))
+		return (isalnum(u) != 0);
+	if (len == 5 && !ft_strncmp(name, "space", 5))
+		return (isspace(u) != 0);
+	if (len == 5 && !ft_strncmp(name, "upper", 5))
+		return (isupper(u) != 0);
+	if (len == 5 && !ft_strncmp(name, "lower", 5))
+		return (islower(u) != 0);
+	return (cm_class_has2(name, len, c));
+}
+
+/* *q points at the '[' of a candidate "[:name:]". Advance past the whole
+   class and return true; an unterminated one is bash's ordinary '[' --
+   advance one character and return false so the caller treats it as a
+   literal member. */
+bool	cm_class_skip(const char **q)
+{
+	const char	*p;
+
+	p = *q + 2;
+	while (*p && !(p[0] == ':' && p[1] == ']'))
+		p++;
+	if (!*p)
+		return ((*q)++, false);
+	*q = p + 2;
+	return (true);
+}
+
+/* Match c against the "[:name:]" at *pp and advance past it. The
+   unterminated case mirrors cm_class_skip: the '[' is an ordinary member,
+   so it matches a literal '[' and only that. */
+bool	cm_class_match(char c, const char **pp)
+{
+	const char	*name;
+	const char	*p;
+
+	name = *pp + 2;
+	p = name;
+	while (*p && !(p[0] == ':' && p[1] == ']'))
+		p++;
+	if (!*p)
+		return ((*pp)++, c == '[');
+	*pp = p + 2;
+	return (cm_class_has(name, p - name, c));
+}

--- a/src/platform/posix/execute_coproc.c
+++ b/src/platform/posix/execute_coproc.c
@@ -90,7 +90,7 @@ static void	coproc_parent(t_shell *state, t_ast_node *node, int *fds,
 	xfree(name);
 	state->bg_job_count++;
 	job = job_add(&state->job_table, pid, "coproc", true);
-	if (state->metinp == INP_RL && job)
+	if (state->metinp == INP_RL && getpid() == state->shell_pid && job)
 		ft_printf("[%d] %d\n", job->id, pid);
 }
 

--- a/src/platform/posix/execute_range_bg.c
+++ b/src/platform/posix/execute_range_bg.c
@@ -163,9 +163,13 @@ static void	bg_job_label(t_shell *state, t_ast_node *node, char *buf,
 
 /* Fork a background job, register it in the job table (this is what makes
    jobs/fg/bg/kill %1 see it), record $! (last_bg_pid), and print
-   "[id] pid" if running interactively.  The parent always returns status
-   0 immediately (background jobs never block the parent).  bg_job_count
-   still gates reap_background_children's waitpid call. */
+   "[id] pid" if running interactively -- AND only in the original shell
+   process (the shell_pid check): bash keeps job control off in subshells,
+   so `( cmd & )` -- the exact spelling z.sh uses to background its
+   bookkeeping silently -- must not announce a job number. It did, and a
+   fresh install printed "[1] <pid>" above every prompt (issue #88).  The
+   parent always returns status 0 immediately (background jobs never block
+   the parent).  bg_job_count still gates reap_background_children. */
 t_execution_state	execute_range_background(t_shell *state,
 										t_executable_node *exe,
 										size_t start, size_t end)
@@ -186,9 +190,9 @@ t_execution_state	execute_range_background(t_shell *state,
 	bg_job_label(state, (t_ast_node *)exe->node->children.ctx + start,
 		label, sizeof(label));
 	job = job_add(&state->job_table, pid, label, true);
-	if (state->metinp == INP_RL && job)
+	if (state->metinp == INP_RL && getpid() == state->shell_pid && job)
 		ft_printf("[%d] %d\n", job->id, pid);
-	else if (state->metinp == INP_RL)
+	else if (state->metinp == INP_RL && getpid() == state->shell_pid)
 		ft_printf("[%d] %d\n", state->bg_job_count, pid);
 	return (res_status(0));
 }

--- a/tests/fresh_install_test.py
+++ b/tests/fresh_install_test.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Regression test: the FRESH INSTALL boots clean -- issue #88.
+
+A brand-new machine, `curl install.sh | sh`, the plugin framework enabled
+with bash-preexec and z -- and every prompt printed
+
+    hellish: _hx_precmd_run__bp_install: command not found
+    [1] 77646
+
+plus two whole function bodies dumped over the banner. Three separate
+shell bugs stacked into one first impression:
+
+  1. the case/trim matcher had no POSIX character classes, so
+     bash-preexec's `${text#"${text%%[![:space:]]*}"}` trimmed every
+     PROMPT_COMMAND to "", and its install string was appended to the
+     UNtrimmed variable with no separator -- the mashed name above;
+  2. `declare -ft fn` fell into the print path instead of silently
+     applying the trace attribute, so bash-preexec's closing line dumped
+     __bp_install and __bp_hook_preexec_into_debug onto the screen;
+  3. `( cmd & )` announced "[1] pid" from inside a subshell -- the exact
+     spelling z.sh uses to keep its bookkeeping SILENT; bash keeps job
+     control off in subshells.
+
+This test rebuilds that machine: a framework-shaped rc (the same
+PROMPT_COMMAND='_hx_precmd_run' convention hellishrc_plugins ships)
+sourcing the REAL upstream bash-preexec.sh and z.sh, on a real pty. It
+shares the plugin corpus's download cache and its philosophy: vendors
+nothing, and the network-dependent half SKIPS cleanly when offline. The
+three underlying bugs also have offline coverage: the golden category
+tests/pattern_class pins 1 and 2 against the bash oracle, and the
+subshell-silence check below needs no network at all.
+
+Usage: python3 fresh_install_test.py [/path/to/hellish]
+"""
+import os
+import pty
+import re
+import select
+import shutil
+import sys
+import tempfile
+import time
+import urllib.request
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else os.path.join(ROOT, "build", "bin", "hellish"))
+CACHE = os.environ.get(
+    "PLUGIN_CACHE",
+    os.path.join(os.environ.get("XDG_CACHE_HOME",
+                                os.path.expanduser("~/.cache")),
+                 "hellish-plugin-corpus"))
+OFFLINE = os.environ.get("OFFLINE", "") not in ("", "0")
+FAILS = []
+
+PLUGINS = [
+    ("bash-preexec.sh", "https://raw.githubusercontent.com/rcaloras/"
+     "bash-preexec/master/bash-preexec.sh"),
+    ("z.sh", "https://raw.githubusercontent.com/rupa/z/master/z.sh"),
+]
+
+RC = """# the hellishrc_plugins loader shape, reduced to what issue #88 needs
+HX_PRECMD_FUNCS=""
+hx_precmd_add() { HX_PRECMD_FUNCS="$HX_PRECMD_FUNCS $1"; }
+_hx_precmd_run() {
+    local f
+    for f in $HX_PRECMD_FUNCS; do
+        command -v "$f" >/dev/null 2>&1 && "$f"
+    done
+    return 0
+}
+PROMPT_COMMAND='_hx_precmd_run'
+PS1='FRESH$ '
+. "$HOME/plugins/bash-preexec.sh"
+. "$HOME/plugins/z.sh"
+"""
+
+
+def check(name, ok, detail=""):
+    print("  %s %s" % ("\033[32mok\033[0m  " if ok else "\033[31mFAIL\033[0m",
+                       name), flush=True)
+    if not ok:
+        if detail:
+            print("       %s" % detail.replace("\n", "\n       "))
+        FAILS.append(name)
+
+
+def fetch(name, url):
+    os.makedirs(CACHE, exist_ok=True)
+    path = os.path.join(CACHE, name)
+    if os.path.isfile(path) and os.path.getsize(path) > 0:
+        return path
+    if OFFLINE:
+        return None
+    try:
+        with urllib.request.urlopen(url, timeout=20) as r:
+            data = r.read()
+        with open(path, "wb") as f:
+            f.write(data)
+        return path
+    except OSError:
+        return None
+
+
+def session(home, cmds, settle=1.2):
+    env = {"HOME": home, "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+           "TERM": "dumb", "LANG": "C.UTF-8", "HELLISH_NO_BANNER": "1",
+           "HELLISH_NO_ANIM": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+           "ASAN_OPTIONS": "detect_leaks=0"}
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.chdir(home)
+        os.environ.clear()
+        os.environ.update(env)
+        os.execv(SHELL, [SHELL, "-i"])
+        os._exit(127)
+    out = b""
+
+    def drain(t):
+        nonlocal out
+        end = time.time() + t
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.15)
+            if not r:
+                continue
+            try:
+                d = os.read(fd, 65536)
+            except OSError:
+                return
+            if not d:
+                return
+            out += d
+
+    drain(3.0)
+    for c in cmds:
+        os.write(fd, c + b"\n")
+        drain(settle)
+    os.write(fd, b"exit\n")
+    drain(0.5)
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+    try:
+        os.waitpid(pid, 0)
+    except ChildProcessError:
+        pass
+    return out.decode("utf-8", "replace")
+
+
+def main():
+    if not os.path.isfile(SHELL):
+        print("error: no shell at %s -- run make" % SHELL)
+        sys.exit(2)
+
+    # The no-network half: the subshell-silence bug on its own.
+    print("\n\033[1;36m▸\033[0m \033[1msubshell background job is silent"
+          "\033[0m")
+    home = tempfile.mkdtemp(prefix="fresh88-")
+    open(os.path.join(home, ".hellishrc"), "w").write("PS1='BARE$ '\n")
+    out = session(home, [b"( sleep 0.1 & ); echo SUBDONE",
+                         b"sleep 20 & echo TOPDONE", b"kill %1"])
+    check("( cmd & ) announces no job", not re.search(
+        r"^\[\d+\] \d+", out.split("TOPDONE")[0], re.M), out[-300:])
+    check("a top-level & still announces its job",
+          re.search(r"\[\d+\] \d+", out) is not None, out[-300:])
+    shutil.rmtree(home, ignore_errors=True)
+
+    # The full machine. Real upstream plugins, cached like the corpus.
+    files = [fetch(n, u) for n, u in PLUGINS]
+    if not all(files):
+        print("\n  \033[33m~\033[0m skipped: bash-preexec/z not cached and "
+              "no network -- the golden category tests/pattern_class still "
+              "covers the underlying bugs")
+        print("\n%d checks failed" % len(FAILS))
+        sys.exit(1 if FAILS else 0)
+
+    print("\n\033[1;36m▸\033[0m \033[1mthe #88 machine: framework rc + "
+          "bash-preexec + z\033[0m")
+    home = tempfile.mkdtemp(prefix="fresh88-")
+    os.makedirs(os.path.join(home, "plugins"))
+    for f in files:
+        shutil.copy2(f, os.path.join(home, "plugins"))
+    open(os.path.join(home, ".hellishrc"), "w").write(RC)
+    out = session(home, [b"echo E2E-ALIVE",
+                         b"printf '<%s>' \"$PROMPT_COMMAND\"",
+                         b"cd /tmp", b"cd -"])
+
+    check("no 'command not found' from the prompt hook",
+          "command not found" not in out, out[-500:])
+    check("no job number announced at any prompt",
+          not re.search(r"^\[\d+\] \d+", out, re.M), out[-500:])
+    check("no function body dumped on the screen",
+          "lastexit" not in out and "__bp_adjust_histcontrol" not in out,
+          out[:600])
+    check("the shell still runs commands", "E2E-ALIVE" in out, out[-300:])
+    check("bash-preexec really installed itself",
+          "__bp_precmd_invoke_cmd" in out,
+          "PROMPT_COMMAND never got the hook:\n" + out[-400:])
+    check("the hooks are separated, not concatenated",
+          "_hx_precmd_run__bp" not in out, out[-400:])
+    shutil.rmtree(home, ignore_errors=True)
+
+    print("\n%d checks failed" % len(FAILS))
+    sys.exit(1 if FAILS else 0)
+
+
+main()

--- a/tests/pattern_class
+++ b/tests/pattern_class
@@ -1,0 +1,31 @@
+case a in [[:alpha:]]) echo M;; *) echo n;; esac
+case " " in [[:space:]]) echo M;; *) echo n;; esac
+case 5 in [[:digit:]]) echo M;; *) echo n;; esac
+case a in [![:digit:]]) echo M;; *) echo n;; esac
+case 5 in [![:digit:]]) echo M;; *) echo n;; esac
+case a in [[:alpha:]x]) echo M;; *) echo n;; esac
+case x in [[:digit:]x]) echo M;; *) echo n;; esac
+case a in [x[:alpha:]]) echo M;; *) echo n;; esac
+case _ in [[:alnum:]_]) echo M;; *) echo n;; esac
+case B in [[:upper:]]) echo M;; *) echo n;; esac
+case b in [[:upper:]]) echo M;; *) echo n;; esac
+case 7 in [[:xdigit:]]) echo M;; *) echo n;; esac
+case g in [[:xdigit:]]) echo M;; *) echo n;; esac
+case - in [[:alpha:]-]) echo M;; *) echo n;; esac
+case ! in [[:punct:]]) echo M;; *) echo n;; esac
+s=" hi"; echo "[${s#[[:space:]]}]"
+s="hi "; echo "[${s%[[:space:]]}]"
+s="Xhi"; echo "[${s#[![:space:]]}]"
+s="_hx_run"; echo "[${s%%[![:space:]]*}]"
+s="  lead"; echo "[${s#"${s%%[![:space:]]*}"}]"
+s="trail  "; echo "[${s%"${s##*[![:space:]]}"}]"
+v="a b c"; echo "${v//[[:space:]]/_}"
+v="tab	sep"; echo "${v/[[:blank:]]/-}"
+s="abc123"; echo "[${s%%[[:digit:]]*}]"
+s="abc123"; echo "[${s##[[:alpha:]]}]"
+f() { :; }; declare -ft f; echo "rc=$?"
+f() { :; }; declare -fx f; echo "rc=$?"
+declare -ft no_such_fn_xyz; echo "rc=$?"; unset -f no_such_fn_xyz
+f() { :; }; g() { :; }; declare -ft f g; echo "rc=$?"
+f() { :; }; declare -ft f no_such_fn_xyz; echo "rc=$?"
+f() { echo body; }; declare -ft f; f

--- a/tests/tester
+++ b/tests/tester
@@ -36,7 +36,7 @@ if [[ ${#test_lists[@]} -eq 0 ]]; then
         "builtins" "compound" "crazy2" "var" "pipe" "sq" "dq" "redir"
         "pipes" "redirects" "extras" "echo_edge_cases" "advanced_edge_cases"
         "regress_hellish" "regress_combos" "cd_posix" "torture"
-        "alias_posix" "builtins_posix" "cmd_not_found_handle"
+        "alias_posix" "builtins_posix" "cmd_not_found_handle" "pattern_class"
         "issue12_export" "issue14_dollar0"
         "issue15_colon_question" "issue11_cmdsub_brace"
         "issue8_set_options"

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -5,7 +5,7 @@ later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**. Released version: **2.8.0**.
+Branch to resume from: **`develop`**. Released version: **2.8.1**.
 
 The previous note on this file covered the issue-fixing session (#27, #32,
 #34, #42 and friends). All of those are closed; the tracker is empty. This


### PR DESCRIPTION
The #88 fix (fresh-install first prompt: pattern classes in case/trim, silent declare -ft, no job notice from subshells) plus the 2.8.1 bump. CI green on develop via #89; full verification record there and on the closed issue #88.