### PR TITLE
fix: the Debian login chain — bash_completion sources cleanly (#105)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,16 @@ jobs:
           echo "clean"
       - name: Shell scripts parse (bash -n, main repo any depth)
         run: |
+          # A script may declare "# bash-n: skip -- <reason>" when it cannot
+          # parse under -n BY DESIGN: a file that arms `shopt -s extglob` at
+          # runtime and then uses extglob patterns fails bash -n in real bash
+          # too (so does /usr/share/bash-completion/bash_completion). The
+          # marker keeps the exemption in the file, next to its reason.
           bad=0
           for f in $(find . -name '*.sh' -not -path '*/vendor/*' -not -path '*/.git/*' -not -path '*/.claude/*' 2>/dev/null); do
             head -1 "$f" | grep -q python && continue
             grep -qE '^[[:space:]]*(import |def |class )' "$f" && continue
+            grep -q '^# bash-n: skip' "$f" && continue
             bash -n "$f" 2>/dev/null || { echo "::error::parse error: $f"; bad=1; }
           done
           [ "$bad" = 0 ] && echo "all .sh parse clean"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,42 @@ shows you how to drive the shell.
 
 ---
 
+## v2.8.5 — *the login-chain release*
+
+One field report — `ssh` into a Debian 13 box printed
+`hellish: syntax error near unexpected token `('` at every login (#105) —
+unravelled into a family of "lexing ahead of execution" bugs, all fixed:
+
+- **`. bash_completion` works.** hellish sets `BASH_VERSION`, so the stock
+  Debian `~/.profile` sources `~/.bashrc`, which sources bash-completion —
+  a file that runs `shopt -s extglob` on line 47 and relies on it ~1800
+  lines down. `exec_string` (eval and the dot builtin) tokenized the whole
+  file before executing any of it, so the option never reached the lexer.
+  Sourced text now flows through hazard-clipped chunks exactly like the
+  main input driver: `shopt`, alias definitions and nested sources take
+  effect for the rest of the same file, on bash's own line-granular terms.
+  Both bash-completion 2.11 (Ubuntu 22.04) and 2.14 (24.04) now load
+  silently, and the plugin corpus row moved from `unsupported` to `loads`.
+- **`shopt` joined the batch hazards**, so the script/file path lexes
+  later lines after a top-level `shopt` executed, matching bash.
+- **Extglob inside `[[ ]]` without `shopt -s extglob`** — bash enables it
+  while parsing and matching the right side of == / != (4.1 semantics);
+  hellish's lexer and matcher now do too, so bash-completion's
+  `[[ $(bind -v) == *+([[:space:]])on* ]]` idiom matches.
+- **`eval -- "text"`** no longer runs `--` as a command;
+  **`complete`** learned the `-e/-g/-j/-s/-u` action letters and installs
+  `complete -D` default specs silently instead of dumping every
+  registration to stdout; **`shopt`** answers real-but-unimplemented bash
+  option names honestly (query/print say off, `-u` succeeds, `-s` refuses
+  loudly) instead of "invalid shell option name".
+
+Detectors, permanent: `tests/login_bashrc_chain_test.py` drives the whole
+profile→bashrc→completion chain in a pty; `tests/scripts/42–44` diff the
+extglob/alias/[[ shapes against bash 5.3.9 byte-for-byte; the corpus now
+*requires* bash-completion to load.
+
+---
+
 ## v2.8.4 — *the fast-scripts release*
 
 Two field reports, one performance audit — and permanent detectors for

--- a/incs/sh_input.h
+++ b/incs/sh_input.h
@@ -42,6 +42,7 @@ typedef enum e_metinp
 # endif
 
 bool	ends_with_bs_nl(t_string s);
+bool	input_hazard_at(const char *s, size_t i, size_t n);
 void	extend_bs(t_shell *state);
 int		get_more_tokens(t_shell *state, char **prompt, t_deque_tok *tt);
 void	parse_and_execute_input(t_shell *state);

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.8.4"
+# define HELLISH_VERSION "2.8.5"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/builtins/builtin_complete.c
+++ b/src/builtins/builtin_complete.c
@@ -101,7 +101,11 @@ static int	comp_print(t_shell *st, t_vec argv, size_t i)
 }
 
 /* complete [-abcdfkv] [-A action] [-W list] [-F func] [-o opt] [-pr] NAME…
-   With no NAME and no -p it prints every spec, like bash. */
+   With no NAME and no -p it prints every spec, like bash — EXCEPT when a
+   default-spec selector (-D/-E/-I) was given: `complete -D -F loader` is
+   how bash-completion installs its lazy loader, names none, and bash sets
+   the default spec silently. Falling into list mode there dumped every
+   registration to stdout at the end of `. bash_completion` (#105). */
 int	builtin_complete(t_shell *state, t_vec argv)
 {
 	t_cmpopt	o;
@@ -115,6 +119,8 @@ int	builtin_complete(t_shell *state, t_vec argv)
 		return (comp_print(state, argv, i));
 	if (o.remove)
 		return (comp_remove(state, argv, i));
+	if (i >= argv.len && o.defsel)
+		return (0);
 	if (i >= argv.len)
 		return (comp_print_all(state), 0);
 	while (i < argv.len)

--- a/src/builtins/builtin_complete3.c
+++ b/src/builtins/builtin_complete3.c
@@ -55,8 +55,8 @@ static int	comp_one_opt(t_shell *st, t_vec argv, size_t i, t_cmpopt *o)
 	if (ft_strcmp(w, "-r") == 0)
 		return (o->remove = true, 0);
 	if (w[1] && !w[2] && ft_strchr("DEI", w[1]))
-		return (0);
-	if (w[1] && !w[2] && ft_strchr("abcdfkv", w[1]))
+		return (o->defsel = true, 0);
+	if (w[1] && !w[2] && ft_strchr("abcdefgjksuv", w[1]))
 		return (o->act = w[1], 0);
 	if (w[1] && !w[2] && ft_strchr("WFoAXPSCG", w[1]))
 		return (comp_val_opt(argv, i, o));

--- a/src/builtins/builtin_dbracket2.c
+++ b/src/builtins/builtin_dbracket2.c
@@ -13,7 +13,26 @@
 #include "builtins_private.h"
 #include "env.h"
 
+#include "ft_glob.h"
+
 bool	case_match(const char *s, const char *p);
+
+/* bash enables extglob while the right side of == / = / != inside [[ ]]
+   is parsed and matched (since 4.1), `shopt -s extglob` or not --
+   bash-completion's _rl_enabled does `[[ $(bind -v) == *+([[:space:]])on* ]]`
+   with nothing armed, and it must match (issue #105). Arm the glob cell
+   for just this match and put it back; `=~` is regex land and untouched. */
+static bool	db_pattern_match(const char *s, const char *p)
+{
+	int		saved;
+	bool	r;
+
+	saved = *glob_extglob_cell();
+	*glob_extglob_cell() = 1;
+	r = case_match(s, p);
+	*glob_extglob_cell() = saved;
+	return (r);
+}
 
 /* Flat [[ ]] primary.  bash semantics: the right side of ==, = and != is
    a PATTERN (the expander escaped its quoted metacharacters, so quoting
@@ -41,9 +60,9 @@ int	db_eval_flat(char **av, int n)
 
 	if (n == 3 && (ft_strcmp(av[1], "==") == 0
 			|| ft_strcmp(av[1], "=") == 0))
-		return (case_match(av[0], av[2]) == false);
+		return (db_pattern_match(av[0], av[2]) == false);
 	if (n == 3 && ft_strcmp(av[1], "!=") == 0)
-		return (case_match(av[0], av[2]) == true);
+		return (db_pattern_match(av[0], av[2]) == true);
 	if (n == 3 && ft_strcmp(av[1], "=~") == 0)
 		return (db_regex_match(av[0], av[2]));
 	r = db_isset(av, n);

--- a/src/builtins/builtin_eval.c
+++ b/src/builtins/builtin_eval.c
@@ -48,15 +48,22 @@ static char	*join_args(t_vec argv, size_t from)
 /* eval: concatenate the arguments (space-separated), then parse and execute
    the resulting string in the current shell context. Must be a builtin for
    the same reason as source: assignments, function definitions, and option
-   changes made inside eval must be visible to the caller. */
+   changes made inside eval must be visible to the caller. A leading `--`
+   is an options terminator, not text: bash-completion 2.14 writes
+   `eval -- "$1=()"` throughout, and joining the -- in made it a command
+   ("--: command not found" at every login, #105). */
 int	builtin_eval(t_shell *state, t_vec argv)
 {
 	char	*joined;
 	int		status;
+	size_t	from;
 
-	if (argv.len < 2)
+	from = 1;
+	if (argv.len > 1 && ft_strcmp(((char **)argv.ctx)[1], "--") == 0)
+		from = 2;
+	if (argv.len <= from)
 		return (0);
-	joined = join_args(argv, 1);
+	joined = join_args(argv, from);
 	status = exec_string(state, joined);
 	xfree(joined);
 	return (status);

--- a/src/builtins/builtin_shopt.c
+++ b/src/builtins/builtin_shopt.c
@@ -85,8 +85,7 @@ static int	shopt_one(t_shell *state, const char *name, char act, int quiet)
 
 	bit = shopt_bit(name);
 	if (bit == 0)
-		return (ft_eprintf("%s: shopt: %s: invalid shell option name\n",
-				state->ctx, name), 1);
+		return (shopt_unknown(state, name, act, quiet));
 	if (act == 's' || act == 'u')
 	{
 		if (act == 's')

--- a/src/builtins/builtin_shopt3.c
+++ b/src/builtins/builtin_shopt3.c
@@ -1,0 +1,66 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_shopt3.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/09/01 18:05:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/09/01 18:05:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins_private.h"
+
+/* Real bash option names hellish implements no behaviour for -- but that
+   scripts legitimately probe. bash_completion runs `shopt -q cdable_vars`
+   and `shopt -u hostcomplete` bare, so answering "invalid shell option
+   name" made `. bash_completion` noisy at every login (#105). */
+static bool	shopt_is_known_unimpl(const char *name)
+{
+	static const char	*tab[] = {"cdable_vars", "checkhash", "checkjobs",
+		"cmdhist", "compat31", "direxpand", "dirspell", "execfail",
+		"expand_aliases", "extdebug", "extquote", "failglob",
+		"force_fignore", "globasciiranges", "globskipdots", "gnu_errfmt",
+		"histreedit", "histverify", "hostcomplete", "huponexit",
+		"inherit_errexit", "interactive_comments", "login_shell",
+		"mailwarn", "no_empty_cmd_completion", "nocasematch",
+		"patsub_replacement", "progcomp_alias", "promptvars",
+		"restricted_shell", "shift_verbose", "sourcepath",
+		"varredir_close", "xpg_echo", NULL};
+	int					i;
+
+	i = 0;
+	while (tab[i] && ft_strcmp(tab[i], name) != 0)
+		i++;
+	return (tab[i] != NULL);
+}
+
+/* The honest answers cost nothing: a query or print says OFF (status 1),
+   `-u` succeeds (turning off what does not run is true), and only `-s`
+   stays loud -- reporting success for a behaviour that will not happen is
+   the #72 anti-pattern this table must never repeat. */
+static int	shopt_unimpl_act(t_shell *state, const char *name, char act,
+				int quiet)
+{
+	if (act == 's')
+		return (ft_eprintf("%s: shopt: %s: not supported\n",
+				state->ctx, name), 1);
+	if (act == 'u')
+		return (0);
+	if (!quiet && act == 'p')
+		ft_printf("shopt -u %s\n", name);
+	else if (!quiet)
+		ft_printf("%-20s\toff\n", name);
+	return (1);
+}
+
+/* Unknown-to-the-bit-table names: the known-but-unimplemented tier first,
+   then bash's invalid-name error. Called by shopt_one. */
+int	shopt_unknown(t_shell *state, const char *name, char act, int quiet)
+{
+	if (shopt_is_known_unimpl(name))
+		return (shopt_unimpl_act(state, name, act, quiet));
+	return (ft_eprintf("%s: shopt: %s: invalid shell option name\n",
+			state->ctx, name), 1);
+}

--- a/src/builtins/builtins_private.h
+++ b/src/builtins/builtins_private.h
@@ -94,6 +94,7 @@ typedef struct s_cmpopt
 	char	act;
 	bool	print;
 	bool	remove;
+	bool	defsel;
 }	t_cmpopt;
 
 typedef struct s_getopts
@@ -320,6 +321,8 @@ typedef struct s_shopt_act
 
 size_t	shopt_flags(t_vec argv, char *act, int *quiet, int *use_o);
 int		shopt_setopt(t_shell *state, t_vec argv, size_t i, t_shopt_act a);
+int		shopt_unknown(t_shell *state, const char *name, char act,
+			int quiet);
 
 /* wait plumbing shared between builtin_proc.c and builtin_proc2.c */
 int		reaped_job_status(t_shell *state, pid_t pid);

--- a/src/execution/exec_string.c
+++ b/src/execution/exec_string.c
@@ -16,18 +16,19 @@
 #include "decomposer.h"
 #include "redir.h"
 
-int		run_parsed(t_shell *state, t_ast_node *ast);
-bool	must_stop(t_shell *state);
 void	report_parse_error(t_shell *state, t_parser *parser, t_deque_tok *tt);
 
-/* Lex `str` once, then parse + execute it one statement at a time (the REPL
-   normally feeds the parser one line at a time). Used by eval, command and the
-   dot/source builtin. `str` must stay valid for the whole call. */
+/* Parse + execute a string one statement at a time. Used by eval, command
+   and the dot/source builtin -- since issue #105 the string reaches the
+   parser in hazard-clipped chunks (exec_string3.c) so statements that
+   change how later text lexes take effect for the rest of the string;
+   run_one_stmt and skip_delimiters below are shared with that chunker's
+   error replay. `str` must stay valid for the whole call. */
 /* Drop any leading newline/semicolon tokens from the token queue before
    the next statement is parsed.  exec_string feeds multiple statements
    from a single token stream, so after each statement the queue may have
    stale statement-separators that would confuse the next parse call. */
-static void	skip_delimiters(t_deque_tok *tt)
+void	skip_delimiters(t_deque_tok *tt)
 {
 	t_tt	t;
 
@@ -54,7 +55,7 @@ static void	skip_delimiters(t_deque_tok *tt)
    about it is the worst possible answer, and it is what every plugin with a
    brace hellish could not parse was getting.  A plain RES_ERR already
    printed its own message during the parse. */
-static int	run_one_stmt(t_shell *state, t_deque_tok *tt, bool *stop)
+int	run_one_stmt(t_shell *state, t_deque_tok *tt, bool *stop)
 {
 	t_parser	parser;
 	t_ast_node	ast;
@@ -77,34 +78,13 @@ static int	run_one_stmt(t_shell *state, t_deque_tok *tt, bool *stop)
 	return (status);
 }
 
-/* Lex `str` once into a token queue, then parse + execute it statement
-   by statement until end-of-tokens or a stop condition.  Clearing
-   func_return at the end prevents a `return` inside eval from propagating
-   out of exec_string into the caller's function frame. */
-static int	exec_string_inner(t_shell *state, char *str)
-{
-	t_deque_tok	tt;
-	int			status;
-	bool		stop;
-
-	tt = (t_deque_tok){0};
-	deque_init(&tt.deqtok, 100, sizeof(t_ltoken));
-	tokenizer(str, &tt);
-	reclassify_keywords(&tt, zsh_mode(state));
-	status = 0;
-	stop = false;
-	skip_delimiters(&tt);
-	while (!stop && ((t_ltoken *)deque_peek(&tt.deqtok))->tt != TT_END)
-		status = run_one_stmt(state, &tt, &stop);
-	state->func_return = 0;
-	xfree(tt.deqtok.buff);
-	return (status);
-}
-
 /* Extract heredoc bodies up front (so they aren't parsed as commands),
    feed them to the heredoc reader via state->hd_src, and run the stripped
    text.  A string without << (or where splitting finds nothing) runs
-   as-is, under whatever hd_src the caller already installed. */
+   as-is, under whatever hd_src the caller already installed. Stripping
+   happens on the RAW text now that alias splicing is per-chunk (#105):
+   bodies are removed before any splice, so alias words inside a heredoc
+   body are never expanded -- which is also what bash does. */
 static int	exec_split_heredocs(t_shell *state, char *str, char **bodies)
 {
 	char	*stripped;
@@ -116,20 +96,32 @@ static int	exec_split_heredocs(t_shell *state, char *str, char **bodies)
 	{
 		state->hd_src = *bodies;
 		state->hd_pos = 0;
-		status = exec_string_inner(state, stripped);
+		status = exec_chunks(state, stripped);
 		xfree(stripped);
 	}
 	else
-		status = exec_string_inner(state, str);
+		status = exec_chunks(state, str);
 	return (status);
 }
 
-/* Alias-expand the line, then execute it, routing any heredoc bodies
-   aside first.  hd_src/hd_pos are saved/restored so nested command
-   substitutions each get their own body stream. */
+/* Execute the string, routing any heredoc bodies aside first.  Alias
+   expansion happens inside exec_chunks, one chunk at a time, so an alias
+   (or shopt, or dialect) set early in the string shapes the rest of it.
+   hd_src/hd_pos are saved/restored so nested command substitutions each
+   get their own body stream.
+
+   The private copy is load-bearing, not defensive fluff: callers pass
+   SHELL STATE as the string -- open_cycle hands over $PROMPT_COMMAND's
+   own env buffer -- and a statement inside can rewrite that variable
+   (bash-preexec's __bp_install does exactly this), freeing the buffer
+   mid-run. The chunker re-reads the source text after every executed
+   statement, so without the copy that free is a use-after-free the
+   fresh-install pty test catches under ASan. The old single-pass code
+   was immune only by accident: its up-front alias splice WAS the copy. */
 int	exec_string(t_shell *state, char *str)
 {
 	char	*bodies;
+	char	*own;
 	char	*prev_src;
 	size_t	prev_pos;
 	int		status;
@@ -137,9 +129,9 @@ int	exec_string(t_shell *state, char *str)
 	prev_src = state->hd_src;
 	prev_pos = state->hd_pos;
 	bodies = NULL;
-	str = alias_scan_line(&state->aliases, str);
-	status = exec_split_heredocs(state, str, &bodies);
-	xfree(str);
+	own = ft_strdup(str);
+	status = exec_split_heredocs(state, own, &bodies);
+	xfree(own);
 	xfree(bodies);
 	state->hd_src = prev_src;
 	state->hd_pos = prev_pos;

--- a/src/execution/exec_string3.c
+++ b/src/execution/exec_string3.c
@@ -1,0 +1,154 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exec_string3.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/09/01 17:20:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/09/01 17:20:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "execution_private.h"
+#include "lexer.h"
+#include "parser.h"
+#include "sh_alias.h"
+#include "sh_input.h"
+
+/* Chunked lex/parse/execute for eval and the dot builtin (issue #105).
+
+   exec_string used to alias-splice and tokenize the WHOLE string before
+   executing any of it, so a statement that changes how later text lexes
+   -- `shopt -s extglob`, an alias definition, a nested source that does
+   either -- had no effect on the rest of the same string. bash reads and
+   runs incrementally, and real files depend on it: bash-completion arms
+   extglob on line 47 and writes extglob case patterns ~1800 lines down,
+   so `. bash_completion` (reached from ~/.bashrc at every login) died
+   with "syntax error near unexpected token `('" on any Debian box.
+
+   The string is now processed in chunks clipped at the same hazard bytes
+   the input driver's batch reader uses (input_hazard_at: alias, source,
+   shopt, `.`, heredocs, backslash-newline), on line boundaries. Each
+   chunk is alias-spliced FRESH from the original text -- a chunk is
+   spliced at most once, so an alias body can never be re-expanded -- and
+   fully parsed before anything in it runs, exactly like one input-driver
+   cycle. Statements after a hazard line therefore lex AFTER it executed.
+   Same-line uses stay unspliced (the hazard line is its own chunk head),
+   matching bash's aliases-apply-from-the-next-line rule.
+
+   A chunk whose parse is incomplete grows by the next span and retries
+   (nothing has executed yet, so the retry is free). A chunk that fails
+   to parse is replayed statement-at-a-time so the healthy prefix still
+   runs before the error is reported, which is bash's observable order.
+   Known residual gap, shared with the batch reader: a lexer-state change
+   hidden from the byte scan (a function body calling shopt, invoked in
+   the same chunk that then uses extglob) still lexes ahead. */
+
+/* Longest hazard-free run of COMPLETE lines starting at off; if a hazard
+   sits in the very first line, that one LOGICAL line -- backslash-newline
+   joins included. Ending a chunk between a trailing `\` and its
+   continuation would hand the parser a truncated command (the tokenizer
+   strips the join, so `echo a \` looks complete and the continuation
+   line becomes a separate statement). The retreat loop cannot land on a
+   joined newline: a backslash-newline is itself a hazard, so the scan
+   already stopped at the first one. */
+static size_t	str_span(const char *s, size_t off, size_t n)
+{
+	size_t	clip;
+
+	clip = off;
+	while (clip < n && !input_hazard_at(s, clip, n))
+		clip++;
+	while (clip > off && s[clip - 1] != '\n')
+		clip--;
+	if (clip > off)
+		return (clip - off);
+	clip = off;
+	while (clip < n && s[clip] != '\n')
+		clip++;
+	while (clip < n && clip > off && s[clip - 1] == '\\')
+	{
+		clip++;
+		while (clip < n && s[clip] != '\n')
+			clip++;
+	}
+	return (clip - off + (clip < n));
+}
+
+/* Parse every statement of the tokenized chunk WITHOUT executing any.
+   Stops at the first non-OK result; only the tail statement can come
+   back RES_GETMOREINPUT (an incomplete construct consumes the queue). */
+static void	parse_all(t_shell *state, t_chunkctx *c)
+{
+	t_ast_node	ast;
+
+	skip_delimiters(&c->tt);
+	while (((t_ltoken *)deque_peek(&c->tt.deqtok))->tt != TT_END)
+	{
+		c->parser.res = RES_OK;
+		c->parser.reported = false;
+		c->parser.parse_stack.len = 0;
+		ast = parse_simple_list(state, &c->parser, &c->tt);
+		vec_push(&c->asts, &ast);
+		if (c->parser.res != RES_OK)
+			return ;
+		skip_delimiters(&c->tt);
+	}
+}
+
+/* Splice, lex and fully parse one chunk of the original text. A lexically
+   incomplete chunk (tokenizer still wants input: open quote, paren) is
+   reported as RES_GETMOREINPUT so the caller grows it like any other
+   incomplete construct. The tokenizer's prompt return is static. */
+static void	chunk_open(t_shell *state, const char *at, size_t len,
+				t_chunkctx *c)
+{
+	char	*more;
+
+	c->chunk = ft_strndup((char *)at, len);
+	c->spliced = alias_scan_line(&state->aliases, c->chunk);
+	c->tt = (t_deque_tok){0};
+	deque_init(&c->tt.deqtok, 100, sizeof(t_ltoken));
+	c->parser = (t_parser){.res = RES_OK};
+	vec_init(&c->parser.parse_stack);
+	c->parser.parse_stack.elem_size = sizeof(int);
+	vec_init(&c->asts);
+	c->asts.elem_size = sizeof(t_ast_node);
+	more = tokenizer(c->spliced, &c->tt);
+	reclassify_keywords(&c->tt, zsh_mode(state));
+	if (more)
+		c->parser.res = RES_GETMOREINPUT;
+	else
+		parse_all(state, c);
+	if (getenv("HELLISH_DBG_CHUNKS"))
+		fprintf(stderr, "[chunk %zu-%zu res=%d]<<<%s>>>\n",
+			c->start, c->end, c->parser.res, c->spliced);
+}
+
+/* Release everything a chunk owns: parsed trees (executed or not), the
+   parser scratch, the token deque, and both text buffers. */
+void	chunk_close(t_chunkctx *c)
+{
+	size_t	i;
+
+	i = 0;
+	while (i < c->asts.len)
+		free_ast((t_ast_node *)c->asts.ctx + i++);
+	xfree(c->asts.ctx);
+	xfree(c->parser.parse_stack.ctx);
+	xfree(c->tt.deqtok.buff);
+	xfree(c->spliced);
+	xfree(c->chunk);
+}
+
+/* Grow the chunk to the next hazard boundary and (re-)open it. Works for
+   the FIRST open too: on a zeroed ctx with start == end, chunk_close only
+   frees NULLs and the span extends from the chunk's start. Nothing of a
+   smaller attempt has executed, so re-parsing from scratch is safe. */
+void	chunk_grow(t_shell *state, const char *s, size_t n, t_chunkctx *c)
+{
+	chunk_close(c);
+	c->end += str_span(s, c->end, n);
+	chunk_open(state, s + c->start, c->end - c->start, c);
+}

--- a/src/execution/exec_string4.c
+++ b/src/execution/exec_string4.c
@@ -1,0 +1,107 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exec_string4.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/09/01 17:25:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/09/01 17:25:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "execution_private.h"
+
+/* The chunk driver half of the #105 fix; the chunk mechanics and the
+   design rationale live in exec_string3.c. */
+
+/* Execute the fully parsed statements of a chunk, in order, stopping on
+   exit/return/errexit/unwind. Freeing is chunk_close's job so even the
+   never-reached tail is reclaimed. */
+static int	run_stmt_list(t_shell *state, t_chunkctx *c, bool *stop)
+{
+	size_t	i;
+	int		status;
+
+	status = 0;
+	i = 0;
+	while (i < c->asts.len && !*stop)
+	{
+		status = run_parsed(state, (t_ast_node *)c->asts.ctx + i);
+		*stop = must_stop(state);
+		i++;
+	}
+	return (status);
+}
+
+/* A chunk that would not parse is replayed statement-at-a-time from its
+   own spliced text: the healthy prefix executes before the error is
+   reported, which is bash's observable order (`eval 'echo ok; ('` prints
+   ok first). Nothing ran before the replay -- the parse-all pass does
+   not execute -- so no statement can run twice. run_one_stmt reports
+   both flavors (hard error, unterminated-at-EOF). The chunk's error ends
+   the whole exec_string, as it always has. */
+static int	replay_chunk(t_shell *state, t_chunkctx *c, bool *stop)
+{
+	t_deque_tok	tt;
+	int			status;
+
+	tt = (t_deque_tok){0};
+	deque_init(&tt.deqtok, 100, sizeof(t_ltoken));
+	tokenizer(c->spliced, &tt);
+	reclassify_keywords(&tt, zsh_mode(state));
+	status = 0;
+	skip_delimiters(&tt);
+	while (!*stop && ((t_ltoken *)deque_peek(&tt.deqtok))->tt != TT_END)
+		status = run_one_stmt(state, &tt, stop);
+	xfree(tt.deqtok.buff);
+	*stop = true;
+	return (status);
+}
+
+/* One chunk, start to finish: open at the next hazard boundary, grow
+   while the construct is incomplete and text remains (nothing executes
+   during growth), then run it -- whole-chunk on success, replay on
+   failure. Advances *off past the chunk either way. */
+static int	run_chunk(t_shell *state, const char *s, size_t *off,
+				bool *stop)
+{
+	t_chunkctx	c;
+	size_t		n;
+	int			status;
+
+	n = ft_strlen(s);
+	c = (t_chunkctx){0};
+	c.start = *off;
+	c.end = *off;
+	chunk_grow(state, s, n, &c);
+	while (c.parser.res == RES_GETMOREINPUT && c.end < n)
+		chunk_grow(state, s, n, &c);
+	if (c.parser.res == RES_OK)
+		status = run_stmt_list(state, &c, stop);
+	else
+		status = replay_chunk(state, &c, stop);
+	chunk_close(&c);
+	*off = c.end;
+	return (status);
+}
+
+/* Drive the whole string chunk by chunk. Clearing func_return at the end
+   keeps a `return` inside eval from leaking into the caller's frame,
+   same contract as the old single-pass loop. */
+int	exec_chunks(t_shell *state, const char *str)
+{
+	size_t	off;
+	size_t	n;
+	int		status;
+	bool	stop;
+
+	off = 0;
+	n = ft_strlen(str);
+	status = 0;
+	stop = false;
+	while (off < n && !stop)
+		status = run_chunk(state, str, &off, &stop);
+	state->func_return = 0;
+	return (status);
+}

--- a/src/execution/execution_private.h
+++ b/src/execution/execution_private.h
@@ -34,6 +34,8 @@
 # include "expander.h"
 # include "sh_input.h"
 # include "executor_types.h"
+# include "lexer.h"
+# include "parser.h"
 
 # define MSG_REDIR_DATA_ERR "%s: internal error: redirects \
 							present but no redirect data\n"
@@ -221,5 +223,31 @@ t_execution_state	execute_brace_group(t_shell *state,
    several names, each brace-expanded. Returns how many were defined. */
 int					zfunc_define_all(t_shell *state, t_token *tok,
 						t_ast_node *body);
+
+/* Chunked exec_string (exec_string3.c / exec_string4.c, issue #105): one
+   in-flight chunk of an eval/source string. [start,end) index the ORIGINAL
+   text; spliced is this chunk's own alias expansion (each chunk is spliced
+   exactly once, so alias bodies are never re-expanded); asts holds the
+   fully parsed statements, executed only when the whole chunk parsed. */
+typedef struct s_chunkctx
+{
+	size_t			start;
+	size_t			end;
+	char			*chunk;
+	char			*spliced;
+	t_deque_tok		tt;
+	t_parser		parser;
+	t_vec			asts;
+}	t_chunkctx;
+
+void				chunk_close(t_chunkctx *c);
+void				chunk_grow(t_shell *state, const char *s, size_t n,
+						t_chunkctx *c);
+int					exec_chunks(t_shell *state, const char *str);
+void				skip_delimiters(t_deque_tok *tt);
+int					run_one_stmt(t_shell *state, t_deque_tok *tt,
+						bool *stop);
+int					run_parsed(t_shell *state, t_ast_node *ast);
+bool				must_stop(t_shell *state);
 
 #endif

--- a/src/infrastructure/rl_multi_line2.c
+++ b/src/infrastructure/rl_multi_line2.c
@@ -22,19 +22,24 @@
    line-at-a-time reading are the ones that can change how LATER lines are
    lexed or consumed: alias/unalias definitions and sourced files (alias
    splicing happens before the lexer), heredocs (bodies must not be parsed
-   as commands), and backslash-newline (line accounting). hazard_at() spots
-   those conservatively — a false positive only means we fall back to the
-   old, always-correct single-line path for that stretch. */
+   as commands), and backslash-newline (line accounting). input_hazard_at()
+   spots those conservatively — a false positive only means we fall back to
+   the old, always-correct single-line path for that stretch. */
 
 /* Every byte of the input passes through here, so the order of the tests is
-   load-bearing, not stylistic. Dispatching on s[i] FIRST turns the two
-   keyword probes from unconditional libc strncmp calls into a byte compare
-   that fails on ~95% of input: a strncmp against "alias" can only succeed
-   where s[i] is already 'a', so the gate is exact, not heuristic. Before it,
+   load-bearing, not stylistic. Dispatching on s[i] FIRST turns the keyword
+   probes from unconditional libc strncmp calls into a byte compare that
+   fails on ~95% of input: a strncmp against "alias" can only succeed where
+   s[i] is already 'a', so the gate is exact, not heuristic. Before it,
    scanning a 2MB script cost ~4M strncmp calls -- 17% of every instruction
    retired during a parse, spent proving that 'x' is not the start of
-   "source". */
-static bool	hazard_at(const char *s, size_t i, size_t n)
+   "source". `shopt` is a hazard for the same reason `alias` is: it can
+   change how LATER text lexes (`shopt -s extglob` arms extglob group
+   tokens), and bash-completion arms it on line 47 then relies on it ~1800
+   lines down -- lexing ahead of that execution broke every Debian login
+   (issue #105). Shared with exec_string's chunker, which needs the same
+   boundaries for the same reason. */
+bool	input_hazard_at(const char *s, size_t i, size_t n)
 {
 	const char	c = s[i];
 
@@ -45,6 +50,8 @@ static bool	hazard_at(const char *s, size_t i, size_t n)
 	if (c == 'a' && n - i >= 5 && ft_strncmp(s + i, "alias", 5) == 0)
 		return (true);
 	if (c == 's' && n - i >= 6 && ft_strncmp(s + i, "source", 6) == 0)
+		return (true);
+	if (c == 's' && n - i >= 5 && ft_strncmp(s + i, "shopt", 5) == 0)
 		return (true);
 	if (c == '.' && (i + 1 == n || s[i + 1] == ' ' || s[i + 1] == '\t')
 		&& (i == 0 || ft_strchr(" \t\n;&|", s[i - 1]) != NULL))
@@ -64,7 +71,7 @@ static size_t	batch_span(t_rl *l)
 	s = (const char *)l->buff.ctx + l->cursor;
 	n = l->buff.len - l->cursor;
 	clip = 0;
-	while (clip < n && !hazard_at(s, clip, n))
+	while (clip < n && !input_hazard_at(s, clip, n))
 		clip++;
 	while (clip > 0 && s[clip - 1] != '\n')
 		clip--;

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -26,15 +26,29 @@ int		extglob_ahead(const char *at);
    the dialect; in bash a leading `=` really is just a word character.
      extglob is the mirror case: `!(a)` and `*(a)` START with characters the
    catch-all would hand to the operator path, so the group has to be spotted
-   here as well as inside parse_lexeme's loop. */
-static char	*try_parse_lexeme(char **str, t_deque_tok *ret)
+   here as well as inside parse_lexeme's loop.
+     Inside [[ ]] the extglob cell is armed for the span of the lexeme:
+   bash recognises extglob groups in conditional operands whether or not
+   `shopt -s extglob` is set (4.1+), so `[[ $x == a@(b|z)c ]]` must lex the
+   group as one word -- unarmed, the group's `|` became a PIPE and the
+   conditional shattered (issue #105; the matcher's half of the same rule
+   is db_pattern_match). */
+static char	*try_parse_lexeme(char **str, t_deque_tok *ret, int in_db)
 {
+	char	*prompt;
+	int		saved;
+
 	if (glob_zsh() && (*str)[0] == '=' && (*str)[1] == '(')
 		return (0);
+	saved = *glob_extglob_cell();
+	if (in_db)
+		*glob_extglob_cell() = 1;
+	prompt = 0;
 	if (**str == '\'' || **str == '"' || **str == '$'
 		|| extglob_ahead(*str) || !(is_word_boundary(*str)))
-		return (parse_lexeme(ret, str));
-	return (0);
+		prompt = parse_lexeme(ret, str);
+	*glob_extglob_cell() = saved;
+	return (prompt);
 }
 
 /* Emit a single TT_NEWLINE token and advance past the '\n'. Newlines are
@@ -78,7 +92,7 @@ char	*tokenize_step(char **str, t_deque_tok *ret, int *in_db)
 		return (NULL);
 	if (**str == '[' || (*in_db && **str == ']'))
 		dbracket_toggle(*str, in_db);
-	prompt = try_parse_lexeme(str, ret);
+	prompt = try_parse_lexeme(str, ret, *in_db);
 	if (prompt)
 		return (prompt);
 	db_track_regex(ret, in_db);

--- a/tests/login_bashrc_chain_test.py
+++ b/tests/login_bashrc_chain_test.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""The Debian login chain (issue #105): hellish as a login shell sources
+/etc/profile -> ~/.profile -> ~/.bashrc -> bash_completion.
+
+hellish sets BASH_VERSION, so the stock Debian ~/.profile sources
+~/.bashrc, which sources /usr/share/bash-completion/bash_completion.
+That file runs `shopt -s extglob` early and uses extglob patterns
+hundreds of lines later — exec_string tokenized the whole file before
+executing anything, so every ssh login printed
+    hellish: syntax error near unexpected token `('
+and aborted ~/.profile before its PATH block ran (=> `claude: command
+not found` for anything living in ~/.local/bin).
+
+This drives the whole chain in a pty against a throwaway HOME with the
+stock Debian .profile/.bashrc shapes and a mini bash_completion carrying
+the trigger constructs. Asserted: no syntax error, the completion file's
+functions exist, the alias chain works, and the PATH block after the
+bashrc sourcing still ran.
+
+Usage: python3 login_bashrc_chain_test.py [/path/to/hellish]
+"""
+import os
+import pty
+import select
+import shutil
+import sys
+import tempfile
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else os.path.join(ROOT, "build", "bin", "hellish"))
+FAILS = []
+
+PROFILE = """\
+if [ -n "$BASH_VERSION" ]; then
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi
+if [ -d "$HOME/.local/bin" ] ; then
+    PATH="$HOME/.local/bin:$PATH"
+fi
+"""
+
+BASHRC = """\
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+HISTCONTROL=ignoreboth
+shopt -s histappend
+shopt -s checkwinsize
+alias ll='ls -alF'
+if ! shopt -oq posix; then
+  if [ -f "$HOME/mini_completion.sh" ]; then
+    . "$HOME/mini_completion.sh"
+  fi
+fi
+"""
+
+# The bash_completion shape: extglob armed on line 2, used far below in
+# case patterns and [[ ]] operands, plus an alias-then-use chain.
+MINI_COMPLETION = """\
+# mini bash_completion: the constructs that broke the real one
+shopt -s extglob
+_mini_rl_enabled()
+{
+    [[ "$(echo 'bell-style  on')" == *+([[:space:]])on* ]]
+}
+""" + "\n".join("# filler line %d" % i for i in range(60)) + """
+_mini_dispatch()
+{
+    case "$1" in
+        -?(\\[)+([a-zA-Z0-9?]))
+            echo "extglob-case-ok" ;;
+        *) : ;;
+    esac
+}
+alias _mini_probe='echo mini-alias-ok'
+_mini_probe
+MINI_COMPLETION_LOADED=1
+"""
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name
+          + ("  " + detail if not ok else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def main():
+    home = tempfile.mkdtemp(prefix="hellish105-")
+    os.mkdir(os.path.join(home, ".local"))
+    os.mkdir(os.path.join(home, ".local", "bin"))
+    for name, body in ((".profile", PROFILE), (".bashrc", BASHRC),
+                       ("mini_completion.sh", MINI_COMPLETION)):
+        with open(os.path.join(home, name), "w") as f:
+            f.write(body)
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        env = {"TERM": "xterm", "HOME": home, "USER": "tester",
+               "LOGNAME": "tester", "PATH": "/usr/bin:/bin",
+               "HELLISH_BANNER": "0", "HELLISH_NO_ANIM": "1",
+               "HELLISH_NO_UPDATE_CHECK": "1"}
+        os.execve(SHELL, ["-hellish", "--norc"], env)
+        os._exit(127)
+    time.sleep(1.0)
+    for c in ('echo "LOADED=[$MINI_COMPLETION_LOADED]"',
+              '_mini_rl_enabled && echo RL-OK',
+              '_mini_dispatch -Word9',
+              'll --version > /dev/null 2>&1; echo "ALIAS-LL=$?"',
+              'case ":$PATH:" in *:"$HOME/.local/bin":*) echo P-OK;; '
+              '*) echo P-MISSING;; esac',
+              'exit'):
+        os.write(fd, c.encode() + b"\r")
+        time.sleep(0.4)
+    out = b""
+    deadline = time.time() + 8
+    while time.time() < deadline:
+        r, _, _ = select.select([fd], [], [], 0.3)
+        if not r:
+            try:
+                wpid, _ = os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                break
+            if wpid:
+                break
+            continue
+        try:
+            d = os.read(fd, 65536)
+        except OSError:
+            break
+        if not d:
+            break
+        out += d
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+    try:
+        os.waitpid(pid, 0)
+    except ChildProcessError:
+        pass
+    text = out.decode("utf-8", "replace")
+    shutil.rmtree(home, ignore_errors=True)
+
+    check("login chain: no syntax error", "syntax error" not in text,
+          repr(text[:400]))
+    check("bash_completion-shape file loaded", "LOADED=[1]" in text,
+          repr(text[-400:]))
+    check("[[ ]] extglob helper works", "RL-OK" in text, repr(text[-400:]))
+    check("extglob case dispatch works", "extglob-case-ok" in text,
+          repr(text[-400:]))
+    check("alias-then-use inside sourced file", "mini-alias-ok" in text,
+          repr(text[-400:]))
+    check(".profile PATH block still ran", "P-OK" in text,
+          repr(text[-400:]))
+    if FAILS:
+        print("\n%d FAILED: %s" % (len(FAILS), ", ".join(FAILS)))
+        sys.exit(1)
+    print("\nall clear")
+
+
+main()

--- a/tests/plugin_corpus_test.py
+++ b/tests/plugin_corpus_test.py
@@ -94,27 +94,20 @@ CORPUS = [
      "bash-preexec.sh", "loads", 15, ""),
     ("z", "https://raw.githubusercontent.com/rupa/z/master/z.sh", "loads", 1,
      ""),
-    # THE ROW THAT HOLDS progcomp's DEFAULT DOWN.
-    #
-    # /etc/profile.d/bash_completion.sh sources this when `shopt -q progcomp`
-    # says yes, so this file failing to parse is exactly why hellish leaves
-    # progcomp off by default while bash turns it on (incs/shell.h). The day
-    # this row can move to `loads`, that default can flip -- which is what a
-    # declared expectation is FOR.
-    #
-    # The blocker is architectural, not a missing feature: exec_string LEXES
-    # a whole sourced file before executing any of it, so `shopt -s extglob`
-    # on line 47 has not run when line 1810's `-?(\[)+([a-zA-Z0-9?]))` case
-    # pattern is tokenised -- and extglob patterns are gated on that option
-    # at lex time. bash reads and runs incrementally, so it has the option by
-    # then. Two real bugs found on the way here DID get fixed (a bare `{`
-    # inside ${...}, and a quoted right-hand side of [[ =~ ]]) and moved the
-    # failure from line 1425 to 1810.
+    # The row that HELD progcomp's default down, promoted to `loads` by
+    # issue #105. The blocker was architectural: exec_string lexed a whole
+    # sourced file before executing any of it, so `shopt -s extglob` on
+    # line 47 had not run when line 1810's `-?(\[)+([a-zA-Z0-9?]))` case
+    # pattern was tokenised -- every ssh login on a Debian box with
+    # bash-completion installed printed "syntax error near unexpected
+    # token `('" and lost the rest of ~/.profile (issue #105). exec_string
+    # now feeds the text through hazard-clipped chunks exactly like the
+    # main input driver, so options, aliases and dialect changes take
+    # effect for later lines of the same sourced file. progcomp's default
+    # (incs/shell.h) can be revisited now that this loads.
     ("bash-completion",
      "https://raw.githubusercontent.com/scop/bash-completion/main/"
-     "bash_completion", "unsupported", 0,
-     "whole-file lexing vs `shopt -s extglob` on line 47: the extglob case "
-     "pattern at line 1810 is tokenised before the option is set"),
+     "bash_completion", "loads", 80, ""),
 ]
 
 
@@ -149,8 +142,14 @@ def fetch(name, url):
 
 
 def run(script, timeout=45):
+    # BASH_COMPLETION_* pinned to nowhere: bash_completion sources every
+    # drop-in under /etc/bash_completion.d and ~/.bash_completion, so
+    # without this the row's verdict depends on what the machine happens
+    # to have installed there, not on the file under test.
     env = dict(os.environ, HELLISH_NO_BANNER="1",
-               HELLISH_NO_UPDATE_CHECK="1", HELLISH_NO_ANIM="1")
+               HELLISH_NO_UPDATE_CHECK="1", HELLISH_NO_ANIM="1",
+               BASH_COMPLETION_COMPAT_DIR="/nonexistent-hellish-corpus",
+               BASH_COMPLETION_USER_FILE="/nonexistent-hellish-corpus")
     try:
         p = subprocess.run([SHELL, "-c", script], capture_output=True,
                            timeout=timeout, env=env)

--- a/tests/scripts/42_shopt_extglob_midfile.sh
+++ b/tests/scripts/42_shopt_extglob_midfile.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# `shopt -s extglob` must arm the lexer for LATER lines of the same input
+# (bash reads and runs incrementally, so line N+1 lexes with whatever
+# line N set). hellish tokenized ahead of execution, and bash-completion
+# arms the option on its line 47 then relies on it ~1800 lines further
+# down: every ssh login on a Debian 13 box died with "syntax error near
+# unexpected token `('" before ~/.profile finished (issue #105).
+# NOTE: the lines above the first case must stay free of batch-hazard
+# words; a stray one would split the batch here and mask the bug.
+shopt -s extglob
+case foo in
+	f@(oo)) echo "case-extglob: matched" ;;
+	*) echo "case-extglob: MISSED" ;;
+esac
+case "ab" in
+	+(a|b)) echo "plus-group: matched" ;;
+	*) echo "plus-group: MISSED" ;;
+esac
+case "zz" in
+	!(a*)) echo "negate-group: matched" ;;
+	*) echo "negate-group: MISSED" ;;
+esac
+
+# The same rule through the dot builtin: the file read there arms the
+# option on ITS first line and uses it below.
+cat > sub_extglob.sh <<'EOF'
+shopt -s extglob
+case "docs" in
+	d?(ocs)) echo "dotted-extglob: matched" ;;
+	*) echo "dotted-extglob: MISSED" ;;
+esac
+EOF
+. ./sub_extglob.sh
+rm -f sub_extglob.sh
+
+# And through eval, across a newline (bash arms it for the eval string's
+# later statements too).
+eval 'shopt -s extglob
+case wow in w@(ow)) echo "eval-extglob: matched" ;; *) echo "eval-extglob: MISSED" ;; esac'

--- a/tests/scripts/42_shopt_extglob_midfile.sh
+++ b/tests/scripts/42_shopt_extglob_midfile.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# bash-n: skip -- this file CANNOT parse under bash -n, by design: -n never
+# executes the `shopt -s extglob` below, so the extglob patterns after it
+# are syntax errors to a parse-only pass (real bash -n rejects this file
+# AND /usr/share/bash-completion/bash_completion for the same reason).
 # `shopt -s extglob` must arm the lexer for LATER lines of the same input
 # (bash reads and runs incrementally, so line N+1 lexes with whatever
 # line N set). hellish tokenized ahead of execution, and bash-completion

--- a/tests/scripts/43_alias_source_chain.sh
+++ b/tests/scripts/43_alias_source_chain.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Aliases and sourced files: bash makes an alias defined on line N of a
+# sourced file visible from line N+1 of that same file (expansion happens
+# per line read), but NOT later in the same line. hellish alias-spliced a
+# sourced file once, up front, so a file that defines then uses an alias
+# printed "command not found" (issue #105 family).
+shopt -s expand_aliases 2>/dev/null || true
+
+cat > sub_alias.sh <<'EOF'
+alias greet='echo sourced-alias-ok'
+greet
+EOF
+. ./sub_alias.sh
+rm -f sub_alias.sh
+
+# Same-line definition + use must NOT expand (bash parity: aliases are
+# expanded when the line is read, before the definition executes).
+cat > sub_alias2.sh <<'EOF'
+alias late='echo late-expanded'; late
+echo "same-line status: $?"
+EOF
+. ./sub_alias2.sh 2>/dev/null
+rm -f sub_alias2.sh
+
+# eval across a newline expands; pre-existing aliases inside eval expand.
+alias pre='echo eval-pre-ok'
+eval 'pre'
+eval 'alias inner="echo eval-inner-ok"
+inner'
+unalias pre inner greet late 2>/dev/null
+echo "done=$?"

--- a/tests/scripts/44_dbracket_extglob.sh
+++ b/tests/scripts/44_dbracket_extglob.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Extended glob patterns on the right of == / != inside [[ ]] work in
+# bash WITHOUT `shopt -s extglob`: the option is temporarily enabled
+# while the operand is parsed and matched (bash 4.1+). hellish's [[ ]]
+# matcher rejected them with "test: syntax error" (issue #105 family —
+# bash-completion's _rl_enabled does exactly this on its first screen).
+x="a  on"
+[[ $x == *+([[:space:]])on* ]] && echo "space-class: matched"
+[[ "abc" == a@(b|z)c ]] && echo "at-group: matched"
+[[ "abc" == a+(b)c ]] && echo "plus-group: matched"
+[[ "ac" == a?(b)c ]] && echo "opt-group: matched"
+[[ "axc" == a!(b)c ]] && echo "negate-group: matched"
+[[ "abbc" == a*(b)c ]] && echo "star-group: matched"
+[[ "abc" != a@(x|y)c ]] && echo "negative-match: ok"
+v="theme+plain"
+[[ $v == *+* ]] && echo "literal-plus-still-glob: ok"
+echo "done=$?"

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -5,7 +5,7 @@ later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**. Released version: **2.8.4**.
+Branch to resume from: **`develop`**. Released version: **2.8.5**.
 
 The previous note on this file covered the issue-fixing session (#27, #32,
 #34, #42 and friends). All of those are closed; the tracker is empty. This


### PR DESCRIPTION
## Summary

Fixes #105 — `hellish: syntax error near unexpected token `('` at every ssh login on a
Debian box — plus the family of "lexing ahead of execution" siblings found sweeping the
same syntax, detector-first:

- **exec_string chunking** (`exec_string3.c`/`exec_string4.c`): eval and the dot builtin
  now lex/parse sourced text in hazard-clipped chunks like the main input driver, so
  `shopt -s extglob`, alias definitions and nested sources affect how the REST of the
  same file lexes. bash-completion 2.11 and 2.14 both load silently now (the login chain
  is hellish sets BASH_VERSION → ~/.profile sources ~/.bashrc → sources bash_completion).
- **`shopt` joined the batch hazards** (`rl_multi_line2.c`) — same staleness on the
  script/file path.
- **Extglob in `[[ ]]` without the shopt** — lexer (`tokenizer.c`) and matcher
  (`builtin_dbracket2.c`) arm extglob for conditional operands, bash 4.1 semantics.
- **`eval --`** options terminator; **`complete`** `-e/-g/-j/-s/-u` action letters and
  silent `-D` default specs; **`shopt`** honest answers for real-but-unimplemented bash
  option names (query off / `-u` ok / `-s` loud), never success-while-doing-nothing.

## Detectors (red before the fixes, green after — permanent)

- `tests/login_bashrc_chain_test.py` — the whole profile→bashrc→completion chain in a
  pty (glob-discovered → `interactive` + `allocator` CI jobs).
- `tests/scripts/42_shopt_extglob_midfile.sh`, `43_alias_source_chain.sh`,
  `44_dbracket_extglob.sh` — byte-for-byte vs bash 5.3.9 across file/source/eval paths.
- Plugin corpus: bash-completion row promoted `unsupported` → **`loads`** (floor 80
  definitions), with `BASH_COMPLETION_COMPAT_DIR` pinned so the verdict tests the file,
  not the machine's drop-ins.

## Verification

- golden suite: 4323/4323 debug + release
- `tests/run_scripts.sh`: 112/112 (three new scripts)
- `tests/hard/run.sh`: 17/17
- `make pty-test`: green including the new chain test
- `cd tests && ./verify_alloc.sh`: both heaps identical, zero leaks
- `make plugin-corpus`: all passed, bash-completion at `loads`
- `make arena-stress`: clean
- `make norm`: passed

Closes #105
