### PR TITLE
fix: linear-time script parsing (#101/#102) and empty-env exit SEGV (#98), detectors first

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,45 @@ shows you how to drive the shell.
 
 ---
 
+## v2.8.4 — *the fast-scripts release*
+
+Two field reports, one performance audit — and permanent detectors for
+all of it:
+
+- **Script files parse in linear time (#101, #102):** a script that is
+  one large compound command — a monolithic rc whose whole body is a
+  single `if`/`else`, like hellishrc_plugins' theme file — parsed in
+  O(n²): the batch reader only batched a cycle's *first* delivery, so one
+  hazard byte (the word "alias" in a comment sufficed) pushed the whole
+  remaining body onto the line-at-a-time path, and every appended line
+  re-lexed and re-parsed everything before it. 2242 real rc lines took
+  **5 seconds** where bash takes 7 ms — while *sourcing the same bytes*
+  took 14 ms, which is why nobody's startup felt slow. Continuation
+  rounds now batch too (heredoc cycles keep the exact line path, and a
+  failed batch still rewinds to the line-exact replay), taking that file
+  to **~15 ms**. This also resolves the audit's mystery of why repeating
+  a fragment was fast but the real file was slow: repetition makes many
+  *small* compounds, the real rc is one *large* one.
+  `tests/parse_scaling_test.py` now pins the shape — t(4N) must stay
+  near-linear over t(N) across the file, pipe, and monolith paths.
+- **`exit` with no `$HOME` no longer segfaults (#98):** with a
+  near-empty environment (`env -i`, some display managers, containers)
+  the history vector was never initialised, and its zero stride made
+  every append grow a phantom entry — the dedup check and the exit
+  teardown then read wild pointers. The vector is now valid before the
+  history file is even looked for. `tests/empty_env_test.py` sweeps the
+  whole class: bare exit, dedup, `history` builtins, `cd`/`~` with no
+  HOME, a HOME that doesn't exist, piped and `-c` runs, and PATH-less
+  absolute execution.
+- **The performance audit (#102)** found the rest healthy: startup is
+  the fastest of dash/bash/hellish (0.33 ms/spawn), execution beats bash
+  on most microbenchmarks, and hellish is the only one of the three that
+  doesn't fork for an all-builtin `$( )`. The one loss (`case` at scale)
+  is the static-musl build flavor, not the algorithm — the glibc build
+  beats bash on the same test.
+
+---
+
 ## v2.8.3 — *the four-bug-reports release*
 
 Four field reports, four root causes, and a detector for each so none of

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.8.3"
+# define HELLISH_VERSION "2.8.4"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/infrastructure/history_utils.c
+++ b/src/infrastructure/history_utils.c
@@ -110,12 +110,24 @@ bool	worthy_of_being_remembered(t_shell *state)
 /* First-time history setup: zero the struct, open the file, load and cap the
    entries, and leave append_fd open for incremental writes.
 
+   The hist_cmds vector is made valid BEFORE parse_history_file runs, because
+   every early return in there (no HOME, unopenable file) used to leave the
+   zeroed struct as-is -- and a t_vec with elem_size 0 is a trap, not an empty
+   vector: vec_push memcpys 0 bytes but still bumps len, so the first command
+   grew a phantom entry and both the dedup check and the exit teardown then
+   read 8-byte pointers out of a zero-stride buffer (issue #98, a SEGV the
+   moment `exit` was typed under `env -i`). The success path replaces this
+   empty vector wholesale (parse_hist_file builds its own), which is fine:
+   nothing was allocated yet.
+
    readmark/appended start at what was just loaded: those entries are
    already both read and on disk, so a later `history -n` must not import
    them a second time and `history -a` must not re-append them. */
 void	init_history(t_shell *state)
 {
 	state->hist = (t_history){.append_fd = -1, .hist_active = true};
+	vec_init(&state->hist.hist_cmds);
+	state->hist.hist_cmds.elem_size = sizeof(char *);
 	parse_history_file(state);
 	state->hist.readmark = state->hist.hist_cmds.len;
 	state->hist.appended = state->hist.hist_cmds.len;

--- a/src/infrastructure/rl_multi_line2.c
+++ b/src/infrastructure/rl_multi_line2.c
@@ -102,22 +102,39 @@ void	begin_cycle(t_shell *state, t_string *ret)
 	state->rl.ln_ptr = NULL;
 }
 
-/* Deliver every complete hazard-free line in one go. Only the FIRST
-   delivery of a cycle may batch: continuation rounds go line-by-line so a
-   command executed mid-construct (an alias definition pulled in whole by
-   round one) can never leak later lines into its own cycle. A cursor
-   below exact_until means a failed batched cycle was rewound for exact
-   replay — keep serving single lines until past the failure point. Line
-   accounting must match per-line delivery: bump rl.line once per newline
-   and refresh the "script: line N" error context once. Returns 4 (data
-   delivered) or 0 (caller must use the single-line path). */
+/* Deliver every complete hazard-free line in one go. Continuation rounds
+   (ret->len != 0: the parser wants more of an incomplete construct) batch
+   too — refusing them made a compound command that trips ONE hazard byte
+   go line-by-line for its whole remaining body, and every appended line
+   re-lexed and re-parsed the accumulated construct: O(n²), five seconds
+   for a 2242-line monolithic rc that bash parses in 7ms (issue #101).
+   The hazard scan still clips every span, so no batch ever contains
+   alias/source/heredoc/backslash-newline text, and a cycle whose input
+   already holds a heredoc operator (cycle_has_hd, set by the previous
+   parse attempt of this same cycle) keeps the exact line path: inline
+   heredoc bodies are the one construct whose CONSUMPTION depends on
+   delivery granularity. cycle_has_hd lags by one parse attempt, so the
+   raw accumulated input is scanned as well: a << delivered by the
+   single-line hazard path can precede the cycle's first parse (an open
+   quote keeps the tokenizer asking before the parser ever runs), and
+   that round must not batch either. A failed batched cycle is still
+   rewound and
+   replayed line-exact (try_replay_exact), so batching stays a pure
+   optimization layer over the always-correct single-line path. A cursor
+   below exact_until means such a replay is in progress — keep serving
+   single lines until past the failure point. Line accounting must match
+   per-line delivery: bump rl.line once per newline and refresh the
+   "script: line N" error context once. Returns 4 (data delivered) or 0
+   (caller must use the single-line path). */
 int	return_batch(t_shell *state, t_string *ret)
 {
 	t_rl	*l;
 	size_t	span;
 
 	l = &state->rl;
-	if (!l->has_line || !l->buff.ctx || l->line_exact || ret->len != 0
+	if (!l->has_line || !l->buff.ctx || l->line_exact
+		|| (ret->len != 0 && (state->cycle_has_hd
+				|| ft_strnstr((char *)ret->ctx, "<<", ret->len) != NULL))
 		|| l->cursor < l->exact_until)
 		return (0);
 	span = batch_span(l);

--- a/tests/empty_env_test.py
+++ b/tests/empty_env_test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Minimal-environment robustness (issue #98).
+
+A login shell genuinely meets near-empty environments: display managers,
+`env -i` wrappers, containers, sshd with a stripped config. hellish 2.8.3
+segfaulted the moment `exit` was typed in an `env -i TERM=xterm` pty:
+with no HOME, parse_history_file() returns before installing the
+hist_cmds vector, leaving elem_size 0 -- vec_push then grows len while
+storing nothing, and both the history dedup (strlen through a garbage
+pointer) and the exit teardown (free of a wild pointer) walk off the
+zero-stride buffer.
+
+This sweeps the whole class, not just the reported crash:
+  pty sessions with no HOME/PATH/USER/SHELL:
+    1. bare `exit` as the first command      (the reported SEGV)
+    2. commands + duplicate, then exit        (the dedup read path)
+    3. `history` listing, then exit
+    4. history -s / -c mutation, then exit
+    5. cd + `echo ~` with no HOME, then exit  (must not crash; cd errors)
+    6. HOME set to a nonexistent dir          (history file open fails)
+  non-interactive, same env:
+    7. hellish -c 'echo ok'
+    8. piped stdin
+    9. absolute-path exec with no PATH at all
+
+Every session must exit 0 with its marker in the transcript, die on no
+signal, and print no sanitizer report.
+
+Usage: python3 empty_env_test.py [/path/to/hellish]
+"""
+import os
+import pty
+import select
+import subprocess
+import sys
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else os.path.join(ROOT, "build", "bin", "hellish"))
+FAILS = []
+
+BASE_ENV = {
+    "TERM": "xterm",
+    "HELLISH_BANNER": "0",
+    "HELLISH_NO_ANIM": "1",
+    "HELLISH_NO_UPDATE_CHECK": "1",
+}
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name
+          + ("  " + detail if not ok else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def pty_session(cmds, env):
+    """Run an interactive session under `env` only, sending each command
+    in order and `exit` last. Returns (transcript, wait status)."""
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.execve(SHELL, [SHELL, "--norc"], env)
+        os._exit(127)
+    time.sleep(0.6)
+    for c in cmds + ["exit"]:
+        os.write(fd, c.encode() + b"\r")
+        time.sleep(0.3)
+    out = b""
+    deadline = time.time() + 8
+    status = None
+    while time.time() < deadline:
+        r, _, _ = select.select([fd], [], [], 0.3)
+        if r:
+            try:
+                d = os.read(fd, 65536)
+            except OSError:
+                break
+            if not d:
+                break
+            out += d
+        else:
+            wpid, st = os.waitpid(pid, os.WNOHANG)
+            if wpid:
+                status = st
+                break
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+    if status is None:
+        _, status = os.waitpid(pid, 0)
+    return out.decode("utf-8", "replace"), status
+
+
+def session_check(name, cmds, env=None):
+    e = dict(BASE_ENV)
+    if env:
+        e.update(env)
+    text, st = pty_session(cmds, e)
+    clean = (os.WIFEXITED(st) and os.WEXITSTATUS(st) == 0
+             and "AddressSanitizer" not in text
+             and "Segmentation fault" not in text)
+    detail = "status=%r tail=%r" % (st, text[-300:])
+    check(name, clean, detail)
+    return text
+
+
+def main():
+    session_check("bare exit, no HOME/PATH (the #98 SEGV)", [])
+    t = session_check("dedup path: repeated command then exit",
+                      ["echo m1", "echo m2", "echo m1", "echo DONE-2"])
+    check("dedup session ran its commands", "DONE-2" in t, repr(t[-300:]))
+    session_check("history listing with no HOME", ["history", "echo DONE-3"])
+    session_check("history -s / -c with no HOME",
+                  ["history -s injected", "history", "history -c",
+                   "echo DONE-4"])
+    t = session_check("cd and tilde with no HOME",
+                      ["cd", "echo ~", "echo DONE-5"])
+    check("cd-no-HOME session stayed alive", "DONE-5" in t, repr(t[-300:]))
+    session_check("HOME points at a nonexistent dir",
+                  ["echo DONE-6"], {"HOME": "/nonexistent-hellish-98"})
+
+    p = subprocess.run([SHELL, "-c", "echo nc-ok"], env=dict(BASE_ENV),
+                       capture_output=True, text=True, timeout=60)
+    check("-c under env -i", p.returncode == 0
+          and p.stdout.strip() == "nc-ok", repr((p.returncode, p.stdout)))
+    p = subprocess.run([SHELL], input="echo pipe-ok\n", env=dict(BASE_ENV),
+                       capture_output=True, text=True, timeout=60)
+    check("piped stdin under env -i", p.returncode == 0
+          and p.stdout.strip() == "pipe-ok", repr((p.returncode, p.stdout)))
+    p = subprocess.run([SHELL, "-c", "/bin/echo abs-ok"], env=dict(BASE_ENV),
+                       capture_output=True, text=True, timeout=60)
+    check("absolute-path exec with no PATH", p.returncode == 0
+          and p.stdout.strip() == "abs-ok", repr((p.returncode, p.stdout)))
+
+    if FAILS:
+        print("\n%d FAILED: %s" % (len(FAILS), ", ".join(FAILS)))
+        sys.exit(1)
+    print("\nall clear")
+
+
+main()

--- a/tests/parse_scaling_test.py
+++ b/tests/parse_scaling_test.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Whole-file parse must scale linearly (issue #101).
+
+A script that is one large compound command (a monolithic rc whose whole
+body is a single if/else, like hellishrc_plugins' theme file) parsed in
+O(n^2)+: the batch reader only batched a cycle's FIRST delivery, so once
+the compound tripped one hazard byte (the word "alias" in a comment was
+enough) every remaining line was delivered alone and the accumulated
+construct was re-lexed, re-parsed and re-freed per line. 2000 lines took
+seconds; bash and dash do the same file in ~0ms. `source FILE` was always
+fine -- it hands the parser the whole buffer at once -- which is exactly
+the hidden-superlinearity trap this test pins.
+
+Guards, machine-independent (shape, not absolute speed):
+  1. hazard-compound file, `-n`:  t(4N) must be < RATIO_MAX * t(N),
+     or just plain fast in absolute terms (fast-pass short-circuit).
+  2. same file piped through stdin (the INP_NOTTY 8K-block path).
+  3. a themes-like mix (case/cmdsub bodies + hazard comments sprinkled).
+  4. a 20000-statement linear file stays under a generous absolute cap
+     (catches a catastrophic regression of batching itself).
+
+Usage: python3 parse_scaling_test.py [/path/to/hellish]
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else os.path.join(ROOT, "build", "bin", "hellish"))
+FAILS = []
+
+N_SMALL = 600
+N_BIG = 2400
+RATIO_MAX = 9.0     # linear ~4, quadratic ~16 for a 4x size step
+FAST_PASS = 1.5     # a t(4N) this small cannot be the quadratic path
+ABS_CAP = 120.0     # even the small run must finish inside this
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name
+          + ("  " + detail if not ok else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def hazard_compound(n):
+    """One giant if-compound with a single hazard byte near the top --
+    the minimal shape that forced per-line continuation delivery."""
+    body = "".join("  echo line %d > /dev/null\n" % i for i in range(n))
+    return ("if true; then\n"
+            "  # keep the aliases below in sync\n" + body + "fi\n")
+
+
+def themes_like(n):
+    """The realistic shape: one monolithic if/else whose body mixes case
+    dispatch, command substitution and hazard words in comments."""
+    out = ["if true; then\n"]
+    for i in range(n // 4):
+        if i % 20 == 0:
+            out.append("  # alias table, sourced by the loader\n")
+        out.append('  case "$%d" in a*) x=A ;; *) x=B ;; esac\n' % (i % 10))
+        out.append("  v=$(printf %%s hi)\n")
+        out.append('  p="${PWD##*/}:${HOME:-none}"\n')
+        out.append("  n=$((n + %d))\n" % i)
+    out.append("fi\n")
+    return "".join(out)
+
+
+def timed(args, stdin_path=None, timeout=300):
+    best = None
+    for _ in range(2):
+        t0 = time.monotonic()
+        with open(stdin_path) if stdin_path else open(os.devnull) as f:
+            subprocess.run(args, stdin=f, capture_output=True,
+                           timeout=timeout)
+        dt = time.monotonic() - t0
+        if best is None or dt < best:
+            best = dt
+    return best
+
+
+def write_tmp(text):
+    f = tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False)
+    f.write(text)
+    f.close()
+    return f.name
+
+
+def scaling_check(name, gen, via_stdin=False):
+    small = write_tmp(gen(N_SMALL))
+    big = write_tmp(gen(N_BIG))
+    try:
+        if via_stdin:
+            t1 = timed([SHELL, "-n"], stdin_path=small)
+            t4 = timed([SHELL, "-n"], stdin_path=big)
+        else:
+            t1 = timed([SHELL, "-n", small])
+            t4 = timed([SHELL, "-n", big])
+    except subprocess.TimeoutExpired:
+        check(name, False, "timed out -- parse is grossly superlinear")
+        return
+    finally:
+        os.unlink(small)
+        os.unlink(big)
+    detail = "t(%d)=%.2fs t(%d)=%.2fs ratio=%.1f" % (
+        N_SMALL, t1, N_BIG, t4, t4 / max(t1, 0.005))
+    print("     " + name + ": " + detail)
+    if t4 <= FAST_PASS:
+        check(name, True)
+        return
+    check(name, t1 <= ABS_CAP and t4 / max(t1, 0.02) < RATIO_MAX, detail)
+
+
+def main():
+    scaling_check("hazard compound via -n FILE", hazard_compound)
+    scaling_check("hazard compound via piped stdin", hazard_compound,
+                  via_stdin=True)
+    scaling_check("themes-like monolith via -n FILE", themes_like)
+
+    linear = write_tmp("".join("echo l%d > /dev/null\n" % i
+                               for i in range(20000)))
+    try:
+        t = timed([SHELL, "-n", linear], timeout=120)
+        check("20000-statement linear file under 60s", t < 60.0,
+              "took %.2fs" % t)
+    except subprocess.TimeoutExpired:
+        check("20000-statement linear file under 60s", False, "timed out")
+    finally:
+        os.unlink(linear)
+
+    if FAILS:
+        print("\n%d FAILED: %s" % (len(FAILS), ", ".join(FAILS)))
+        sys.exit(1)
+    print("\nall clear")
+
+
+main()

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -5,7 +5,7 @@ later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**. Released version: **2.8.3**.
+Branch to resume from: **`develop`**. Released version: **2.8.4**.
 
 The previous note on this file covered the issue-fixing session (#27, #32,
 #34, #42 and friends). All of those are closed; the tracker is empty. This


### PR DESCRIPTION
## Summary

Detector-first fixes for the three open reports, plus the v2.8.4 release notes:

- **#101 / #102 — script files parse in linear time.** Continuation rounds of the
  non-interactive batch reader now batch too (`rl_multi_line2.c`): refusing them made a
  script that is one large compound command (a monolithic rc whose body is a single
  if/else) fall to line-at-a-time delivery after the first hazard byte, re-lexing and
  re-parsing the accumulated construct per line — O(n²). The 2242-line theme rc: 5 s →
  ~15 ms (`-n`), bash-class. Heredoc cycles keep the exact line path, and a failed batch
  still rewinds to the line-exact replay, so batching stays a pure optimization layer.
- **#98 — no SEGV on `exit` under `env -i`.** `init_history` now installs a valid
  `hist_cmds` vector before `parse_history_file` can bail (no HOME, unopenable file);
  the zeroed vector's 0 elem_size made `vec_push` grow phantom entries that the dedup
  check and exit teardown then dereferenced.

## Detectors (added first, red before the fixes, green after — permanent via pty-suite glob)

- `tests/parse_scaling_test.py` — machine-independent scaling-shape gate: t(4N)/t(N)
  near-linear across file, piped-stdin, and themes-like-monolith paths + an absolute cap
  on a 20000-statement linear file. Red at ratio ≈ 15 (quadratic) before, ≈ 4 after.
- `tests/empty_env_test.py` — minimal-environment sweep: bare exit, dedup, history
  builtins, cd/~ without HOME, nonexistent HOME, `-c`/pipe/PATH-less runs. 4 of 6 pty
  sessions died with SIGSEGV before, all green after.

Both are glob-discovered, so they run in the required `interactive` (ASan) and
`allocator` (release) CI jobs on every PR with no wiring to forget.

## Verification

- golden suite: 4323/4323 (debug+ASan) and 4323/4323 (`make test-release`)
- `tests/run_scripts.sh`: 109/109 vs bash --posix
- `tests/hard/run.sh`: green
- `make pty-test`: green (including the two new detectors)
- `cd tests && ./verify_alloc.sh`: both heaps identical, zero leaks
- `make plugin-corpus`: matrix unchanged
- `make arena-stress`: green
- `make norm`: passed

Closes #98
Closes #101
Closes #102
