### PR TITLE
test(pty): resolve the shell path before the run-as-a-file cases change directory

### DIFF
--- a/tests/bash_source_test.py
+++ b/tests/bash_source_test.py
@@ -34,8 +34,10 @@ import sys
 import tempfile
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-SHELL = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
-    ROOT, "build", "bin", "hellish")
+# Absolute on purpose: the run-as-a-file cases start the shell from another
+# directory, and the pty suite hands us build/bin/hellish relative to ROOT.
+SHELL = os.path.abspath(sys.argv[1] if len(sys.argv) > 1 else os.path.join(
+    ROOT, "build", "bin", "hellish"))
 ENV = dict(os.environ, HELLISH_NO_BANNER="1", HELLISH_NO_UPDATE_CHECK="1",
            HELLISH_NO_ANIM="1")
 FAILS = []


### PR DESCRIPTION
The pty suite passes `build/bin/hellish` relative to the repo root, and the two run-as-a-file cases in `tests/bash_source_test.py` start the shell from a scratch directory, so the relative path no longer resolved and the test died on ENOENT before running them. The path is now made absolute once at start-up. Seen on develop's interactive job after #124 landed.