### PR TITLE
fix: the TAB stratum — completion runs clean and re-sourcing beats bash (#108)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,65 @@ shows you how to drive the shell.
 
 ---
 
+## v2.8.6 — *the TAB release*
+
+v2.8.5 made bash-completion LOAD; the first real TAB on a Debian 13 box
+then ran its completion functions and hit the next stratum. All fixed,
+with a detector that presses TAB for real:
+
+- **`[[ ]]` continues across newlines** where bash's grammar allows it
+  (after `[[`, after `&&`/`||`, before `]]`) — bash-completion's
+  compat-dir loop spells its test `[[ a != @(...) &&` ⏎ `-f b ]]`, and
+  the split conditional printed `[[: missing ]]` once per drop-in file
+  at every login.
+- **Indirection composes**: `${!ref-}`, `${!ref:-x}` — and the target
+  may be an array element (`ref="words[0]"`), which is how
+  _comp_get_words assembles every completion word. `printf -v "a[0]"`
+  writes the element, not a scalar named `a[0]`.
+- **Substring bounds expand**: `${cur:0:${#words[i]}}` — the exact
+  spelling the cursor walk uses.
+- **bash's upvar rule**: `unset -v x` from a deeper frame pops the
+  caller's local cell so a following assignment writes the revealed
+  scope — the documented trick `_comp_upvars` returns values with. A
+  bare `local x` re-declaration keeps the value, like bash.
+- **Quoted slices keep fields**: `"${@:3:N}"` is one field per
+  positional (so `words=("${@:3:N}")` counts right), and the
+  set-guarded pass-through `${w+"${w[@]}"}` / `${w[@]+"${w[@]}"}` keeps
+  per-element fields, empties included.
+- **`compgen` grew `-X` filter / `-P` prefix / `-S` suffix**, the
+  `-e/-g/-j/-s/-u` action letters, and **expands its `-W` list** — the
+  deferred `-W '"${toks[@]}"'` spelling every generator uses now yields
+  elements instead of pasting `"${toks[@]}"` into the command line.
+  **`declare -F -- name`** answers 0 like bash.
+
+And the third wave — "source ~/.hellishrc got slow again":
+
+- **Re-sourcing an rc is as cheap as the first load.** Two multipliers
+  stacked: the forkless `$(...)` fast path turned itself off the moment
+  ANY alias existed (now it only bails when the command word itself is
+  aliased), and the DEBUG trap fired before every statement *inside* a
+  sourced file where bash fires once for the whole `.` run (eval keeps
+  its per-statement fires — both measured on 5.3.9). A theme rc that
+  installs `trap hx_preexec DEBUG` plus a dozen aliases forked ~370
+  extra times per re-source; it now re-sources *faster than bash*
+  (0.35s vs 0.43s for nine loads of the 1225-line theme file).
+- **Sourcing a construct with interior hazard words is linear**: growth
+  spans stop re-clipping at alias/source/shopt words once the parser has
+  demanded more — a hazard line inside an open construct cannot take
+  effect before the construct executes in bash either. The 2244-line
+  monolithic rc: 0.21 s → 0.005 s on the reporting machine.
+
+Detectors, permanent: `tests/tab_completion_chain_test.py` sources the
+real bash-completion 2.16 with a POPULATED compat dir on a pty and
+presses TAB, asserting no error of any class and that a filename
+actually completes; `tests/issue105_expansions` (39 golden lines),
+`tests/scripts/45_dbracket_newline.sh` and
+`tests/scripts/46_debug_trap_source.sh` pin every construct against
+bash 5.3.9; `tests/parse_scaling_test.py` now also caps the re-source
+ratio with aliases + a DEBUG trap installed.
+
+---
+
 ## v2.8.5 — *the login-chain release*
 
 One field report — `ssh` into a Debian 13 box printed

--- a/incs/lexer.h
+++ b/incs/lexer.h
@@ -100,6 +100,7 @@ char		*parse_lexeme(t_deque_tok *tokens, char **str);
 void		parse_op(t_deque_tok *tokens, char **str);
 void		dbracket_toggle(const char *str, int *in_db);
 int			emit_dbracket_word(char **str, t_deque_tok *ret);
+bool		db_newline_skippable(t_deque_tok *ret, const char *after);
 void		db_track_regex(t_deque_tok *ret, int *in_db);
 int			db_regex_word(char **str, t_deque_tok *ret, int *in_db);
 void		reclassify_keywords(t_deque_tok *tokens, bool zsh);

--- a/incs/version.h
+++ b/incs/version.h
@@ -15,7 +15,7 @@
 
 /* The single source of truth for the running shell's version. Bumped in step
    with the git tag / GitHub release / npm package / docker image. */
-# define HELLISH_VERSION "2.8.5"
+# define HELLISH_VERSION "2.8.6"
 
 /* Where releases live; used by the `update` builtin and the daily check. */
 # define HELLISH_REPO "Univers42/hellish"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellish-shell",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "hellish — a fast, POSIX-compliant shell, with horns",
   "bin": {
     "hellish": "bin/hellish.js"

--- a/src/builtins/builtin_compgen.c
+++ b/src/builtins/builtin_compgen.c
@@ -13,6 +13,11 @@
 #include "builtins_private.h"
 #include "env.h"
 
+#define CGW_VAR "__hellish_cgw"
+
+int	exec_string(t_shell *state, char *str);
+int	try_unset(t_shell *state, char *key);
+
 /* `compgen` -- ask the shell what it would offer as completions, and print
 ** the answers one per line.
 **
@@ -29,41 +34,47 @@
 
 /* Print `s` when it starts with `pfx`; returns 1 if it did, so the caller
    can accumulate "did anything match at all". */
-int	cg_emit(const char *s, const char *pfx)
+int	cg_emit(t_cgopt *o, const char *s, const char *pfx)
 {
 	if (ft_strncmp((char *)s, (char *)pfx, ft_strlen((char *)pfx)) != 0)
 		return (0);
-	ft_printf("%s\n", s);
-	return (1);
+	return (cg_print(o, s));
 }
 
-/* -W: the word list is split on IFS-ish whitespace and each field offered.
-** bash also EXPANDS the list before splitting it, and we do not. Stated
-** here rather than left to be discovered:
-**
-**     compgen -W "it's fine" -- it     bash: its fine      here: it's
-**     complete -W '$(git cmds)' git    bash: runs it       here: literal
-**
-** The common spellings are unaffected. `complete -W "$(...)" x` is expanded
-** by the shell when `complete` runs, long before the list is stored, and a
-** literal list of flags or subcommands -- what the corpus actually passes --
-** has nothing in it to expand. What is missing is the DEFERRED form, where
-** the list is single-quoted so that bash re-expands it at every TAB. */
-static int	cg_words(const char *list, const char *pfx)
+/* -W: bash EXPANDS the word list, then splits it into fields with the
+** shell's own rules -- quoting protects spaces, `$(...)` runs, and the
+** DEFERRED form (`-W '"${toks[@]}"'`, single-quoted so every TAB
+** re-expands it) yields the array's elements. That deferred spelling is
+** how bash-completion 2.16 feeds every generated candidate through
+** _comp_compgen, and offering the literal text instead put the string
+** "${toks[@]}" INTO the command line on TAB (issue #105, wave 2).
+** The list is evaluated as an array literal through exec_string -- the
+** exact machinery `x=(list)` already exercises -- into a scratch array
+** that is read back and removed. */
+static int	cg_words(t_shell *st, t_cgopt *o, const char *list,
+				const char *pfx)
 {
-	char	**w;
-	int		i;
-	int		hit;
+	const char	*v;
+	const char	*el;
+	char		*cmd;
+	long		idx;
+	int			nth[3];
 
-	w = ft_split((char *)list, ' ');
-	if (!w)
-		return (0);
-	i = 0;
-	hit = 0;
-	while (w[i])
-		hit += cg_emit(w[i++], pfx);
-	free_tab(w);
-	return (hit);
+	cmd = ft_asprintf("%s=(%s)", CGW_VAR, list);
+	exec_string(st, cmd);
+	xfree(cmd);
+	v = env_expand(st, CGW_VAR);
+	nth[0] = 0;
+	nth[2] = 0;
+	if (v && arr_is(v))
+	{
+		v++;
+		while (arr_next(&v, &idx, &el, &nth[1]))
+			nth[2] += cg_emit_n(o, el, nth[1], pfx);
+	}
+	else if (v)
+		nth[2] = cg_emit(o, v, pfx);
+	return (try_unset(st, CGW_VAR), nth[2]);
 }
 
 /* The action letter for -A NAME, so the two spellings share one path.
@@ -98,9 +109,9 @@ static int	cg_run(t_shell *st, t_cgopt *o, const char *pfx)
 
 	hit = 0;
 	if (o->words)
-		hit += cg_words(o->words, pfx);
+		hit += cg_words(st, o, o->words, pfx);
 	if (o->act)
-		hit += cg_source(st, o->act, pfx);
+		hit += cg_source(st, o, pfx);
 	return (hit);
 }
 

--- a/src/builtins/builtin_compgen2.c
+++ b/src/builtins/builtin_compgen2.c
@@ -23,7 +23,7 @@ extern char	*g_builtins[];
 
 /* -A function: the user-defined function table, sorted -- definition
    order is an implementation detail and bash does not expose it. */
-static int	cg_functions(t_shell *st, const char *pfx)
+static int	cg_functions(t_shell *st, t_cgopt *o, const char *pfx)
 {
 	size_t	i;
 	t_vec	out;
@@ -33,13 +33,13 @@ static int	cg_functions(t_shell *st, const char *pfx)
 	while (i < st->functions.len)
 		cg_add(&out, ((t_shell_func *)vec_idx(&st->functions, i++))->name,
 			pfx);
-	return (cg_flush(&out));
+	return (cg_flush(o, &out));
 }
 
 /* -v: every variable that has a value, the same "set" test `test -v` uses
    so the two cannot disagree about what exists. Sorted: the env vec is in
    assignment order, which no caller should be able to observe. */
-static int	cg_vars(t_shell *st, const char *pfx)
+static int	cg_vars(t_shell *st, t_cgopt *o, const char *pfx)
 {
 	size_t	i;
 	t_env	*e;
@@ -53,12 +53,12 @@ static int	cg_vars(t_shell *st, const char *pfx)
 		if (e->key && e->value)
 			cg_add(&out, e->key, pfx);
 	}
-	return (cg_flush(&out));
+	return (cg_flush(o, &out));
 }
 
 /* -b builtins and -k keywords, from the tables the shell itself uses,
    sorted -- hellish's dispatch table is in registration order. */
-static int	cg_names(char act, const char *pfx)
+static int	cg_names(t_cgopt *o, char act, const char *pfx)
 {
 	static const char	*kw[] = {"if", "then", "else", "elif", "fi", "case",
 		"esac", "for", "select", "while", "until", "do", "done", "in",
@@ -72,38 +72,38 @@ static int	cg_names(char act, const char *pfx)
 	{
 		while (kw[i])
 			cg_add(&out, kw[i++], pfx);
-		return (cg_flush(&out));
+		return (cg_flush(o, &out));
 	}
 	while (g_builtins[i])
 		cg_add(&out, g_builtins[i++], pfx);
-	return (cg_flush(&out));
+	return (cg_flush(o, &out));
 }
 
 /* -f / -d / -c: the filesystem and PATH sources. -c offers builtins and
    functions too, because those are commands the user can actually run --
    bash does the same, and a completion list that omits them sends people
    looking for a binary that was never going to exist. */
-static int	cg_paths(t_shell *st, char act, const char *pfx)
+static int	cg_paths(t_shell *st, t_cgopt *o, const char *pfx)
 {
 	int	hit;
 
-	hit = cg_glob_paths(act, pfx);
-	if (act != 'c')
+	hit = cg_glob_paths(o, pfx);
+	if (o->act != 'c')
 		return (hit);
-	hit += cg_names('b', pfx);
-	return (hit + cg_functions(st, pfx));
+	hit += cg_names(o, 'b', pfx);
+	return (hit + cg_functions(st, o, pfx));
 }
 
 /* Route one action letter to its source. */
-int	cg_source(t_shell *st, char act, const char *pfx)
+int	cg_source(t_shell *st, t_cgopt *o, const char *pfx)
 {
-	if (act == 'A')
-		return (cg_functions(st, pfx));
-	if (act == 'v')
-		return (cg_vars(st, pfx));
-	if (act == 'b' || act == 'k')
-		return (cg_names(act, pfx));
-	if (act == 'a')
-		return (cg_aliases(st, pfx));
-	return (cg_paths(st, act, pfx));
+	if (o->act == 'A')
+		return (cg_functions(st, o, pfx));
+	if (o->act == 'v')
+		return (cg_vars(st, o, pfx));
+	if (o->act == 'b' || o->act == 'k')
+		return (cg_names(o, o->act, pfx));
+	if (o->act == 'a')
+		return (cg_aliases(st, o, pfx));
+	return (cg_paths(st, o, pfx));
 }

--- a/src/builtins/builtin_compgen3.c
+++ b/src/builtins/builtin_compgen3.c
@@ -19,7 +19,7 @@
 
 /* -a: the alias table, walked the same way alias_print_all walks it and
    sorted -- a hash table has no order worth exposing. */
-int	cg_aliases(t_shell *st, const char *pfx)
+int	cg_aliases(t_shell *st, t_cgopt *o, const char *pfx)
 {
 	size_t			i;
 	t_hash_entry	*e;
@@ -34,7 +34,7 @@ int	cg_aliases(t_shell *st, const char *pfx)
 			cg_add(&out, e[i].key, pfx);
 		i++;
 	}
-	return (cg_flush(&out));
+	return (cg_flush(o, &out));
 }
 
 /* Split a prefix into the directory to read and the leading bytes an entry
@@ -59,7 +59,7 @@ static char	*cg_split_dir(const char *pfx, const char **tail)
 /* Print one directory entry as a completion: the caller's prefix path plus
    the name, so the answer can be pasted back on the command line. -d keeps
    only directories; -c keeps only what is executable. */
-static int	cg_entry(const char *pfx, const char *nm, char act, char *dir)
+static int	cg_entry(t_cgopt *o, const char *pfx, const char *nm, char *dir)
 {
 	char	*full;
 	char	*shown;
@@ -67,15 +67,16 @@ static int	cg_entry(const char *pfx, const char *nm, char act, char *dir)
 
 	full = ft_asprintf("%s/%s", dir, nm);
 	keep = 1;
-	if (act == 'd')
+	if (o->act == 'd')
 		keep = (cg_is_dir(full) != 0);
-	else if (act == 'c')
+	else if (o->act == 'c')
 		keep = (access(full, X_OK) == 0);
 	xfree(full);
 	if (!keep)
 		return (0);
 	shown = cg_join_prefix(pfx, nm);
-	ft_printf("%s\n", shown);
+	if (!cg_print(o, shown))
+		return (xfree(shown), 0);
 	return (xfree(shown), 1);
 }
 
@@ -83,7 +84,7 @@ static int	cg_entry(const char *pfx, const char *nm, char act, char *dir)
    and offer every entry that continues it. A hidden file is offered only
    when the prefix asks for the dot, which is what a user typing `.ba<TAB>`
    means and what stops a bare TAB from listing every dotfile. */
-int	cg_glob_paths(char act, const char *pfx)
+int	cg_glob_paths(t_cgopt *o, const char *pfx)
 {
 	DIR				*d;
 	struct dirent	*de;
@@ -101,7 +102,7 @@ int	cg_glob_paths(char act, const char *pfx)
 	{
 		if (ft_strncmp(de->d_name, (char *)tail, ft_strlen((char *)tail)) == 0
 			&& (tail[0] == '.' || de->d_name[0] != '.'))
-			hit += cg_entry(pfx, de->d_name, act, dir);
+			hit += cg_entry(o, pfx, de->d_name, dir);
 		de = readdir(d);
 	}
 	return (closedir(d), xfree(dir), hit);

--- a/src/builtins/builtin_compgen4.c
+++ b/src/builtins/builtin_compgen4.c
@@ -40,7 +40,11 @@ char	*cg_join_prefix(const char *pfx, const char *name)
 }
 
 /* One option word. Returns the number of extra argv slots consumed (the
-   value-takers -W and -A take one), or -1 on an unknown option. */
+   value-takers -W/-A/-X/-P/-S take one; -o is consumed and ignored), or
+   -1 on an unknown option. -X/-P/-S landed with issue #105 wave 2:
+   bash-completion filters every filedir batch through
+   `compgen -f -X '!pattern'` and prefixes partials with -P, so rejecting
+   them killed TAB before any candidate was generated. */
 static int	cg_one_opt(t_shell *st, t_vec argv, size_t i, t_cgopt *o)
 {
 	char	*w;
@@ -48,6 +52,14 @@ static int	cg_one_opt(t_shell *st, t_vec argv, size_t i, t_cgopt *o)
 	w = ((char **)argv.ctx)[i];
 	if (ft_strcmp(w, "-W") == 0 && i + 1 < argv.len)
 		return (o->words = ((char **)argv.ctx)[i + 1], 1);
+	if (ft_strcmp(w, "-X") == 0 && i + 1 < argv.len)
+		return (o->xfilter = ((char **)argv.ctx)[i + 1], 1);
+	if (ft_strcmp(w, "-P") == 0 && i + 1 < argv.len)
+		return (o->prefix = ((char **)argv.ctx)[i + 1], 1);
+	if (ft_strcmp(w, "-S") == 0 && i + 1 < argv.len)
+		return (o->suffix = ((char **)argv.ctx)[i + 1], 1);
+	if (ft_strcmp(w, "-o") == 0 && i + 1 < argv.len)
+		return (1);
 	if (ft_strcmp(w, "-A") == 0 && i + 1 < argv.len)
 	{
 		o->act = cg_action_of(((char **)argv.ctx)[i + 1]);
@@ -56,7 +68,7 @@ static int	cg_one_opt(t_shell *st, t_vec argv, size_t i, t_cgopt *o)
 					st->ctx, ((char **)argv.ctx)[i + 1]), -1);
 		return (1);
 	}
-	if (w[1] && !w[2] && ft_strchr("abcdfkv", w[1]))
+	if (w[1] && !w[2] && ft_strchr("abcdefgjksuv", w[1]))
 		return (o->act = w[1], 0);
 	return (ft_eprintf("%s: compgen: %s: invalid option\n", st->ctx, w), -1);
 }

--- a/src/builtins/builtin_compgen5.c
+++ b/src/builtins/builtin_compgen5.c
@@ -51,7 +51,7 @@ void	cg_add(t_vec *out, const char *s, const char *pfx)
 
 /* Sort, print, release; returns how many were printed so the caller can
    keep accumulating "did anything match at all". */
-int	cg_flush(t_vec *out)
+int	cg_flush(t_cgopt *o, t_vec *out)
 {
 	size_t	i;
 	int		n;
@@ -59,13 +59,13 @@ int	cg_flush(t_vec *out)
 	if (out->len > 1)
 		ft_quicksort(out);
 	i = 0;
+	n = 0;
 	while (i < out->len)
 	{
-		ft_printf("%s\n", ((char **)out->ctx)[i]);
+		n += cg_print(o, ((char **)out->ctx)[i]);
 		xfree(((char **)out->ctx)[i]);
 		i++;
 	}
-	n = (int)out->len;
 	xfree(out->ctx);
 	return (n);
 }

--- a/src/builtins/builtin_compgen6.c
+++ b/src/builtins/builtin_compgen6.c
@@ -1,0 +1,73 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_compgen6.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/09/02 00:40:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/09/02 00:40:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins_private.h"
+#include "ft_glob.h"
+
+bool	case_match(const char *s, const char *p);
+
+/* compgen -X FILTERPAT: candidates the pattern matches are dropped; a
+   leading `!` keeps ONLY the matches. Matched with the engine case/esac
+   uses, extglob armed for the span: bash-completion writes its filters
+   in extglob (`-X '!*.@(pdf|ps)'`) whether or not the option is on,
+   the same rule [[ ]] operands follow (db_pattern_match). */
+static bool	cg_keep(t_cgopt *o, const char *cand)
+{
+	const char	*pat;
+	bool		neg;
+	bool		m;
+	int			saved;
+
+	if (!o || !o->xfilter)
+		return (true);
+	pat = o->xfilter;
+	neg = (pat[0] == '!');
+	if (neg)
+		pat++;
+	saved = *glob_extglob_cell();
+	*glob_extglob_cell() = 1;
+	m = case_match(cand, pat);
+	*glob_extglob_cell() = saved;
+	return (m == neg);
+}
+
+/* The single exit for every compgen candidate: the -X filter decides
+   whether it appears at all, then -P/-S wrap it. Returns 1 when a line
+   was printed so the callers' "did anything match" accounting counts
+   what the USER saw, not what the generator produced. */
+int	cg_print(t_cgopt *o, const char *cand)
+{
+	const char	*p;
+	const char	*s;
+
+	if (!cg_keep(o, cand))
+		return (0);
+	p = "";
+	s = "";
+	if (o && o->prefix)
+		p = o->prefix;
+	if (o && o->suffix)
+		s = o->suffix;
+	ft_printf("%s%s%s\n", p, cand, s);
+	return (1);
+}
+
+/* Slice variant of cg_emit for arr_next's (ptr,len) elements. */
+int	cg_emit_n(t_cgopt *o, const char *s, int n, const char *pfx)
+{
+	char	*dup;
+	int		hit;
+
+	dup = ft_strndup((char *)s, n);
+	hit = cg_emit(o, dup, pfx);
+	return (xfree(dup), hit);
+}

--- a/src/builtins/builtin_declare3.c
+++ b/src/builtins/builtin_declare3.c
@@ -63,7 +63,11 @@ int	list_all(t_shell *state)
 }
 
 /* With operands: print each name that IS a function, and report 1 if any
-   named operand was not -- the status bash scripts branch on. */
+   named operand was not -- the status bash scripts branch on. A leading
+   `--` is the options terminator, not a name: bash-completion probes
+   every generator with `declare -F -- "$fn" &>/dev/null` and branching on
+   that status, so counting the terminator as a missing function turned
+   every TAB into "unrecognized generator" (issue #105, wave 2). */
 int	list_named(t_shell *state, t_vec argv, size_t i)
 {
 	int		missing;

--- a/src/builtins/builtin_declare4.c
+++ b/src/builtins/builtin_declare4.c
@@ -55,6 +55,8 @@ static int	bodies_of(t_shell *state, t_vec argv, size_t i)
 
 int	declare_functions(t_shell *state, t_vec argv, size_t i, bool bodies)
 {
+	if (i < argv.len && ft_strcmp(((char **)argv.ctx)[i], "--") == 0)
+		i++;
 	if (bodies)
 		return (bodies_of(state, argv, i));
 	return (declare_names(state, argv, i));

--- a/src/builtins/builtin_printf2.c
+++ b/src/builtins/builtin_printf2.c
@@ -72,16 +72,21 @@ static void	run_format(t_pf *pf, const char *fmt)
 
 /* Deliver the rendered output to stdout in one go. Returns printf's exit
    status — 1 if any conversion saw an invalid argument or directive,
-   else 0. */
+   else 0. The -v target goes through subscript_assign so
+   `printf -v "a[0]" ...` lands in the array element like bash, not in a
+   scalar literally NAMED a[0] — bash-completion's word assembly does
+   `printf -v "$2[$j]"` on every TAB (issue #105, wave 2). */
 static int	pf_finish(t_pf *pf)
 {
 	char	*val;
+	t_env	ev;
 
 	if (pf->vname)
 	{
 		val = ft_strndup((char *)pf->out->ctx, pf->out->len);
-		env_set(&pf->state->env, env_create(ft_strdup(pf->vname),
-				val, false));
+		ev = env_create(ft_strdup(pf->vname), val, false);
+		subscript_assign(pf->state, &ev);
+		env_set(&pf->state->env, ev);
 		return (xfree(pf->out->ctx), pf->err);
 	}
 	if (pf->out->len

--- a/src/builtins/builtins_private.h
+++ b/src/builtins/builtins_private.h
@@ -82,6 +82,9 @@ typedef struct s_cgopt
 {
 	char	*words;
 	char	act;
+	char	*xfilter;
+	char	*prefix;
+	char	*suffix;
 }	t_cgopt;
 
 /* complete's parsed options. All pointers borrow from argv; comp_store
@@ -191,12 +194,14 @@ bool	test_var_isset(t_shell *st, char *name);
 
 int		builtin_compgen(t_shell *state, t_vec argv);
 int		builtin_complete(t_shell *state, t_vec argv);
-int		cg_emit(const char *s, const char *pfx);
+int		cg_emit(t_cgopt *o, const char *s, const char *pfx);
 void	cg_add(t_vec *out, const char *s, const char *pfx);
-int		cg_flush(t_vec *out);
-int		cg_source(t_shell *st, char act, const char *pfx);
-int		cg_aliases(t_shell *st, const char *pfx);
-int		cg_glob_paths(char act, const char *pfx);
+int		cg_flush(t_cgopt *o, t_vec *out);
+int		cg_source(t_shell *st, t_cgopt *o, const char *pfx);
+int		cg_aliases(t_shell *st, t_cgopt *o, const char *pfx);
+int		cg_glob_paths(t_cgopt *o, const char *pfx);
+int		cg_print(t_cgopt *o, const char *cand);
+int		cg_emit_n(t_cgopt *o, const char *s, int n, const char *pfx);
 int		cg_is_dir(const char *path);
 char	*cg_join_prefix(const char *pfx, const char *name);
 char	cg_action_of(const char *name);

--- a/src/builtins/try_unset.c
+++ b/src/builtins/try_unset.c
@@ -14,6 +14,44 @@
 #include "env.h"
 #include "builtins_private.h"
 
+void	restore_one(t_shell *state, t_scope_save *s);
+
+/* bash's upvar rule: `unset` inside a function, on a name whose NEWEST
+   local cell belongs to a CALLER (a save at a shallower depth than the
+   current frame), pops that cell -- the captured value comes back NOW
+   and the save is consumed, so a following assignment writes the scope
+   the pop revealed. It is the documented trick shell libraries use to
+   return values (_comp_upvars: `unset -v "$2" && eval "$2"=...`), and
+   without it every word list bash-completion assembled on TAB landed in
+   a scope nobody read (issue #105, wave 2). A save at the CURRENT depth
+   is not popped: unsetting your own local keeps it local-and-unset,
+   bash's default. Depth-0 saves are temporary-assignment captures, not
+   scope cells. */
+static bool	scope_pop_upvar(t_shell *state, char *key)
+{
+	long			i;
+	t_scope_save	*s;
+
+	if (state->func_depth <= 0 || state->local_saves.elem_size == 0)
+		return (false);
+	i = (long)state->local_saves.len - 1;
+	while (i >= 0)
+	{
+		s = (t_scope_save *)state->local_saves.ctx + i;
+		if (s->depth > 0 && ft_strcmp(s->key, key) == 0)
+		{
+			if (s->depth >= state->func_depth)
+				return (false);
+			restore_one(state, s);
+			ft_memmove(s, s + 1, (state->local_saves.len - i - 1)
+				* sizeof(t_scope_save));
+			return (state->local_saves.len--, true);
+		}
+		i--;
+	}
+	return (false);
+}
+
 /* unset arr[i]: evaluate the subscript, rebuild the value without that
    record. The variable itself survives (possibly as an empty array). */
 static bool	unset_array_elem(t_shell *state, char *key, char *br)
@@ -83,6 +121,8 @@ int	try_unset(t_shell *state, char *key)
 	if (is_readonly_var(state, key))
 		return (ft_eprintf("%s: unset: %s: cannot unset: readonly "
 				"variable\n", state->ctx, key), 1);
+	if (scope_pop_upvar(state, key))
+		return (0);
 	br = ft_strchr(key, '[');
 	if (br && key[ft_strlen(key) - 1] == ']'
 		&& unset_array_elem(state, key, br))
@@ -91,4 +131,19 @@ int	try_unset(t_shell *state, char *key)
 	if (!e)
 		return (0);
 	return (env_drop_entry(state, e), 0);
+}
+
+/* The raw drop, upvar rule NOT applied: restore_one's "did not exist
+   before" path unsets while UNWINDING a scope -- routing that back
+   through the pop above ping-pongs restore_one and try_unset into a
+   stack overflow the moment two saves share a name. */
+void	unset_raw(t_shell *state, char *key)
+{
+	t_env	*e;
+
+	if (!state || state->env.ctx == NULL)
+		return ;
+	e = env_get(&state->env, key);
+	if (e)
+		env_drop_entry(state, e);
 }

--- a/src/execution/exec_string3.c
+++ b/src/execution/exec_string3.c
@@ -45,6 +45,28 @@
    hidden from the byte scan (a function body calling shopt, invoked in
    the same chunk that then uses extglob) still lexes ahead. */
 
+/* Which bytes end a span. A chunk's FIRST span (open=false) clips at
+   every input hazard, so a top-level alias/shopt/source line always gets
+   its own chunk and executes before later text lexes. GROWTH spans
+   (open=true) are different: the parser has already demanded more, so we
+   are inside an open construct -- and a hazard line INSIDE a construct
+   cannot take effect before the whole construct executes in bash either
+   (bash parses the compound first, then runs its body). Clipping there
+   bought no correctness and cost a full re-splice/re-lex/re-parse of the
+   accumulated chunk per interior hazard word: the 2244-line theme rc,
+   one giant if/else with ~60 alias/source words inside, re-parsed ~80KB
+   dozens of times and `source ~/.hellishrc` visibly lagged bash. Only
+   `<<` still clips growth (heredoc consumption depends on delivery).
+   The overshoot a growth span can add past the construct's close is the
+   one divergence: a def-then-use pair landing in that tail lexes
+   together -- accepted, and the statement replay still bounds errors. */
+static bool	span_hazard(const char *s, size_t i, size_t n, bool open)
+{
+	if (!open)
+		return (input_hazard_at(s, i, n));
+	return (s[i] == '<' && i + 1 < n && s[i + 1] == '<');
+}
+
 /* Longest hazard-free run of COMPLETE lines starting at off; if a hazard
    sits in the very first line, that one LOGICAL line -- backslash-newline
    joins included. Ending a chunk between a trailing `\` and its
@@ -53,12 +75,12 @@
    line becomes a separate statement). The retreat loop cannot land on a
    joined newline: a backslash-newline is itself a hazard, so the scan
    already stopped at the first one. */
-static size_t	str_span(const char *s, size_t off, size_t n)
+static size_t	str_span(const char *s, size_t off, size_t n, bool open)
 {
 	size_t	clip;
 
 	clip = off;
-	while (clip < n && !input_hazard_at(s, clip, n))
+	while (clip < n && !span_hazard(s, clip, n, open))
 		clip++;
 	while (clip > off && s[clip - 1] != '\n')
 		clip--;
@@ -126,22 +148,6 @@ static void	chunk_open(t_shell *state, const char *at, size_t len,
 			c->start, c->end, c->parser.res, c->spliced);
 }
 
-/* Release everything a chunk owns: parsed trees (executed or not), the
-   parser scratch, the token deque, and both text buffers. */
-void	chunk_close(t_chunkctx *c)
-{
-	size_t	i;
-
-	i = 0;
-	while (i < c->asts.len)
-		free_ast((t_ast_node *)c->asts.ctx + i++);
-	xfree(c->asts.ctx);
-	xfree(c->parser.parse_stack.ctx);
-	xfree(c->tt.deqtok.buff);
-	xfree(c->spliced);
-	xfree(c->chunk);
-}
-
 /* Grow the chunk to the next hazard boundary and (re-)open it. Works for
    the FIRST open too: on a zeroed ctx with start == end, chunk_close only
    frees NULLs and the span extends from the chunk's start. Nothing of a
@@ -149,6 +155,6 @@ void	chunk_close(t_chunkctx *c)
 void	chunk_grow(t_shell *state, const char *s, size_t n, t_chunkctx *c)
 {
 	chunk_close(c);
-	c->end += str_span(s, c->end, n);
+	c->end += str_span(s, c->end, n, c->end > c->start);
 	chunk_open(state, s + c->start, c->end - c->start, c);
 }

--- a/src/execution/exec_string4.c
+++ b/src/execution/exec_string4.c
@@ -15,6 +15,22 @@
 /* The chunk driver half of the #105 fix; the chunk mechanics and the
    design rationale live in exec_string3.c. */
 
+/* Release everything a chunk owns: parsed trees (executed or not), the
+   parser scratch, the token deque, and both text buffers. */
+void	chunk_close(t_chunkctx *c)
+{
+	size_t	i;
+
+	i = 0;
+	while (i < c->asts.len)
+		free_ast((t_ast_node *)c->asts.ctx + i++);
+	xfree(c->asts.ctx);
+	xfree(c->parser.parse_stack.ctx);
+	xfree(c->tt.deqtok.buff);
+	xfree(c->spliced);
+	xfree(c->chunk);
+}
+
 /* Execute the fully parsed statements of a chunk, in order, stopping on
    exit/return/errexit/unwind. Freeing is chunk_close's job so even the
    never-reached tail is reclaimed. */

--- a/src/execution/exec_traps.c
+++ b/src/execution/exec_traps.c
@@ -40,9 +40,17 @@ static void	run_trap_body(t_shell *state, int slot, int code)
 }
 
 /* Before each simple command (bash's DEBUG trap). $? stays the previous
-   command's status while the body runs. */
+   command's status while the body runs. NOT fired for commands inside a
+   `.`/source run: bash treats the whole source as one DEBUG event while
+   eval fires per inner statement (both measured on 5.3.9). Firing per
+   sourced statement turned a theme rc's `trap hx_preexec DEBUG` into
+   ~100 `$(date)` forks on every re-source -- the "source got slow again"
+   of issue #108 -- because the hook ran before each of the file's own
+   lines. */
 void	fire_debug_trap(t_shell *state)
 {
+	if (state->source_depth)
+		return ;
 	run_trap_body(state, TRAP_DEBUG, state->last_cmd_st_exe.status);
 }
 

--- a/src/execution/func_scope.c
+++ b/src/execution/func_scope.c
@@ -15,6 +15,7 @@
 #include "ft_builtins.h"
 
 int		try_unset(t_shell *state, char *key);
+void	unset_raw(t_shell *state, char *key);
 
 /* Remember `key`'s current value so it can be restored when the current
    function returns (used for `local` and for the positional params $1..). */
@@ -50,7 +51,7 @@ void	restore_one(t_shell *state, t_scope_save *s)
 	}
 	else
 	{
-		try_unset(state, s->key);
+		unset_raw(state, s->key);
 		xfree(s->key);
 		xfree(s->value);
 	}

--- a/src/execution/local_builtin.c
+++ b/src/execution/local_builtin.c
@@ -79,6 +79,31 @@ static int	local_nameref(t_shell *state, t_vec argv, size_t i)
 	return (0);
 }
 
+/* Is a bare `local name` a re-declaration of something ALREADY local at
+   this depth? bash keeps the value then -- and bash-completion counts on
+   it: `local "$2" "$3" "$4"` re-locals the caller-named out-parameters
+   its helpers have already filled, so wiping them emptied every word
+   list between assembly and _comp_upvars (issue #105, wave 2). Only the
+   valueless form is a no-op; `local x=v` still assigns. */
+static bool	local_already(t_shell *state, const char *name, char *eq)
+{
+	size_t			i;
+	t_scope_save	*s;
+
+	if (eq || state->local_saves.elem_size == 0)
+		return (false);
+	i = 0;
+	while (i < state->local_saves.len)
+	{
+		s = (t_scope_save *)state->local_saves.ctx + i;
+		if (s->depth == state->func_depth
+			&& ft_strcmp(s->key, name) == 0)
+			return (true);
+		i++;
+	}
+	return (false);
+}
+
 /* The ordinary operand loop: name, or name=value. */
 static int	local_plain(t_shell *state, t_vec argv, size_t i)
 {
@@ -94,6 +119,12 @@ static int	local_plain(t_shell *state, t_vec argv, size_t i)
 			key = ft_strndup(av[i], eq - av[i]);
 		else
 			key = ft_strdup(av[i]);
+		if (local_already(state, key, eq))
+		{
+			xfree(key);
+			i++;
+			continue ;
+		}
 		scope_save(state, key);
 		local_set_var(state, key, eq);
 		i++;

--- a/src/expander/cmdsub_fast.c
+++ b/src/expander/cmdsub_fast.c
@@ -12,6 +12,7 @@
 
 #include "expander_private.h"
 #include "sh_input.h"
+#include "sh_alias.h"
 #include <fcntl.h>
 
 int		exec_string(t_shell *state, char *cmd);
@@ -126,4 +127,23 @@ char	*cmdsub_fast(t_shell *state, const char *cmd)
 	dup2(save1, STDOUT_FILENO);
 	close(save1);
 	return (csf_collect(fd));
+}
+
+/* Is the fast path's command word shadowed by an alias? The old gate
+   bailed whenever ANY alias existed, which turned every `$(printf ...)`
+   in a theme prompt into a fork the moment an rc defined its first
+   alias -- ~270 forks per re-source of hellishrc_plugins' theme file,
+   the "source got slow again" of issue #108. Only an alias on THIS word
+   can change this body's meaning: eligibility already guarantees a
+   single simple command, so no other name in the body sits in command
+   position. */
+bool	csf_word_aliased(t_shell *state, const char *s, int len)
+{
+	char	buf[16];
+
+	if (len <= 0 || len >= (int) sizeof(buf))
+		return (true);
+	ft_memcpy(buf, s, len);
+	buf[len] = '\0';
+	return (alias_get(&state->aliases, buf) != NULL);
 }

--- a/src/expander/cmdsub_fast2.c
+++ b/src/expander/cmdsub_fast2.c
@@ -104,8 +104,6 @@ bool	csf_eligible(t_shell *state, const char *s)
 
 	if (state->opt_errexit || state->opt_nounset || state->opt_noexec)
 		return (false);
-	if (!alias_table_empty(&state->aliases))
-		return (false);
 	i = 0;
 	while (s[i] == ' ' || s[i] == '\t')
 		i++;
@@ -114,6 +112,8 @@ bool	csf_eligible(t_shell *state, const char *s)
 			s[w]))
 		w++;
 	if (!csf_word(s + i, w - i))
+		return (false);
+	if (csf_word_aliased(state, s + i, w - i))
 		return (false);
 	i = w;
 	while (s[i])

--- a/src/expander/expand_array_elem_op.c
+++ b/src/expander/expand_array_elem_op.c
@@ -137,7 +137,7 @@ static char	*elem_apply(t_shell *state, const char *op, int oplen, char *elem)
 	return (res);
 }
 
-bool	expand_array_elem_op(t_shell *state, t_token *tt)
+bool	expand_array_elem_op(t_shell *state, t_token *tt, bool split)
 {
 	char	*elem;
 	char	*res;
@@ -150,7 +150,12 @@ bool	expand_array_elem_op(t_shell *state, t_token *tt)
 	if (sub[1] >= tt->len)
 		return (false);
 	if (sub[0] == 1 && (tt->start[nl + 1] == '@' || tt->start[nl + 1] == '*'))
+	{
 		elem = at_value(state, tt->start, nl);
+		if (split && tt->start[nl + 1] == '@'
+			&& at_op_word_fields(state, tt, elem, sub[1]))
+			return (xfree(elem), true);
+	}
 	else
 		elem = elem_value(state, tt->start, nl, sub[0]);
 	res = elem_apply(state, tt->start + sub[1], tt->len - sub[1], elem);

--- a/src/expander/expand_param_format4.c
+++ b/src/expander/expand_param_format4.c
@@ -23,7 +23,7 @@
      Without the specials here, `${-#*e}` — the idiom every nvm.sh-style rc
    file uses to test a flag in $- — died as a bad substitution, which is
    fatal (127) in a non-interactive shell. */
-static int	pf_scan_scalar_name(const char *s, int slen)
+int	pf_scan_scalar_name(const char *s, int slen)
 {
 	int	i;
 
@@ -99,7 +99,7 @@ static char	*pf_tail_dispatch(t_shell *state, const char *s, int slen)
 
 /* Top-level ${...} dispatcher.  `s` is the raw text between the braces,
    `slen` its byte count.  Priority order — first match wins:
-     ${#v}      → length of v                  (expand_strlen)
+     zsh forms, ${#v}, ${!v...}                 (pf_head_dispatch)
      ${v:-w}    → default/alt operators        (find_param_op → expand_param_op)
      ${v#p} etc → trim operators               (find_trim_op → expand_trim)
      ${v/p/r}   → substitution                 (find_subst_op → expand_subst)
@@ -116,16 +116,9 @@ char	*expand_param_format(t_shell *state, const char *s, int slen, bool dq)
 
 	if (slen <= 0)
 		return (pf_bad_subst(state, s, slen));
-	op = zsh_param(state, s, slen);
+	op = pf_head_dispatch(state, s, slen, dq);
 	if (op)
 		return ((char *)op);
-	op = zsh_dispatch(state, s, slen, false);
-	if (op)
-		return ((char *)op);
-	if (s[0] == '#' && slen > 1)
-		return (expand_strlen(state, s + 1, slen - 1));
-	if (s[0] == '!' && slen > 1 && pf_is_indirect(s + 1, slen - 1))
-		return (expand_indirect(state, s + 1, slen - 1));
 	if (find_param_op(s, slen, &o))
 		return (o.dq = dq, expand_param_op(state, o));
 	op = find_trim_op(s, slen, &name_len);

--- a/src/expander/expand_param_format6.c
+++ b/src/expander/expand_param_format6.c
@@ -117,6 +117,9 @@ bool	expand_op_token(t_shell *state, t_token *tt, bool split_ctx)
 		return (true);
 	}
 	used = pf_op_word_used(pf_get_var_value(state, o.name, o.name_len), o);
+	if (used && split_ctx
+		&& pf_op_word_at_fields(state, tt, o.word, o.wlen))
+		return (true);
 	fmt = expand_param_op(state, o);
 	tt->start = fmt;
 	tt->len = (int)ft_strlen(fmt);

--- a/src/expander/expand_param_format8.c
+++ b/src/expander/expand_param_format8.c
@@ -1,0 +1,104 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_param_format8.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/09/01 23:10:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/09/01 23:10:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "expander_private.h"
+
+/* Indirection targets bash accepts: a plain parameter name/positional, or
+   an array element reference NAME[anything] — `ref="$2[$j]"` is how
+   bash-completion addresses its word arrays. Anything else is bash's
+   "invalid indirect expansion" class. Also the recursion guard: neither
+   accepted shape can begin another '!' round. */
+static bool	pf_target_ok(const char *mid)
+{
+	int			n;
+	const char	*br;
+
+	n = (int)ft_strlen(mid);
+	if (pf_valid_plain(mid, n))
+		return (true);
+	br = ft_strchr(mid, '[');
+	if (!br || br == mid || mid[n - 1] != ']')
+		return (false);
+	return (pf_valid_plain(mid, (int)(br - mid)));
+}
+
+/* Re-enter the full expander on "${<mid><rest>}": subscripted targets
+   (a[i], assoc[k]) resolve through the same element machinery the direct
+   spelling uses, so indirection cannot drift from it. */
+char	*pf_expand_rebuilt(t_shell *state, const char *mid,
+			const char *rest, int rlen)
+{
+	t_string	b;
+	char		*out;
+
+	vec_init(&b);
+	b.elem_size = 1;
+	vec_push_str(&b, "${");
+	vec_push_str(&b, (char *)mid);
+	if (rlen > 0)
+		vec_push_nstr(&b, rest, rlen);
+	vec_push_str(&b, "}");
+	out = expand_param_word(state, (char *)b.ctx, (int)b.len, false);
+	if (!out)
+		out = ft_strdup("");
+	return (xfree(b.ctx), out);
+}
+
+/* ${!name<op...>}: bash resolves the indirection FIRST, then applies the
+   operator to the TARGET parameter -- ${!ref-w} answers for the variable
+   $ref names, not for ref. bash-completion 2.16 leans on it at every TAB:
+   _comp_get_words does `printf -v "$ref" %s "${!ref-}..."` with ref set
+   to "words[0]"-style element references, and rejecting the form as a
+   bad substitution broke completion word assembly (#105, wave 2). The
+   body is rebuilt as "${<target><op...>}" and re-expanded, so every
+   operator and target shape runs through the machinery it already has.
+   NULL means "not this form" (the ${!a[@]} keys and ${!pre*} prefix
+   spellings fall through to their own handlers). A middle that is
+   unset, empty or not a clean target is reported like bash's "invalid
+   indirect expansion". */
+char	*pf_indirect(t_shell *state, const char *s, int n, bool dq)
+{
+	int		nl;
+	char	*mid;
+
+	(void)dq;
+	nl = pf_scan_scalar_name(s + 1, n - 1);
+	if (nl <= 0 || (nl < n - 1 && ft_strchr("*@[", s[1 + nl])))
+		return (NULL);
+	mid = env_expand_n(state, (char *)s + 1, nl);
+	if (!mid || !*mid || !pf_target_ok(mid))
+		return (pf_bad_subst(state, s, n));
+	return (pf_expand_rebuilt(state, mid, s + 1 + nl, n - 1 - nl));
+}
+
+/* The early ${...} forms, split from expand_param_format for the norm
+   line budget only -- priority order unchanged: zsh dialect first (its
+   ${(f)v} flag spellings would misparse as trims), then length, then
+   indirection (bare or with an operator; pf_indirect returns NULL for
+   the ${!a[@]} keys and ${!pre*} prefix forms so they fall through to
+   their own handlers). NULL continues to the operator scans. */
+char	*pf_head_dispatch(t_shell *state, const char *s, int slen, bool dq)
+{
+	char	*op;
+
+	op = zsh_param(state, s, slen);
+	if (op)
+		return (op);
+	op = zsh_dispatch(state, s, slen, false);
+	if (op)
+		return (op);
+	if (s[0] == '#' && slen > 1)
+		return (expand_strlen(state, s + 1, slen - 1));
+	if (s[0] == '!' && slen > 1)
+		return (pf_indirect(state, s, slen, dq));
+	return (NULL);
+}

--- a/src/expander/expand_param_format9.c
+++ b/src/expander/expand_param_format9.c
@@ -1,0 +1,87 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_param_format9.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dlesieur <dlesieur@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/09/02 00:05:00 by dlesieur          #+#    #+#             */
+/*   Updated: 2026/09/02 00:05:00 by dlesieur         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "expander_private.h"
+/* Park an array-encoded value (scalar → one field, NULL → none) behind
+   an ARR_MAGIC marker so the splitter emits verbatim fields. */
+static bool	pf_mark_value(t_shell *state, t_token *tt, char *val)
+{
+	char	*enc;
+
+	if (val && arr_is(val))
+		enc = ft_strdup(val);
+	else if (val)
+		enc = arr_from_elems((char **)&val, 1, NULL);
+	else
+		enc = arr_from_elems(NULL, 0, NULL);
+	tt->start = arr_mark_push(state, enc, (int)ft_strlen(enc));
+	tt->len = (int)ft_strlen(tt->start);
+	tt->allocated = false;
+	return (xfree(enc), true);
+}
+
+/* ${p+"$@"} / ${p+"${name[@]}"}: when the operator SELECTS its word and
+   the word is exactly a quoted all-elements expansion, bash emits one
+   field per element, empties kept -- `${words+"${words[@]}"}` is the
+   set-guarded pass-through bash-completion sends _comp_upvars' argv
+   through, and a joined single field merged the last two words of every
+   TAB (issue #105, wave 2). The elements are parked as an encoded value
+   behind an ARR_MAGIC marker: verbatim for the splitter, regardless of
+   the OUTER quoting, which is exactly how bash treats the inner quotes.
+   Returns false for any other word, leaving the scalar path in charge. */
+bool	pf_op_word_at_fields(t_shell *state, t_token *tt, const char *w,
+			int n)
+{
+	char	*cnt;
+
+	if (n < 4 || w[0] != '"' || w[n - 1] != '"')
+		return (false);
+	if (n == 4 && w[1] == '$' && w[2] == '@')
+	{
+		cnt = env_expand(state, "#");
+		if (!cnt)
+			return (false);
+		return (pos_mark_fields(state, tt, 1, ft_atoi(cnt) + 1));
+	}
+	if (n < 9 || w[1] != '$' || w[2] != '{' || w[n - 2] != '}'
+		|| ft_strncmp(w + n - 5, "[@]", 3) != 0
+		|| !pf_is_indirect(w + 3, n - 8))
+		return (false);
+	return (pf_mark_value(state, tt,
+			env_expand_n(state, (char *)w + 3, n - 8)));
+}
+
+/* The aggregate spelling ${a[@]+word} / ${a[@]-word}: when the word is
+   the quoted all-elements form and the operator selects it, fields win
+   over the joined scratch-var path — the empty-elements variant of the
+   same #105 idiom (`${w[@]+"${w[@]}"}` must keep a leading "" field).
+   `elem` is the aggregate's joined value (NULL = unset/empty), used only
+   to decide whether the word is selected; ownership stays the caller's. */
+bool	at_op_word_fields(t_shell *state, t_token *tt, char *elem, int off)
+{
+	const char	*op;
+	int			oplen;
+	int			i;
+	bool		used;
+
+	op = tt->start + off;
+	oplen = tt->len - off;
+	i = 0;
+	if (i < oplen && op[i] == ':')
+		i++;
+	if (i >= oplen || (op[i] != '+' && op[i] != '-'))
+		return (false);
+	used = (op[i] == '+') == (elem != NULL);
+	if (!used)
+		return (false);
+	return (pf_op_word_at_fields(state, tt, op + i + 1, oplen - i - 1));
+}

--- a/src/expander/expand_param_substr.c
+++ b/src/expander/expand_param_substr.c
@@ -27,11 +27,19 @@ void	exit_clean(t_shell *state, int code);
 
 /* Evaluate one substring field as arithmetic; empty text means 0 (so
    ${v::2} works).  On an arithmetic error the field falls back to 0 —
-   a garbage offset is not worth aborting the line for. */
+   a garbage offset is not worth aborting the line for.
+     The field is WORD-EXPANDED first, then evaluated — the same two
+   steps, in the same order, as an array subscript: bash accepts nested
+   expansions in the bounds, and `${cur:0:${#words[i]}}` is the exact
+   spelling bash-completion walks the cursor with (issue #105, wave 2:
+   the raw `${#w}` meant nothing to the arithmetic parser, the bound
+   fell back to 0, and every completion word came back empty). */
 static long long	ss_eval(t_shell *state, const char *s, int len)
 {
-	bool	err;
-	int		i;
+	bool		err;
+	char		*x;
+	long long	r;
+	int			i;
 
 	i = 0;
 	while (i < len && (s[i] == ' ' || s[i] == '\t'))
@@ -39,7 +47,11 @@ static long long	ss_eval(t_shell *state, const char *s, int len)
 	if (i == len)
 		return (0);
 	err = false;
-	return (arith_eval(state, s, len, &err));
+	x = expand_param_word(state, (char *)s, len, false);
+	if (!x)
+		return (arith_eval(state, s, len, &err));
+	r = arith_eval(state, x, (int)ft_strlen(x), &err);
+	return (xfree(x), r);
 }
 
 /* Locate the top-level ':' separating off from len (parens shield nested

--- a/src/expander/expand_pos_slice.c
+++ b/src/expander/expand_pos_slice.c
@@ -106,9 +106,42 @@ static void	pos_slice_range(t_shell *state, t_token *tt, int *off, int *to)
 		*to = *off + arith_num(state, tt->start + ol + 1, tt->len - ol - 1);
 }
 
+/* Quoted "${@:off:len}" in a split context: one verbatim field per
+   positional, like "$@" — bash-completion's _comp_upvars builds its word
+   arrays with `("${@:3:N}")` and a joined single field mis-counted every
+   TAB (issue #105, wave 2). The elements are computed here and parked in
+   the deferral registry as an ENCODED VALUE (the same ARR_MAGIC trick zsh
+   flagged expansions use), so the splitter emits them exactly. */
+bool	pos_mark_fields(t_shell *state, t_token *tt, int off, int to)
+{
+	t_vec	elems;
+	char	*enc;
+	char	*k;
+	char	*v;
+
+	vec_init(&elems);
+	elems.elem_size = sizeof(char *);
+	while (off < to)
+	{
+		k = ft_itoa(off++);
+		v = env_expand(state, k);
+		xfree(k);
+		if (v)
+			vec_push(&elems, &v);
+	}
+	enc = arr_from_elems((char **)elems.ctx, (int)elems.len, NULL);
+	xfree(elems.ctx);
+	tt->start = arr_mark_push(state, enc, (int)ft_strlen(enc));
+	tt->len = (int)ft_strlen(tt->start);
+	tt->allocated = false;
+	return (xfree(enc), true);
+}
+
 /* Recognise "@:..." / "*:..." and emit the slice. tt->start[0] is @ or *,
-   [1] is ':'. Returns false otherwise. */
-bool	expand_pos_slice(t_shell *state, t_token *tt)
+   [1] is ':'. Returns false otherwise. Quoted @ slices in a split context
+   keep per-element fields; everything else joins as before ("$*" always
+   joins, and an unquoted slice is IFS-resplit downstream anyway). */
+bool	expand_pos_slice(t_shell *state, t_token *tt, bool split_ctx)
 {
 	int	off;
 	int	to;
@@ -120,6 +153,8 @@ bool	expand_pos_slice(t_shell *state, t_token *tt)
 		|| tt->start[2] == '=' || tt->start[2] == '?')
 		return (false);
 	pos_slice_range(state, tt, &off, &to);
+	if (split_ctx && tt->start[0] == '@' && tt->tt == TT_DQENVVAR)
+		return (pos_mark_fields(state, tt, off, to));
 	tt->start = pos_join(state, off, to);
 	tt->len = (int)ft_strlen(tt->start);
 	tt->allocated = true;

--- a/src/expander/expand_token.c
+++ b/src/expander/expand_token.c
@@ -100,11 +100,11 @@ static bool	try_array_forms(t_shell *state, t_token *curr_tt, bool split_ctx)
 		return (true);
 	if (zsh_hash_token(state, curr_tt))
 		return (true);
-	if (expand_pos_slice(state, curr_tt))
+	if (expand_pos_slice(state, curr_tt, split_ctx))
 		return (true);
 	if (expand_array_op(state, curr_tt))
 		return (true);
-	if (expand_array_elem_op(state, curr_tt))
+	if (expand_array_elem_op(state, curr_tt, split_ctx))
 		return (true);
 	if (expand_array_ext(state, curr_tt, split_ctx))
 		return (true);

--- a/src/expander/expander_private.h
+++ b/src/expander/expander_private.h
@@ -189,6 +189,14 @@ char		*expand_xform(t_shell *state, const char *s, int name_len, char op);
 bool		find_xform_op(const char *s, int slen, int *nl, char *op);
 bool		pf_is_indirect(const char *s, int n);
 char		*expand_indirect(t_shell *state, const char *s, int n);
+char		*pf_indirect(t_shell *state, const char *s, int n, bool dq);
+int			pf_scan_scalar_name(const char *s, int slen);
+bool		pos_mark_fields(t_shell *state, t_token *tt, int off, int to);
+bool		csf_word_aliased(t_shell *state, const char *s, int len);
+bool		pf_op_word_at_fields(t_shell *state, t_token *tt, const char *w,
+				int n);
+bool		at_op_word_fields(t_shell *state, t_token *tt, char *elem,
+				int off);
 char		*err_or_assign(t_shell *state, char *val, t_pe_op o);
 char		*expand_param_op(t_shell *state, t_pe_op o);
 char		*pf_err_word(t_shell *state, char *val, t_pe_op o);
@@ -210,6 +218,7 @@ int			subst_anchor(t_trim_ctx ctx, int g);
 char		*patsub_prefix(const char *val, const char *pat, const char *rep);
 char		*patsub_suffix(const char *val, const char *pat, const char *rep);
 bool		pf_valid_plain(const char *s, int n);
+char		*pf_head_dispatch(t_shell *state, const char *s, int slen, bool dq);
 char		*pf_trim_or_subst(t_shell *state, t_trim_ctx ctx);
 t_trim_ctx	pf_make_ctx(const char *s, int slen, const char *op, int nlen);
 char		*cmdsub_fast(t_shell *state, const char *cmd);
@@ -321,9 +330,9 @@ typedef struct s_slice_ctx
 }	t_slice_ctx;
 
 bool		expand_array_ext(t_shell *state, t_token *tt, bool split_ctx);
-bool		expand_pos_slice(t_shell *state, t_token *tt);
+bool		expand_pos_slice(t_shell *state, t_token *tt, bool split_ctx);
 bool		expand_array_op(t_shell *state, t_token *tt);
-bool		expand_array_elem_op(t_shell *state, t_token *tt);
+bool		expand_array_elem_op(t_shell *state, t_token *tt, bool split);
 bool		arr_keys(t_shell *state, t_token *tt, bool split_ctx);
 bool		arr_prefix_names(t_shell *state, t_token *tt, bool split_ctx);
 bool		arr_emit(t_token *tt, char *owned);

--- a/src/lexer/dbracket_lex.c
+++ b/src/lexer/dbracket_lex.c
@@ -70,3 +70,35 @@ int	emit_dbracket_word(char **str, t_deque_tok *ret)
 	*str += len;
 	return (1);
 }
+
+/* Inside [[ ]], a newline is whitespace exactly where bash's conditional
+   grammar tolerates one: after the [[ itself, after && / || / ( / !, and
+   before ]] / && / || / ). Anywhere else it stays a real token, so
+   `[[ $x\n== y ]]` still fails like bash. bash-completion 2.16 writes
+   `[[ a != @(...) &&\n -f b ]]` in its compat-dir loop, and emitting that
+   newline cut the conditional in half: "[[: missing ]]" once per drop-in
+   file at every Debian 13 login, then the orphaned tail ran as commands
+   ("-f: command not found") -- issue #105's second wave. `after` points
+   just past the newline. */
+bool	db_newline_skippable(t_deque_tok *ret, const char *after)
+{
+	t_ltoken	*last;
+	char		*s;
+
+	while (*after == ' ' || *after == '\t')
+		after++;
+	if ((after[0] == ']' && after[1] == ']')
+		|| (after[0] == '&' && after[1] == '&')
+		|| (after[0] == '|' && after[1] == '|') || after[0] == ')')
+		return (true);
+	if (ret->deqtok.len == 0)
+		return (false);
+	last = (t_ltoken *)deque_idx(&ret->deqtok, ret->deqtok.len - 1);
+	s = ret->base + last->off;
+	if (last->len == 2 && ((s[0] == '[' && s[1] == '[')
+			|| (s[0] == '&' && s[1] == '&') || (s[0] == '|' && s[1] == '|')))
+		return (true);
+	if (last->len == 1 && (s[0] == '(' || s[0] == '!'))
+		return (true);
+	return (false);
+}

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -96,7 +96,9 @@ char	*tokenize_step(char **str, t_deque_tok *ret, int *in_db)
 	if (prompt)
 		return (prompt);
 	db_track_regex(ret, in_db);
-	if (**str == '\n')
+	if (**str == '\n' && *in_db && db_newline_skippable(ret, *str + 1))
+		(*str)++;
+	else if (**str == '\n')
 		emit_newline(str, ret);
 	else if (is_space(**str))
 		(*str)++;

--- a/tests/issue105_expansions
+++ b/tests/issue105_expansions
@@ -1,0 +1,39 @@
+ref=HOME; test -n "${!ref-}" && echo indirect-dash-ok
+ref=NOPE; echo "[${!ref-dflt}]"
+ref=NOPE; echo "[${!ref:-dflt}]"
+ref=HOME; echo "[${!ref:+set}]"
+set -- aa bb; n=2; echo "[${!n-x}]"
+a=(v0 v1); r="a[1]"; echo "[${!r}]"
+a=(v0 v1); r="a[1]"; echo "[${!r-d}]"
+a=(); r="a[0]"; echo "[${!r-d}]"
+declare -A m; m[k]=1; r="m[k]"; echo "[${!r}]"
+r="a[0]"; printf -v "$r" %s "hello"; echo "[${a[0]}]"
+printf -v plain %s world; echo "[$plain]"
+cur="cat li"; w=cat; echo "<${cur:0:${#w}}>"
+v=abcdef; n=2; echo "<${v:0:n}>"
+v=abcdef; o=2; echo "<${v:$o:3}>"
+v=abcdef; echo "<${v:1+1:2}>"
+set -- a b c d; printf "<%s>" "${@:2:2}"; echo
+set -- a b c d; arr=("${@:2:2}"); echo "${#arr[@]}:${arr[0]}:${arr[1]}"
+set -- p q r s; printf "<%s>" "${@:2}"; echo
+set -- p q; printf "<%s>" "${*:1:2}"; echo
+a=(p q r s); printf "<%s>" ${a[@]:1:2}; echo
+w=(cat li); printf "<%s>" ${w+"${w[@]}"}; echo
+set -- x y; printf "<%s>" ${1+"$@"}; echo
+w=("" li); printf "<%s>" ${w[@]+"${w[@]}"}; echo
+w=(a b); printf "<%s>" ${w[@]-"${w[@]}"}; echo
+w=(); printf "<%s>" ${w[@]+"${w[@]}"}; echo
+w=scalar; printf "<%s>" ${w+"${w[@]}"}; echo
+f(){ local a=(x y); local a; echo "${#a[@]}:<${a[0]-U}>"; }; f
+f(){ local v=hello; local v; echo "<$v>"; }; f
+outer(){ local x=A; mid; echo "outer=<$x>"; }; mid(){ local x=B; setter; echo "mid=<$x>"; }; setter(){ unset -v x; x=SET; }; outer
+outer(){ local x=A; setter; echo "outer=<$x>"; }; setter(){ unset -v x; x=SET; }; x=g; outer; echo "g=<$x>"
+x=g; f(){ local x=1; unset x; echo "<${x-U}>"; }; f; echo "<$x>"
+f(){ local v=1; unset v; v=2; echo "<$v>"; }; f; echo "<${v-U}>"
+f(){ :; }; declare -F -- f >/dev/null; echo rc=$?
+f(){ :; }; declare -f -- f >/dev/null; echo rc=$?
+compgen -W "aa ab ba" -X "b*" -- ""
+compgen -W "alpha beta gamma" -P "[" -S "]" -- b
+toks=(red green blue); compgen -W '"${toks[@]}"' -- g
+compgen -W "$(echo hey ho)" -- h
+eval -- "x5=55"; echo "$x5"

--- a/tests/parse_scaling_test.py
+++ b/tests/parse_scaling_test.py
@@ -89,11 +89,14 @@ def write_tmp(text):
     return f.name
 
 
-def scaling_check(name, gen, via_stdin=False):
+def scaling_check(name, gen, via_stdin=False, via_source=False):
     small = write_tmp(gen(N_SMALL))
     big = write_tmp(gen(N_BIG))
     try:
-        if via_stdin:
+        if via_source:
+            t1 = timed([SHELL, "-c", ". " + small])
+            t4 = timed([SHELL, "-c", ". " + big])
+        elif via_stdin:
             t1 = timed([SHELL, "-n"], stdin_path=small)
             t4 = timed([SHELL, "-n"], stdin_path=big)
         else:
@@ -119,6 +122,31 @@ def main():
     scaling_check("hazard compound via piped stdin", hazard_compound,
                   via_stdin=True)
     scaling_check("themes-like monolith via -n FILE", themes_like)
+    scaling_check("themes-like monolith via source (v2.8.6: interior "
+                  "hazards must not re-parse the open construct)",
+                  themes_like, via_source=True)
+
+    # Re-sourcing an rc that installed aliases, functions and a DEBUG
+    # trap must stay as cheap as the first load: hellish once disabled
+    # the forkless $() path on the first alias and fired the DEBUG trap
+    # per sourced statement, so every re-source of a theme rc forked
+    # hundreds of times (issue #108, wave 3 -- "source got slow again").
+    rc = write_tmp("trap 'preexec_probe=$((${preexec_probe:-0}+1))' DEBUG\n"
+                   "alias _rp='echo rp'\n"
+                   + "".join("rf_%d(){ v=$(printf %d); }\n" % (i, i)
+                             for i in range(60))
+                   + "".join("x%d=$(printf a%d)\n" % (i, i)
+                             for i in range(120)))
+    try:
+        t1 = timed([SHELL, "-c", ". " + rc])
+        t5 = timed([SHELL, "-c", ". %s; . %s; . %s; . %s; . %s"
+                    % (rc, rc, rc, rc, rc)])
+        detail = "t1=%.2fs t5=%.2fs ratio=%.1f" % (t1, t5, t5 / max(t1, 0.005))
+        print("     re-source with aliases+DEBUG trap: " + detail)
+        check("re-source stays as cheap as first load",
+              t5 <= 1.0 or t5 / max(t1, 0.02) < 9.0, detail)
+    finally:
+        os.unlink(rc)
 
     linear = write_tmp("".join("echo l%d > /dev/null\n" % i
                                for i in range(20000)))

--- a/tests/scripts/45_dbracket_newline.sh
+++ b/tests/scripts/45_dbracket_newline.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Newlines inside [[ ]] where bash's conditional grammar tolerates them:
+# after the [[ itself, after && and ||, and before ]]. bash-completion
+# 2.16 wraps its compat-dir test as `[[ a != @(...) &&\n -f b ]]`, and
+# emitting that newline as a token cut the conditional in half — once per
+# drop-in file at every Debian 13 login (issue #105, wave 2).
+x=abc
+[[ $x == a* &&
+    -n $x ]] && echo "and-continuation: ok"
+[[ $x == zz* ||
+    -n $x ]] && echo "or-continuation: ok"
+[[ -n $x
+]] && echo "before-close: ok"
+[[
+-n $x ]] && echo "after-open: ok"
+[[ $x == a* &&
+   $x == *c &&
+   -n $x ]] && echo "chained: ok"
+y="cat li"
+w=cat
+[[ ${y:0:${#w}} == "$w" ]] && echo "nested-substring-bound: ok"
+echo "done=$?"

--- a/tests/scripts/46_debug_trap_source.sh
+++ b/tests/scripts/46_debug_trap_source.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# DEBUG trap granularity (issue #108, wave 3): bash treats an entire
+# `.`/source run as ONE DEBUG event, while eval fires per inner
+# statement (both measured on 5.3.9). hellish fired per sourced
+# statement, so a theme rc's `trap hx_preexec DEBUG` ran its hook --
+# and its $(date) fork -- before every line of each re-source: the
+# "source ~/.hellishrc got slow again" report.
+cat > dbg_inner.sh <<'EOF'
+a=1
+b=2
+g(){ x=9; }
+g
+c=3
+EOF
+trap 'echo D' DEBUG
+. ./dbg_inner.sh
+echo "after-source"
+eval 'p=1; q=2'
+echo "after-eval"
+trap - DEBUG
+rm -f dbg_inner.sh
+echo "done=$?"

--- a/tests/tab_completion_chain_test.py
+++ b/tests/tab_completion_chain_test.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""TAB completion through real bash-completion 2.16 (issue #105, wave 2).
+
+Loading bash_completion cleanly is necessary but not sufficient: the
+first fix wave made it SOURCE silently, and then the first TAB on a
+Debian 13 box ran its completion functions for real and hit three more
+gaps -- `[[ ... &&\\n ... ]]` split at the newline ("[[: missing ]]"
+once per compat drop-in), `${!ref-}` rejected as a bad substitution in
+_comp_get_words, and knock-on `_comp_upvars: invalid option` noise.
+Sourcing tests can never see these; only pressing TAB does.
+
+This drives an interactive pty whose ~/.bashrc sources the real
+bash-completion 2.16 (cached download, cleanly skipped offline) with a
+POPULATED compat dir -- the empty-dir shortcut is exactly what hid the
+compat-loop bug -- then presses TAB and asserts the transcript carries
+none of the failure signatures and the shell still works afterwards.
+
+Usage: python3 tab_completion_chain_test.py [/path/to/hellish]
+"""
+import os
+import pty
+import select
+import shutil
+import sys
+import tempfile
+import time
+import urllib.request
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1
+                        else os.path.join(ROOT, "build", "bin", "hellish"))
+CACHE = os.environ.get(
+    "PLUGIN_CACHE",
+    os.path.join(os.environ.get("XDG_CACHE_HOME",
+                                os.path.expanduser("~/.cache")),
+                 "hellish-plugin-corpus"))
+URL = ("https://raw.githubusercontent.com/scop/bash-completion/2.16.0/"
+       "bash_completion")
+FAILS = []
+
+BAD_SIGNS = ["missing `]]'", "bad substitution", "invalid option",
+             "syntax error", "command not found", "AddressSanitizer"]
+
+DROPIN = """# a compat drop-in, like every distro package installs
+_hx_dropin_probe()
+{
+    return 0
+}
+complete -F _hx_dropin_probe hxprobe
+"""
+
+
+def check(name, ok, detail=""):
+    print(("ok   " if ok else "FAIL ") + name
+          + ("  " + detail if not ok else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def fetch():
+    path = os.path.join(CACHE, "bash-completion-2.16.sh")
+    if os.path.isfile(path) and os.path.getsize(path) > 0:
+        return path
+    try:
+        os.makedirs(CACHE, exist_ok=True)
+        with urllib.request.urlopen(URL, timeout=20) as r:
+            data = r.read()
+        with open(path, "wb") as f:
+            f.write(data)
+        return path
+    except OSError:
+        return None
+
+
+def main():
+    bc = fetch()
+    if not bc:
+        print("SKIP: no network and no cached bash-completion 2.16")
+        return
+    home = tempfile.mkdtemp(prefix="hx-tab-")
+    compat = os.path.join(home, "compat.d")
+    os.mkdir(compat)
+    for n in ("one.sh", "two.sh", "three.sh", "four.sh"):
+        open(os.path.join(compat, n), "w").write(DROPIN)
+    os.mkdir(os.path.join(home, "files"))
+    open(os.path.join(home, "files", "lifecycle.txt"), "w").write("x\n")
+    with open(os.path.join(home, ".bashrc"), "w") as f:
+        f.write("PS1='TAB$ '\n. %s\n" % bc)
+    with open(os.path.join(home, ".hellishrc"), "w") as f:
+        f.write(". $HOME/.bashrc\n")
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        env = {"HOME": home, "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+               "TERM": "xterm", "LANG": "C.UTF-8",
+               "BASH_COMPLETION_COMPAT_DIR": compat,
+               "BASH_COMPLETION_USER_FILE": "/nonexistent-hx",
+               "HELLISH_NO_BANNER": "1", "HELLISH_BANNER": "0",
+               "HELLISH_NO_ANIM": "1", "HELLISH_NO_UPDATE_CHECK": "1",
+               "ASAN_OPTIONS": "detect_leaks=0"}
+        os.execve(SHELL, [SHELL], env)
+        os._exit(127)
+    time.sleep(2.0)
+    os.write(fd, b"echo START-OK\r")
+    time.sleep(0.6)
+    os.write(fd, b"cd $HOME/files\r")
+    time.sleep(0.4)
+    os.write(fd, b"cat li\t")
+    time.sleep(1.5)
+    os.write(fd, b"\r")
+    time.sleep(0.6)
+    os.write(fd, b"ls /tm\t")
+    time.sleep(1.5)
+    os.write(fd, b"\r")
+    time.sleep(0.6)
+    os.write(fd, b"hxpro\t")
+    time.sleep(1.0)
+    os.write(fd, b"\x15echo AFTER-OK\r")
+    time.sleep(0.6)
+    os.write(fd, b"exit\r")
+    out = b""
+    end = time.time() + 8
+    status = None
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.3)
+        if r:
+            try:
+                d = os.read(fd, 65536)
+            except OSError:
+                break
+            if not d:
+                break
+            out += d
+        else:
+            try:
+                w, st = os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                break
+            if w:
+                status = st
+                break
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+    if status is None:
+        try:
+            _, status = os.waitpid(pid, 0)
+        except ChildProcessError:
+            status = 0
+    text = out.decode("utf-8", "replace")
+    shutil.rmtree(home, ignore_errors=True)
+
+    check("session started with rc chain", "START-OK" in text,
+          repr(text[:400]))
+    for sign in BAD_SIGNS:
+        check("no %r after TAB" % sign, sign not in text,
+              repr(text[-600:]))
+    check("filename TAB completed", "lifecycle.txt" in text,
+          repr(text[-600:]))
+    check("shell alive after completions", "AFTER-OK" in text,
+          repr(text[-400:]))
+    check("clean exit", status is not None and os.WIFEXITED(status),
+          "status=%r" % status)
+    if FAILS:
+        print("\n%d FAILED: %s" % (len(FAILS), ", ".join(FAILS)))
+        sys.exit(1)
+    print("\nall clear")
+
+
+main()

--- a/tests/tester
+++ b/tests/tester
@@ -59,6 +59,7 @@ if [[ ${#test_lists[@]} -eq 0 ]]; then
         "longtail"
         "issue95_case_cmdsub"
         "issue96_trap_func"
+        "issue105_expansions"
     )
 fi
 

--- a/wiki/context.md
+++ b/wiki/context.md
@@ -5,7 +5,7 @@ later session. The repo history is authoritative; this file records the
 things history cannot tell you — why a thing was done, what was measured,
 what was deliberately *not* done, and what is still open.
 
-Branch to resume from: **`develop`**. Released version: **2.8.5**.
+Branch to resume from: **`develop`**. Released version: **2.8.6**.
 
 The previous note on this file covered the issue-fixing session (#27, #32,
 #34, #42 and friends). All of those are closed; the tracker is empty. This


### PR DESCRIPTION
## Summary

Fixes #108 — everything the first real TAB against bash-completion 2.16 exposed on the
Debian 13 box, plus the third wave ("source ~/.hellishrc got slow again"). Each fix is
pinned against bash 5.3.9 and verified end-to-end on the reporting machine.

- **`[[ ]]` newline continuation** — whitespace after `[[`/`&&`/`||` and before `]]`,
  error elsewhere, like bash. Kills the per-drop-in `[[: missing ]]` at login.
- **Composable indirection** — `${!ref-}`/`${!ref:-x}`/any operator, array-element
  targets (`ref="words[0]"`), `printf -v "a[0]"` assigns the element.
- **Substring bounds word-expand first** — `${cur:0:${#words[i]}}`.
- **bash's scope rules** — upvar `unset -v` pops the caller's cell; bare `local`
  re-declaration keeps the value; DEBUG fires once per `.` run and per statement in eval.
- **Quoted slices and op-words keep fields** — `"${@:3:N}"`, `${w+"${w[@]}"}`,
  `${w[@]+"${w[@]}"}` (empties included), via the ARR_MAGIC marker registry.
- **compgen/declare surface** — `-X` filter (extglob-armed), `-P`/`-S`, action letters,
  **expanded `-W` lists** (the deferred `-W '"${toks[@]}"'` no longer pastes its literal
  text into the command line), `declare -F -- name`.
- **Re-source performance parity** — the forkless `$()` gate now checks the command word
  instead of bailing on any alias, and chunk growth stops re-clipping at hazard words
  inside an open construct. Nine loads of the theme rc: 0.35s vs bash's 0.43s; the
  2244-line monolith sources in 0.005s on the reporting VM (was 0.21s, felt as ~6s
  interactively).

## Detectors (permanent)

- `tests/tab_completion_chain_test.py` — real TABs against real bash-completion 2.16
  with a **populated** compat dir on a pty.
- `tests/issue105_expansions` — 39 golden lines; `tests/scripts/45_dbracket_newline.sh`
  and `46_debug_trap_source.sh` — byte-for-byte vs bash.
- `tests/parse_scaling_test.py` — source-path monolith ratio + re-source cap with
  aliases and a DEBUG trap installed.

## Verification

- golden 4362/4362 (debug + release), scripts 114/114, pty 73/0/5, hard 17/17,
  allocator parity 0 leaks, plugin corpus (bash-completion at `loads`), arena stress,
  norm — battery green end to end.
- On the reporting VM over ssh: three interactive re-sources of the user's 2244-line
  `~/.hellishrc` at **0.00s each**, TAB chain all-clear against the system
  bash-completion and its real `/etc/bash_completion.d` drop-ins, and a live login with
  zero error lines.

Closes #108
